### PR TITLE
Fix dynamic gradient rendering in VerticalRangeControl

### DIFF
--- a/src/le_beta_vis/frontend/fitsconverters/__init__.py
+++ b/src/le_beta_vis/frontend/fitsconverters/__init__.py
@@ -6,3 +6,4 @@ from .noop import NoOpConverter
 from .fast import FastPixmapConverter
 from .opencv import OpenCVBasedConverter
 from .cluster_thumbnail import generate_cluster_thumbnail
+from .colormaps import generate_gradient_array

--- a/src/le_beta_vis/frontend/fitsconverters/colormaps.py
+++ b/src/le_beta_vis/frontend/fitsconverters/colormaps.py
@@ -37,21 +37,81 @@ def get_cv2_colormap_id(name: str) -> int:
     return mapping.get(name, cv2.COLORMAP_VIRIDIS)
 
 
-def generate_gradient_pixmap(name: str, width: int = 20, height: int = 256):
+def generate_gradient_array(
+    name: str,
+    vmin_ratio: float = 0.0,
+    vmax_ratio: float = 1.0,
+    width: int = 20,
+    height: int = 256,
+) -> np.ndarray:
     """
-    Generates a vertical gradient QPixmap for the specified colormap.
-    Used for UI widgets (legends/sliders).
-    PySide6 is imported lazily to keep this module headless-safe.
+    Generate a vertical gradient as an RGB uint8 NumPy array.
+
+    The full colormap is compressed between ``vmin_ratio`` and
+    ``vmax_ratio``.  Rows above ``vmax_ratio`` are filled with the
+    top-end color; rows below ``vmin_ratio`` with the bottom-end color.
+
+    :param name: Colormap name (member of ``Colormap``).
+    :param vmin_ratio: Lower bound of the active range as a 0-1 ratio.
+    :param vmax_ratio: Upper bound of the active range as a 0-1 ratio.
+    :param width: Pixel width of the output array.
+    :param height: Pixel height of the output array.
+    :returns: ``(height, width, 3)`` RGB ``uint8`` array.
     """
     import cv2
-    from PySide6.QtGui import QImage, QPixmap
 
-    ramp = np.linspace(255, 0, height, dtype=np.uint8)
-    ramp = np.tile(ramp[:, np.newaxis], (1, width))
+    # Clamp to [0, 1] and ensure vmin <= vmax
+    vmin_ratio = float(np.clip(vmin_ratio, 0.0, 1.0))
+    vmax_ratio = float(np.clip(vmax_ratio, 0.0, 1.0))
+    if vmin_ratio > vmax_ratio:
+        vmin_ratio, vmax_ratio = vmax_ratio, vmin_ratio
+
+    # positions: 1.0 at top row, 0.0 at bottom row
+    positions = np.linspace(1.0, 0.0, height)
+
+    span = vmax_ratio - vmin_ratio
+    if span < 1e-9:
+        # Degenerate: single color at the given ratio
+        gray_val = int(np.clip(vmin_ratio * 255, 0, 255))
+        gray = np.full((height, width), gray_val, dtype=np.uint8)
+    else:
+        normalized = np.clip(
+            (positions - vmin_ratio) / span, 0.0, 1.0
+        )
+        gray_values = (normalized * 255).astype(np.uint8)
+        gray = np.tile(gray_values[:, np.newaxis], (1, width))
 
     cmap_id = get_cv2_colormap_id(name)
-    color_img = cv2.applyColorMap(ramp, cmap_id)
+    color_img = cv2.applyColorMap(gray, cmap_id)
     color_img = cv2.cvtColor(color_img, cv2.COLOR_BGR2RGB)
+    return color_img
+
+
+def generate_gradient_pixmap(
+    name: str,
+    vmin_ratio: float = 0.0,
+    vmax_ratio: float = 1.0,
+    width: int = 20,
+    height: int = 256,
+):
+    """
+    Generate a vertical gradient QPixmap for the specified colormap.
+
+    Delegates to ``generate_gradient_array`` for the pixel data, then
+    wraps the result in a ``QPixmap``.  PySide6 is imported lazily to
+    keep this module headless-safe.
+
+    :param name: Colormap name (member of ``Colormap``).
+    :param vmin_ratio: Lower bound of the active range as a 0-1 ratio.
+    :param vmax_ratio: Upper bound of the active range as a 0-1 ratio.
+    :param width: Pixel width of the output pixmap.
+    :param height: Pixel height of the output pixmap.
+    """
+    from PySide6.QtGui import QImage, QPixmap
+
+    color_img = generate_gradient_array(
+        name, vmin_ratio, vmax_ratio, width, height
+    )
 
     h, w, ch = color_img.shape
     bytes_per_line = ch * w

--- a/src/le_beta_vis/frontend/widgets/VerticalRangeControl.py
+++ b/src/le_beta_vis/frontend/widgets/VerticalRangeControl.py
@@ -55,6 +55,9 @@ class _Style:
 class GradientBar(QLabel):
     """
     Vertical bar displaying a colormap gradient pixmap.
+
+    The gradient is compressed between ``vmin_ratio`` and ``vmax_ratio``
+    so that the colormap visually matches the active slider range.
     """
 
     def __init__(self, parent=None):
@@ -62,11 +65,30 @@ class GradientBar(QLabel):
         self.setScaledContents(True)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.setMinimumHeight(20)  # Prevent collapse to 0 height
+        self._colormap_name: str = "viridis"
+        self._vmin_ratio: float = 0.0
+        self._vmax_ratio: float = 1.0
         # Default gradient
         self.setColormap("viridis")
 
-    def setColormap(self, name: str):
-        pixmap = generate_gradient_pixmap(name)
+    def setColormap(self, name: str) -> None:
+        """Update the colormap and re-render the gradient."""
+        self._colormap_name = name
+        self._updatePixmap()
+
+    def updateRatios(self, vmin_ratio: float, vmax_ratio: float) -> None:
+        """Update the visible gradient compression range."""
+        self._vmin_ratio = vmin_ratio
+        self._vmax_ratio = vmax_ratio
+        self._updatePixmap()
+
+    def _updatePixmap(self) -> None:
+        """Re-render the gradient pixmap from current state."""
+        pixmap = generate_gradient_pixmap(
+            self._colormap_name,
+            self._vmin_ratio,
+            self._vmax_ratio,
+        )
         if not pixmap.isNull():
             self.setPixmap(pixmap)
 
@@ -243,6 +265,8 @@ class VerticalRangeControl(QWidget):
         self.slider.setValue((s_min, s_max))
         self.slider.blockSignals(False)
 
+        self._updateGradientRatios()
+
         self.blockSignals(False)
 
     def setColormap(self, name: str):
@@ -252,6 +276,15 @@ class VerticalRangeControl(QWidget):
         :param name: The name of the colormap to display (e.g., 'viridis').
         """
         self.gradient.setColormap(name)
+
+    def _updateGradientRatios(self) -> None:
+        """Recompute and apply gradient compression ratios."""
+        span = self._abs_max - self._abs_min
+        if span <= 0:
+            return
+        vmin_ratio = (self.spinMin.value() - self._abs_min) / span
+        vmax_ratio = (self.spinMax.value() - self._abs_min) / span
+        self.gradient.updateRatios(vmin_ratio, vmax_ratio)
 
     def _onSliderChanged(self, values: Tuple[int, int]):
         vmin = self._from_slider(values[0])
@@ -264,6 +297,7 @@ class VerticalRangeControl(QWidget):
         self.spinMin.blockSignals(False)
         self.spinMax.blockSignals(False)
 
+        self._updateGradientRatios()
         self.rangeChanged.emit(vmin, vmax)
 
     def _onSpinBoxChanged(self):
@@ -282,6 +316,7 @@ class VerticalRangeControl(QWidget):
         self.slider.setValue((s_min, s_max))
         self.slider.blockSignals(False)
 
+        self._updateGradientRatios()
         self.rangeChanged.emit(vmin, vmax)
 
     def _to_slider(self, val: float) -> int:

--- a/tests/test_GradientArray.py
+++ b/tests/test_GradientArray.py
@@ -1,0 +1,95 @@
+"""
+Pure-NumPy tests for ``generate_gradient_array``.
+
+No QApplication — safe for headless CI.
+
+References
+----------
+Issue #90 — Dynamic Gradient Rendering in VerticalRangeControl
+"""
+import numpy as np
+
+from le_beta_vis.frontend.fitsconverters.colormaps import (
+    generate_gradient_array,
+)
+
+
+class TestGradientArrayShape:
+    """Basic shape, dtype, and default behaviour."""
+
+    def test_default_shape_and_dtype(self):
+        arr = generate_gradient_array("viridis")
+        assert arr.shape == (256, 20, 3)
+        assert arr.dtype == np.uint8
+
+    def test_custom_dimensions(self):
+        arr = generate_gradient_array("viridis", width=10, height=128)
+        assert arr.shape == (128, 10, 3)
+
+    def test_full_range_matches_default(self):
+        default = generate_gradient_array("viridis")
+        explicit = generate_gradient_array("viridis", 0.0, 1.0)
+        np.testing.assert_array_equal(default, explicit)
+
+
+class TestEndcapColors:
+    """Rows outside the active range should be flat end-cap colors."""
+
+    def test_top_endcap_uniform(self):
+        arr = generate_gradient_array("viridis", 0.0, 0.5, height=100)
+        # Top row (index 0) corresponds to position 1.0, which is above
+        # vmax_ratio=0.5 → should be clamped to top color.
+        top_color = arr[0, 0]
+        # All rows in the top ~half should share this color.
+        for row in range(0, 40):
+            np.testing.assert_array_equal(arr[row, 0], top_color)
+
+    def test_bottom_endcap_uniform(self):
+        arr = generate_gradient_array("viridis", 0.5, 1.0, height=100)
+        bottom_color = arr[-1, 0]
+        for row in range(61, 100):
+            np.testing.assert_array_equal(arr[row, 0], bottom_color)
+
+
+class TestDegenerateRange:
+    """When vmin_ratio == vmax_ratio the array is a single color."""
+
+    def test_single_color(self):
+        arr = generate_gradient_array("viridis", 0.5, 0.5, height=64)
+        first_pixel = arr[0, 0]
+        for row in range(64):
+            np.testing.assert_array_equal(arr[row, 0], first_pixel)
+
+
+class TestRatioCorrectionAndClamping:
+    """Swapped and out-of-bounds ratios are auto-corrected."""
+
+    def test_swapped_ratios_auto_corrected(self):
+        normal = generate_gradient_array("viridis", 0.2, 0.8)
+        swapped = generate_gradient_array("viridis", 0.8, 0.2)
+        np.testing.assert_array_equal(normal, swapped)
+
+    def test_out_of_bounds_clamped(self):
+        clamped = generate_gradient_array("viridis", -0.5, 1.5)
+        full = generate_gradient_array("viridis", 0.0, 1.0)
+        np.testing.assert_array_equal(clamped, full)
+
+
+class TestColormapVariation:
+    """Different colormaps should produce different pixel data."""
+
+    def test_different_colormaps_differ(self):
+        a = generate_gradient_array("viridis")
+        b = generate_gradient_array("plasma")
+        assert not np.array_equal(a, b)
+
+
+class TestRowUniformity:
+    """All columns within a single row must be identical."""
+
+    def test_columns_identical(self):
+        arr = generate_gradient_array("inferno", 0.1, 0.9, width=30)
+        for row in range(arr.shape[0]):
+            first_col = arr[row, 0]
+            for col in range(1, arr.shape[1]):
+                np.testing.assert_array_equal(arr[row, col], first_col)


### PR DESCRIPTION
- Refactor `colormaps.py` to extract pure-NumPy `generate_gradient_array` from `generate_gradient_pixmap` to enable headless testing.
- Add support for `vmin_ratio` and `vmax_ratio` in gradient generation to allow compressing the colormap range.
- Update `GradientBar` and `VerticalRangeControl` to dynamically adjust and re-render the visible gradient based on the active slider range.


https://github.com/user-attachments/assets/85efbc30-7324-4a00-ac67-62e0d76f1eaa

Closes #90 