### PR TITLE
feat: implement pointer tool pan & inspect (#41)

### DIFF
--- a/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
@@ -51,13 +51,16 @@ class RawDataViewModel:
         )
         self._scale: float = 1.0
 
-        # Magnifier Tool State
+        # Tool State
         self._activeTool: ActiveTool = ActiveTool.POINTER
         self._magnificationFactor: float = self._config.get(
             "gui:raw_analysis:magnifier_default_factor", 3.0
         )
         self._magnifier_pos: Tuple[int, int] = (0, 0)
         self._image_bounds: Tuple[int, int] = (0, 0)
+
+        # Pointer Hover State
+        self._pointer_hover_pos: Optional[Tuple[int, int]] = None
 
         # Async Rendering State
         self._current_buffer: Optional[np.ndarray] = None
@@ -74,6 +77,7 @@ class RawDataViewModel:
         self._on_active_tool_changed_callbacks: List[Callable] = []
         self._on_magnifier_state_changed_callbacks: List[Callable] = []
         self._on_magnifier_position_changed_callbacks: List[Callable] = []
+        self._on_pointer_hover_changed_callbacks: List[Callable] = []
 
     def loadFile(self, filePath: str):
         path = Path(filePath)
@@ -210,6 +214,31 @@ class RawDataViewModel:
             row + drow * step, col + dcol * step
         )
 
+    # --- Pointer Tool ---
+
+    def setPointerHoverPosition(self, row: int, col: int) -> None:
+        """
+        Sets the pointer hover pixel position, clamped to image bounds.
+        Notifies listeners if the position changed.
+        """
+        rows, cols = self._image_bounds
+        if rows > 0 and cols > 0:
+            row = max(0, min(row, rows - 1))
+            col = max(0, min(col, cols - 1))
+        new_pos = (row, col)
+        if new_pos != self._pointer_hover_pos:
+            self._pointer_hover_pos = new_pos
+            self._notify_pointer_hover_changed()
+
+    def clearPointerHover(self) -> None:
+        """
+        Clears the pointer hover position.
+        Notifies listeners if it was previously set.
+        """
+        if self._pointer_hover_pos is not None:
+            self._pointer_hover_pos = None
+            self._notify_pointer_hover_changed()
+
     def _request_render(self):
         """Queues a render request."""
         try:
@@ -293,6 +322,10 @@ class RawDataViewModel:
         return self._activeTool
 
     @property
+    def isPointerActive(self) -> bool:
+        return self._activeTool == ActiveTool.POINTER
+
+    @property
     def isMagnifierActive(self) -> bool:
         return self._activeTool == ActiveTool.MAGNIFIER
 
@@ -309,6 +342,20 @@ class RawDataViewModel:
         if self._activeIndex == -1 or not self._captures:
             return None
         return self._captures[self._activeIndex].rawData()
+
+    @property
+    def pointerHoverInfo(
+        self,
+    ) -> Optional[Tuple[int, int, float]]:
+        """Returns (row, col, keV_value) or None if not hovering."""
+        if self._pointer_hover_pos is None:
+            return None
+        row, col = self._pointer_hover_pos
+        raw = self.activeRawData
+        if raw is None:
+            return None
+        value = float(raw[row, col]) * self.kevConversionFactor
+        return (row, col, value)
 
     @property
     def magnifierPosition(self) -> Tuple[int, int]:
@@ -370,4 +417,13 @@ class RawDataViewModel:
 
     def _notify_magnifier_position_changed(self):
         for callback in self._on_magnifier_position_changed_callbacks:
+            callback()
+
+    def add_pointer_hover_changed_callback(
+        self, callback: Callable
+    ):
+        self._on_pointer_hover_changed_callbacks.append(callback)
+
+    def _notify_pointer_hover_changed(self):
+        for callback in self._on_pointer_hover_changed_callbacks:
             callback()

--- a/src/le_beta_vis/frontend/views/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/RawDataView.py
@@ -5,6 +5,7 @@ from PySide6.QtGui import (
     QIcon,
     QImage,
     QPainter,
+    QPen,
     QPixmap,
     QTransform,
 )
@@ -103,8 +104,10 @@ class RawDataView(QWidget):
 
         # Pointer
         self.btnPointer = QToolButton()
-        self.btnPointer.setText(self.tr("Ptr"))
-        self.btnPointer.setToolTip(self.tr("Pointer"))
+        self.btnPointer.setIcon(self._createPointerIcon())
+        self.btnPointer.setToolTip(
+            self.tr("Pointer: Select and Pan")
+        )
         self.btnPointer.setCheckable(True)
         self.btnPointer.setChecked(True)
         self.btnPointer.setFixedSize(btn_size)
@@ -142,6 +145,31 @@ class RawDataView(QWidget):
         )
         self._toolButtonGroup.addButton(self.btnBoxSelect)
         layout.addWidget(self.btnBoxSelect, 0, Qt.AlignHCenter)
+
+    def _createPointerIcon(self) -> QIcon:
+        """Creates a crosshair/target icon for the Pointer tool."""
+        icon = QIcon.fromTheme("crosshairs")
+        if not icon.isNull():
+            return icon
+
+        size = 40
+        pixmap = QPixmap(size, size)
+        pixmap.fill(Qt.transparent)
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.Antialiasing)
+        pen = QPen(QColor("#ffffff"))
+        pen.setWidth(2)
+        painter.setPen(pen)
+        cx, cy = size // 2, size // 2
+        r = 10
+        painter.drawEllipse(cx - r, cy - r, r * 2, r * 2)
+        arm = 6
+        painter.drawLine(cx, cy - r - arm, cx, cy - r)
+        painter.drawLine(cx, cy + r, cx, cy + r + arm)
+        painter.drawLine(cx - r - arm, cy, cx - r, cy)
+        painter.drawLine(cx + r, cy, cx + r + arm, cy)
+        painter.end()
+        return QIcon(pixmap)
 
     def _createMagnifierIcon(self) -> QIcon:
         """Creates a magnifier icon from theme or painted fallback."""
@@ -202,6 +230,11 @@ class RawDataView(QWidget):
         return line
 
     def _setupCenterImageArea(self):
+        centerContainer = QWidget()
+        centerLayout = QVBoxLayout(centerContainer)
+        centerLayout.setContentsMargins(0, 0, 0, 0)
+        centerLayout.setSpacing(0)
+
         self.scene = QGraphicsScene()
         self.graphicsView = CaptureGraphicsView()
         self.graphicsView.setScene(self.scene)
@@ -227,7 +260,21 @@ class RawDataView(QWidget):
             ])
         self.scene.addItem(self._magnifierItem)
 
-        self.bodyLayout.addWidget(self.graphicsView)
+        centerLayout.addWidget(self.graphicsView)
+
+        # Status bar for pointer pixel inspection
+        self._statusLabel = QLabel()
+        self._statusLabel.setFixedHeight(24)
+        self._statusLabel.setStyleSheet(
+            "background-color: #1e1e1e; color: #cccccc;"
+            " font-size: 12px; padding-left: 8px;"
+        )
+        centerLayout.addWidget(self._statusLabel)
+
+        # Activate pointer mode by default
+        self.graphicsView.setPointerActive(True)
+
+        self.bodyLayout.addWidget(centerContainer)
 
     def _setupRightSidebar(self):
         self.rightSidebar = QFrame()
@@ -305,6 +352,12 @@ class RawDataView(QWidget):
                 Qt.QueuedConnection,
             )
 
+        def on_pointer_hover_changed():
+            QMetaObject.invokeMethod(
+                self, "_updatePointerStatus",
+                Qt.QueuedConnection,
+            )
+
         self.viewModel.add_image_changed_callback(on_image_changed)
         self.viewModel.mosaicViewModel.add_thumbnails_changed_callback(
             self.updateMosaicVisibility
@@ -319,6 +372,9 @@ class RawDataView(QWidget):
         self.viewModel.add_magnifier_position_changed_callback(
             on_magnifier_position_changed
         )
+        self.viewModel.add_pointer_hover_changed_callback(
+            on_pointer_hover_changed
+        )
         self.updateMosaicVisibility()
 
         vmin, vmax = self.viewModel.visualizationRange
@@ -332,6 +388,9 @@ class RawDataView(QWidget):
         )
         self.graphicsView.magnificationDeltaRequested.connect(
             self.viewModel.adjustMagnification
+        )
+        self.graphicsView.mouseLeft.connect(
+            self.viewModel.clearPointerHover
         )
 
     def updateMosaicVisibility(self):
@@ -405,15 +464,21 @@ class RawDataView(QWidget):
 
     @Slot()
     def _updateActiveTool(self):
-        """Syncs toolbar button states and magnifier visibility."""
+        """Syncs toolbar button states, cursor modes, and overlays."""
         tool = self.viewModel.activeTool
         self.btnPointer.setChecked(tool == ActiveTool.POINTER)
         self.btnMagnifier.setChecked(tool == ActiveTool.MAGNIFIER)
         self.btnBoxSelect.setChecked(tool == ActiveTool.BOX_SELECT)
 
+        pointerActive = self.viewModel.isPointerActive
         magnifierActive = self.viewModel.isMagnifierActive
+
+        self.graphicsView.setPointerActive(pointerActive)
         self.graphicsView.setMagnifierActive(magnifierActive)
         self._magnifierItem.setVisible(magnifierActive)
+
+        if not pointerActive:
+            self.viewModel.clearPointerHover()
 
         if magnifierActive:
             self.graphicsView.setFocus()
@@ -427,10 +492,11 @@ class RawDataView(QWidget):
 
     @Slot(int, int)
     def _onPixelHovered(self, row: int, col: int):
-        """Routes mouse hover to the ViewModel."""
-        if not self.viewModel.isMagnifierActive:
-            return
-        self.viewModel.setMagnifierPosition(row, col)
+        """Routes mouse hover to the active tool in the ViewModel."""
+        if self.viewModel.isMagnifierActive:
+            self.viewModel.setMagnifierPosition(row, col)
+        elif self.viewModel.isPointerActive:
+            self.viewModel.setPointerHoverPosition(row, col)
 
     @Slot(int, int)
     def _onPixelNudged(self, drow: int, dcol: int):
@@ -443,6 +509,20 @@ class RawDataView(QWidget):
         row, col = self.viewModel.magnifierPosition
         self._magnifierItem.setPixelPos(row, col)
         self._positionMagnifierItem(row, col)
+
+    @Slot()
+    def _updatePointerStatus(self):
+        """Updates the status label with pointer hover info."""
+        info = self.viewModel.pointerHoverInfo
+        if info is None:
+            self._statusLabel.setText("")
+        else:
+            row, col, kev = info
+            self._statusLabel.setText(
+                self.tr("X: {col}  Y: {row}  Value: {kev} keV").format(
+                    col=col, row=row, kev=f"{kev:.5f}"
+                )
+            )
 
     def _positionMagnifierItem(self, row: int, col: int) -> None:
         """Positions the magnifier near the cursor, clamped to image."""

--- a/src/le_beta_vis/frontend/widgets/CaptureGraphicsView.py
+++ b/src/le_beta_vis/frontend/widgets/CaptureGraphicsView.py
@@ -1,4 +1,6 @@
-from PySide6.QtCore import Qt, Signal
+from typing import Optional
+
+from PySide6.QtCore import QEvent, QPointF, Qt, Signal
 from PySide6.QtGui import QKeyEvent, QMouseEvent, QWheelEvent
 from PySide6.QtWidgets import QGraphicsView, QWidget
 
@@ -7,16 +9,19 @@ class CaptureGraphicsView(QGraphicsView):
     """
     A QGraphicsView subclass that emits pixel-hover coordinates,
     pixel-nudge requests, and magnification-change requests.
-    Event interception is conditional on the magnifier tool state.
+    Event interception is conditional on the active tool state.
     """
 
     pixelHovered = Signal(int, int)
     pixelNudgeRequested = Signal(int, int)
     magnificationDeltaRequested = Signal(int)
+    mouseLeft = Signal()
 
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
         self._magnifierActive: bool = False
+        self._pointerActive: bool = False
+        self._panStart: Optional[QPointF] = None
         self.setFocusPolicy(Qt.StrongFocus)
 
     def setMagnifierActive(self, active: bool) -> None:
@@ -27,16 +32,71 @@ class CaptureGraphicsView(QGraphicsView):
             active: True to enable magnifier mouse tracking.
         """
         self._magnifierActive = active
-        self.setMouseTracking(active)
+        self.setMouseTracking(active or self._pointerActive)
+
+    def setPointerActive(self, active: bool) -> None:
+        """
+        Enables or disables pointer interaction mode.
+        Uses CrossCursor for precision pixel inspection and
+        manual panning with ClosedHand cursor on drag.
+
+        Args:
+            active: True to enable pointer pan and inspect.
+        """
+        self._pointerActive = active
+        self._panStart = None
+        self.setMouseTracking(active or self._magnifierActive)
+        if active:
+            self.viewport().setCursor(Qt.CrossCursor)
+        else:
+            self.viewport().unsetCursor()
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        """Starts manual pan on left-click when pointer is active."""
+        if self._pointerActive and event.button() == Qt.LeftButton:
+            self._panStart = event.position()
+            self.viewport().setCursor(Qt.ClosedHandCursor)
+            event.accept()
+            return
+        super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event: QMouseEvent) -> None:
-        """Emits pixelHovered when magnifier is active."""
+        """Emits pixelHovered or handles panning depending on state."""
         if self._magnifierActive:
             scene_pos = self.mapToScene(event.pos())
             self.pixelHovered.emit(
                 int(scene_pos.y()), int(scene_pos.x())
             )
+        elif self._pointerActive:
+            if self._panStart is not None:
+                delta = event.position() - self._panStart
+                self._panStart = event.position()
+                hs = self.horizontalScrollBar()
+                vs = self.verticalScrollBar()
+                hs.setValue(hs.value() - int(delta.x()))
+                vs.setValue(vs.value() - int(delta.y()))
+                event.accept()
+                return
+            else:
+                scene_pos = self.mapToScene(event.pos())
+                self.pixelHovered.emit(
+                    int(scene_pos.y()), int(scene_pos.x())
+                )
         super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
+        """Ends manual pan and restores CrossCursor."""
+        if self._pointerActive and event.button() == Qt.LeftButton:
+            self._panStart = None
+            self.viewport().setCursor(Qt.CrossCursor)
+            event.accept()
+            return
+        super().mouseReleaseEvent(event)
+
+    def leaveEvent(self, event: QEvent) -> None:
+        """Emits mouseLeft when the cursor exits the view."""
+        self.mouseLeft.emit()
+        super().leaveEvent(event)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         """Arrow keys nudge position; +/- adjust magnification."""

--- a/tests/test_PointerViewModel.py
+++ b/tests/test_PointerViewModel.py
@@ -1,0 +1,143 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from le_beta_vis.common.ConfigurationService import MockConfigurationService
+from le_beta_vis.frontend.viewmodels.RawDataViewModel import (
+    ActiveTool,
+    RawDataViewModel,
+)
+
+
+@pytest.fixture
+def view_model():
+    config = MockConfigurationService()
+    vm = RawDataViewModel(config)
+    vm._converter = MagicMock()
+    vm._converter.convert.return_value = np.zeros(
+        (10, 10, 3), dtype=np.uint8
+    )
+
+    def mock_request():
+        vm._render_worker_logic()
+
+    vm._request_render = mock_request
+    return vm
+
+
+# --- isPointerActive ---
+
+
+def test_is_pointer_active_initial(view_model):
+    """Test that the pointer tool is active by default."""
+    assert view_model.isPointerActive is True
+
+
+def test_is_pointer_active_after_switch(view_model):
+    """Test isPointerActive is False when another tool is active."""
+    view_model.setActiveTool(ActiveTool.MAGNIFIER)
+    assert view_model.isPointerActive is False
+
+
+def test_is_pointer_active_after_switch_back(view_model):
+    """Test isPointerActive returns True after switching back."""
+    view_model.setActiveTool(ActiveTool.MAGNIFIER)
+    view_model.setActiveTool(ActiveTool.POINTER)
+    assert view_model.isPointerActive is True
+
+
+# --- Pointer Hover Position ---
+
+
+def test_initial_pointer_hover_is_none(view_model):
+    """Test that pointerHoverInfo starts as None."""
+    assert view_model.pointerHoverInfo is None
+
+
+def test_set_pointer_hover_position(view_model):
+    """Test setPointerHoverPosition stores and fires callback."""
+    view_model._image_bounds = (100, 100)
+    cb = MagicMock()
+    view_model.add_pointer_hover_changed_callback(cb)
+    view_model.setPointerHoverPosition(50, 60)
+    cb.assert_called_once()
+
+
+def test_set_pointer_hover_position_clamped(view_model):
+    """Test setPointerHoverPosition clamps to image bounds."""
+    view_model._image_bounds = (100, 100)
+    mock_capture = MagicMock()
+    raw = np.ones((100, 100))
+    mock_capture.rawData.return_value = raw
+    view_model._captures = [mock_capture]
+    view_model._activeIndex = 0
+
+    view_model.setPointerHoverPosition(200, -5)
+    info = view_model.pointerHoverInfo
+    assert info is not None
+    row, col, _ = info
+    assert row == 99
+    assert col == 0
+
+
+def test_no_callback_if_position_unchanged(view_model):
+    """Test that setting the same position doesn't fire callback."""
+    view_model._image_bounds = (100, 100)
+    view_model.setPointerHoverPosition(10, 20)
+    cb = MagicMock()
+    view_model.add_pointer_hover_changed_callback(cb)
+    view_model.setPointerHoverPosition(10, 20)
+    cb.assert_not_called()
+
+
+# --- clearPointerHover ---
+
+
+def test_clear_pointer_hover(view_model):
+    """Test clearPointerHover resets to None and fires callback."""
+    view_model._image_bounds = (100, 100)
+    view_model.setPointerHoverPosition(10, 20)
+    cb = MagicMock()
+    view_model.add_pointer_hover_changed_callback(cb)
+    view_model.clearPointerHover()
+    assert view_model.pointerHoverInfo is None
+    cb.assert_called_once()
+
+
+def test_clear_pointer_hover_when_already_none(view_model):
+    """Test clearPointerHover does not fire if already None."""
+    cb = MagicMock()
+    view_model.add_pointer_hover_changed_callback(cb)
+    view_model.clearPointerHover()
+    cb.assert_not_called()
+
+
+# --- pointerHoverInfo ---
+
+
+def test_pointer_hover_info_with_capture(view_model):
+    """Test pointerHoverInfo returns correct (row, col, keV) tuple."""
+    mock_capture = MagicMock()
+    raw = np.full((100, 100), 1000.0)
+    mock_capture.rawData.return_value = raw
+    view_model._captures = [mock_capture]
+    view_model._activeIndex = 0
+    view_model._image_bounds = (100, 100)
+
+    view_model.setPointerHoverPosition(25, 30)
+    info = view_model.pointerHoverInfo
+
+    assert info is not None
+    row, col, kev = info
+    assert row == 25
+    assert col == 30
+    expected_kev = 1000.0 * view_model.kevConversionFactor
+    assert abs(kev - expected_kev) < 1e-12
+
+
+def test_pointer_hover_info_no_capture(view_model):
+    """Test pointerHoverInfo returns None when no data loaded."""
+    view_model._image_bounds = (100, 100)
+    view_model.setPointerHoverPosition(10, 20)
+    assert view_model.pointerHoverInfo is None


### PR DESCRIPTION
Add panning and pixel inspection to the default Pointer tool in the Raw Data View. Hovering displays real-time coordinates and keV values in a new status bar; click-and-drag pans the viewport.

- RawDataViewModel: Add hover position tracking with clamping, pointerHoverInfo property (row, col, keV), isPointerActive flag, and observer callbacks for hover changes
- RawDataView: Replace Ptr text label with crosshair icon, add status bar for pixel inspection, wire pointer hover callbacks
- CaptureGraphicsView: Add pointer mode with CrossCursor, manual pan via mouse press/drag/release, mouseLeft signal for clearing hover state on leave
- tests: Add test_PointerViewModel covering tool activation, coordinate clamping, keV calculation, and callback behavior

## User Interface

https://github.com/user-attachments/assets/5add7384-47d9-44fa-b0b7-eda32ccab7c0

closes #41 