### PR TITLE
implement zoom controls in RawDataView

### DIFF
--- a/ConfigurationKeys.md
+++ b/ConfigurationKeys.md
@@ -14,6 +14,7 @@ This document serves as the authoritative registry for all configuration keys us
 | **gui:raw_analysis** | `vis_range_max` | Float | `20.0` | Upper bound (in keV) for visualization thresholding. Values above this are clipped or normalized. Shared by Main View and Mosaic View. |
 | **gui:raw_analysis** | `filter_gaussian_sigma` | Float | `1.5` | Sigma (radius) value for the interactive Gaussian blur filter. |
 | **gui:raw_analysis** | `clustering_threshold` | Float | `4.0` | Signal-to-noise ratio (sigma multiplier) used for identifying event clusters. |
+| **gui:raw_analysis** | `zoom_step_factor` | Float | `1.2` | Factor to multiply/divide scale by when zooming in or out. |
 | **gui:window** | `default_width` | Integer | `1024` | Default initial width of the application window. |
 | **gui:window** | `default_height` | Integer | `700` | Default initial height of the application window. |
 | **gui:mosaic** | `height` | Integer | `130` | Fixed height (in pixels) of the Mosaic View container strip. |

--- a/src/le_beta_vis/common/ConfigurationService.py
+++ b/src/le_beta_vis/common/ConfigurationService.py
@@ -41,6 +41,7 @@ class MockConfigurationService(ConfigurationService):
             "gui:raw_analysis:vis_range_max": 20.0,
             "gui:raw_analysis:filter_gaussian_sigma": 1.5,
             "gui:raw_analysis:clustering_threshold": 4.0,
+            "gui:raw_analysis:zoom_step_factor": 1.2,
             # Window Geometry
             "gui:window:default_width": 1024,
             "gui:window:default_height": 700,

--- a/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
@@ -1,11 +1,13 @@
-from typing import List, Optional, Callable, Tuple
-import threading
 import queue
-import numpy as np
+import threading
 from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+import numpy as np
+
 from le_beta_vis.common.CCDCaptureModel import CCDCaptureModel
 from le_beta_vis.common.ConfigurationService import ConfigurationService
-from le_beta_vis.frontend.fitsconverters import OpenCVBasedConverter, Colormap
+from le_beta_vis.frontend.fitsconverters import Colormap, OpenCVBasedConverter
 
 
 class RawDataViewModel:
@@ -38,6 +40,7 @@ class RawDataViewModel:
             self._config.get("gui:raw_analysis:vis_range_min", 0.0),
             self._config.get("gui:raw_analysis:vis_range_max", 20.0),
         )
+        self._scale: float = 1.0
 
         # Async Rendering State
         self._current_buffer: Optional[np.ndarray] = None
@@ -48,6 +51,7 @@ class RawDataViewModel:
         # Callbacks
         self._on_image_changed_callbacks: List[Callable] = []
         self._on_file_loaded_callbacks: List[Callable] = []
+        self._on_scale_changed_callbacks: List[Callable] = []
 
     def loadFile(self, filePath: str):
         path = Path(filePath)
@@ -79,6 +83,39 @@ class RawDataViewModel:
     def setVisualizationRange(self, vmin: float, vmax: float):
         self._vrange = (vmin, vmax)
         self._request_render()
+
+    def zoomIn(self):
+        """
+        Increases the zoom scale by the configured factor.
+        Clamped at a maximum scale of 1000.0 (1000%).
+        Notifies scale changed listeners.
+        """
+        factor = self._config.get("gui:raw_analysis:zoom_step_factor", 1.2)
+        new_scale = self._scale * factor
+        if new_scale <= 1000.0:
+            self._scale = new_scale
+            self._notify_scale_changed()
+
+    def zoomOut(self):
+        """
+        Decreases the zoom scale by the configured factor.
+        Clamped at a minimum scale of 0.1 (10%).
+        Notifies scale changed listeners.
+        """
+        factor = self._config.get("gui:raw_analysis:zoom_step_factor", 1.2)
+        new_scale = self._scale / factor
+        if new_scale >= 0.1:
+            self._scale = new_scale
+            self._notify_scale_changed()
+
+    def resetZoom(self):
+        """
+        Resets the zoom scale to 1.0 (100%).
+        Notifies scale changed listeners if a change occurred.
+        """
+        if self._scale != 1.0:
+            self._scale = 1.0
+            self._notify_scale_changed()
 
     def _request_render(self):
         """Queues a render request."""
@@ -148,6 +185,10 @@ class RawDataViewModel:
     def activeIndex(self) -> int:
         return self._activeIndex
 
+    @property
+    def scale(self) -> float:
+        return self._scale
+
     # --- Observer Pattern Helpers ---
 
     def add_image_changed_callback(self, callback: Callable):
@@ -156,10 +197,17 @@ class RawDataViewModel:
     def add_file_loaded_callback(self, callback: Callable):
         self._on_file_loaded_callbacks.append(callback)
 
+    def add_scale_changed_callback(self, callback: Callable):
+        self._on_scale_changed_callbacks.append(callback)
+
     def _notify_image_changed(self):
         for callback in self._on_image_changed_callbacks:
             callback()
 
     def _notify_file_loaded(self):
         for callback in self._on_file_loaded_callbacks:
+            callback()
+
+    def _notify_scale_changed(self):
+        for callback in self._on_scale_changed_callbacks:
             callback()

--- a/src/le_beta_vis/frontend/views/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/RawDataView.py
@@ -1,19 +1,23 @@
+from PySide6.QtCore import QMetaObject, QSize, Qt, Slot
+from PySide6.QtGui import QImage, QPixmap, QTransform
 from PySide6.QtWidgets import (
-    QWidget,
-    QVBoxLayout,
+    QApplication,
+    QComboBox,
+    QFrame,
+    QGraphicsPixmapItem,
+    QGraphicsScene,
+    QGraphicsView,
+    QGroupBox,
     QHBoxLayout,
     QLabel,
-    QComboBox,
-    QScrollArea,
-    QGroupBox,
-    QFrame,
     QSizePolicy,
     QToolButton,
+    QVBoxLayout,
+    QWidget,
 )
-from PySide6.QtCore import Qt, QMetaObject, Slot
-from PySide6.QtGui import QImage, QPixmap
-from ..viewmodels.RawDataViewModel import RawDataViewModel
+
 from ..fitsconverters import Colormap
+from ..viewmodels.RawDataViewModel import RawDataViewModel
 from ..widgets.VerticalRangeControl import VerticalRangeControl
 from .MosaicView import MosaicView
 
@@ -59,34 +63,79 @@ class RawDataView(QWidget):
         layout = QVBoxLayout(self.leftToolbar)
         layout.setContentsMargins(5, 10, 5, 10)
         layout.setSpacing(10)
-        layout.setAlignment(Qt.AlignTop)
+        layout.setAlignment(Qt.AlignTop | Qt.AlignHCenter)
 
-        tools = [self.tr("Ptr"), self.tr("Mag"), self.tr("Box"), self.tr("Zoom")]
+        # Common size for squared buttons
+        btn_size = QSize(40, 40)
+
+        tools = [self.tr("Ptr"), self.tr("Mag"), self.tr("Box")]
         for tool in tools:
             btn = QToolButton()
             btn.setText(tool)
-            btn.setFixedSize(90, 40)
-            layout.addWidget(btn)
+            btn.setFixedSize(btn_size)
+            layout.addWidget(btn, 0, Qt.AlignHCenter)
 
-        layout.addSpacing(20)
+        layout.addWidget(self._createDivider(), 0, Qt.AlignHCenter)
+
+        # Zoom In
+        self.btnZoomIn = QToolButton()
+        self.btnZoomIn.setText("+")
+        self.btnZoomIn.setToolTip(self.tr("Zoom In"))
+        self.btnZoomIn.setFixedSize(btn_size)
+        self.btnZoomIn.setStyleSheet(
+            "font-size: 20px; font-weight: bold; color: #ffffff;"
+        )
+        self.btnZoomIn.clicked.connect(self.viewModel.zoomIn)
+        layout.addWidget(self.btnZoomIn, 0, Qt.AlignHCenter)
+
+        # Reset Zoom
+        self.btnZoomReset = QToolButton()
+        self.btnZoomReset.setText("1x")
+        self.btnZoomReset.setToolTip(self.tr("Reset Zoom (1:1)"))
+        self.btnZoomReset.setFixedSize(btn_size)
+        self.btnZoomReset.setStyleSheet("font-weight: bold; color: #ffffff;")
+        self.btnZoomReset.clicked.connect(self.viewModel.resetZoom)
+        layout.addWidget(self.btnZoomReset, 0, Qt.AlignHCenter)
+
+        # Zoom Out
+        self.btnZoomOut = QToolButton()
+        self.btnZoomOut.setText("-")
+        self.btnZoomOut.setToolTip(self.tr("Zoom Out"))
+        self.btnZoomOut.setFixedSize(btn_size)
+        self.btnZoomOut.setStyleSheet(
+            "font-size: 20px; font-weight: bold; color: #ffffff;"
+        )
+        self.btnZoomOut.clicked.connect(self.viewModel.zoomOut)
+        layout.addWidget(self.btnZoomOut, 0, Qt.AlignHCenter)
+
+        layout.addWidget(self._createDivider(), 0, Qt.AlignHCenter)
+        layout.addSpacing(10)
 
         self.rangeControl = VerticalRangeControl(abs_min=0.0, abs_max=1.0)
         self.rangeControl.setVisible(False)
         self.rangeControl.rangeChanged.connect(self.onRangeChanged)
-        layout.addWidget(self.rangeControl)
+        layout.addWidget(self.rangeControl, 0, Qt.AlignHCenter)
 
         self.bodyLayout.addWidget(self.leftToolbar)
 
-    def _setupCenterImageArea(self):
-        self.scrollArea = QScrollArea()
-        self.scrollArea.setWidgetResizable(True)
-        self.scrollArea.setAlignment(Qt.AlignCenter)
-        self.scrollArea.setStyleSheet("background-color: #000; border: none;")
+    def _createDivider(self) -> QFrame:
+        line = QFrame()
+        line.setFrameShape(QFrame.HLine)
+        line.setFrameShadow(QFrame.Sunken)
+        line.setStyleSheet("background-color: #555555;")
+        line.setFixedWidth(80)
+        return line
 
-        self.imageLabel = QLabel()
-        self.imageLabel.setAlignment(Qt.AlignCenter)
-        self.scrollArea.setWidget(self.imageLabel)
-        self.bodyLayout.addWidget(self.scrollArea)
+    def _setupCenterImageArea(self):
+        self.scene = QGraphicsScene()
+        self.graphicsView = QGraphicsView(self.scene)
+        self.graphicsView.setStyleSheet("background-color: #000; border: none;")
+        self.graphicsView.setAlignment(Qt.AlignCenter)
+
+        self.pixmapItem = QGraphicsPixmapItem()
+        self.scene.addItem(self.pixmapItem)
+
+        self.bodyLayout.addWidget(self.graphicsView)
 
     def _setupRightSidebar(self):
         self.rightSidebar = QFrame()
@@ -141,10 +190,14 @@ class RawDataView(QWidget):
         def on_image_changed():
             QMetaObject.invokeMethod(self, "updateImage", Qt.QueuedConnection)
 
+        def on_scale_changed():
+            QMetaObject.invokeMethod(self, "updateZoom", Qt.QueuedConnection)
+
         self.viewModel.add_image_changed_callback(on_image_changed)
         self.viewModel.mosaicViewModel.add_thumbnails_changed_callback(
             self.updateMosaicVisibility
         )
+        self.viewModel.add_scale_changed_callback(on_scale_changed)
         self.updateMosaicVisibility()
 
         vmin, vmax = self.viewModel.visualizationRange
@@ -168,7 +221,13 @@ class RawDataView(QWidget):
             q_img = QImage(
                 buffer.data, width, height, bytes_per_line, QImage.Format_RGB888
             )
-            self.imageLabel.setPixmap(QPixmap.fromImage(q_img.copy()))
+            pixmap = QPixmap.fromImage(q_img)
+
+            self.pixmapItem.setPixmap(pixmap)
+            self.scene.setSceneRect(0, 0, width, height)
+
+            # Ensure zoom is correct for new image
+            self.updateZoom()
 
             # Update Range Control Limits (Sync with ViewModel data range)
             dmin, dmax = self.viewModel.dataRange
@@ -178,7 +237,28 @@ class RawDataView(QWidget):
             self.rangeControl.setValues(vmin, vmax)
             self.rangeControl.setColormap(self.viewModel.colormap)
         else:
-            self.imageLabel.clear()
+            self.pixmapItem.setPixmap(QPixmap())
+
+    @Slot()
+    def updateZoom(self):
+        """Updates the graphics view transform based on scale."""
+        # UX Feedback: Busy Cursor & Disable Buttons
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        self.btnZoomIn.setEnabled(False)
+        self.btnZoomOut.setEnabled(False)
+        self.btnZoomReset.setEnabled(False)
+
+        try:
+            scale = self.viewModel.scale
+            transform = QTransform()
+            transform.scale(scale, scale)
+            self.graphicsView.setTransform(transform)
+        finally:
+            # Restore UX
+            self.btnZoomIn.setEnabled(True)
+            self.btnZoomOut.setEnabled(True)
+            self.btnZoomReset.setEnabled(True)
+            QApplication.restoreOverrideCursor()
 
     def onColormapChanged(self, text):
         self.viewModel.setColormap(text)

--- a/tests/test_ConfigurationService.py
+++ b/tests/test_ConfigurationService.py
@@ -14,6 +14,7 @@ def test_mock_configuration_service_defaults():
     # Test GUI defaults
     assert service.get("gui:raw_analysis:default_colormap") == "viridis"
     assert service.get("gui:raw_analysis:vis_range_min") == 0.0
+    assert service.get("gui:raw_analysis:zoom_step_factor") == 1.2
 
 
 def test_mock_configuration_service_set_get():

--- a/tests/test_RawDataViewModel.py
+++ b/tests/test_RawDataViewModel.py
@@ -1,10 +1,12 @@
-import pytest
 import sys
-import numpy as np
 from unittest.mock import MagicMock, patch
-from le_beta_vis.frontend.viewmodels.RawDataViewModel import RawDataViewModel
-from le_beta_vis.common.ConfigurationService import MockConfigurationService
+
+import numpy as np
+import pytest
+
 from le_beta_vis.common.CCDCaptureModel import CCDCaptureModel
+from le_beta_vis.common.ConfigurationService import MockConfigurationService
+from le_beta_vis.frontend.viewmodels.RawDataViewModel import RawDataViewModel
 
 
 @pytest.fixture
@@ -112,3 +114,33 @@ def test_set_colormap(view_model):
 
     assert view_model.colormap == "magma"
     view_model._converter.convert.assert_called()
+
+
+def test_zoom_logic(view_model):
+    """Test zoom in and out logic."""
+    # Default is 1.0
+    assert view_model.scale == 1.0
+
+    mock_cb = MagicMock()
+    view_model.add_scale_changed_callback(mock_cb)
+
+    # Zoom In
+    # Default zoom factor is 1.2
+    view_model.zoomIn()
+    assert view_model.scale == 1.2
+    mock_cb.assert_called_once()
+    mock_cb.reset_mock()
+
+    # Zoom Out
+    view_model.zoomOut()
+    assert abs(view_model.scale - 1.0) < 0.0001
+    mock_cb.assert_called_once()
+
+    # Reset Zoom
+    view_model.zoomIn()
+    view_model.zoomIn()
+    assert view_model.scale > 1.0
+    mock_cb.reset_mock()
+    view_model.resetZoom()
+    assert view_model.scale == 1.0
+    mock_cb.assert_called_once()


### PR DESCRIPTION
# implement zoom controls in RawDataView (#44)

Replaces the placeholder 'Zoom' button with functional Zoom In (+), Zoom Out (-), and Reset (1x) controls using QGraphicsView for performance.

- Switched RawDataView from QLabel to QGraphicsView for hardware-accelerated scaling.
- Added squared toolbar buttons with dividers and centered alignment.
- Implemented scale factor logic in RawDataViewModel with limits (0.1x - 1000x).
- Added `gui:raw_analysis:zoom_step_factor` (default 1.2).
- Added unit tests for zoom logic and configuration.

## User Interface

https://github.com/user-attachments/assets/fcc8bea8-741a-4837-aac8-03a74b331b10

Close #44