### PR TITLE
chore: Make Python 3.10 environment default

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -27,10 +27,10 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('experiments/experiments-conda-env.yml') }}
 
-      - name: Set up Python 3.13
+      - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: '3.13'
+          python-version: '3.10'
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - https://conda.anaconda.org/conda-forge
 dependencies:
+  - python=3.10
   - astropy
   - matplotlib
   - numpy<2


### PR DESCRIPTION
- Make Python 3.10 default at conda environment level
- Make sure GitHub actions tests using Python 3.10 instead of 3.13

closes #26 
