### PR TITLE
feat: Add event repository <-> EPS glue

### DIFF
--- a/ConfigurationKeys.md
+++ b/ConfigurationKeys.md
@@ -45,3 +45,7 @@ This document serves as the authoritative registry for all configuration keys us
 | **gui:inspector** | `histogram_bins` | Integer | `50` | Number of bins to use when generating energy distribution histograms for selected events. |
 | **gui:export** | `default_path` | String | `~/Data` | Default file system path presented in the "Save As" dialog. |
 | **gui:export** | `image_format` | String | `png` | Preferred file format for exporting plots and images. |
+| **eps** | `cluster_ipc` | String | `ipc:///tmp/EPCCluster.ipc` | ZMQ IPC address for the EPS cluster socket. |
+| **eps** | `fits_ipc` | String | `ipc:///tmp/EPCFits.ipc` | ZMQ IPC address for the EPS FITS socket. |
+| **eps** | `command_ipc` | String | `ipc:///tmp/EPCCommand.ipc` | ZMQ IPC address for the EPS command socket. |
+| **eps** | `timeout_ms` | Integer | `5000` | Timeout in milliseconds for ZMQ send/receive operations against the EPS. |

--- a/src/le_beta_vis/common/ConfigurationService.py
+++ b/src/le_beta_vis/common/ConfigurationService.py
@@ -80,6 +80,11 @@ class MockConfigurationService(ConfigurationService):
             "gui:export:image_format": "png",
             # Pipeline and Ingress
             "pipeline:ingress:polling_location": "~/Google\ Drive\/My\ Drive/FITS",
+            # Event Persistence Service (EPS)
+            "eps:cluster_ipc": "ipc:///tmp/EPCCluster.ipc",
+            "eps:fits_ipc": "ipc:///tmp/EPCFits.ipc",
+            "eps:command_ipc": "ipc:///tmp/EPCCommand.ipc",
+            "eps:timeout_ms": 5000,
         }
 
     def get(self, key: str, default: Any = None) -> Any:

--- a/src/le_beta_vis/common/EPSDataClasses.py
+++ b/src/le_beta_vis/common/EPSDataClasses.py
@@ -1,0 +1,193 @@
+"""Request/response DTOs for the Event Persistence Service (EPS) ZMQ protocol.
+
+Each class maps to a specific JSON message exchanged over the EPS IPC
+sockets.  All classes are frozen dataclasses with conversion helpers
+(``to_eps_dict`` for requests, ``from_eps_dict`` for responses).
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Request DTOs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ClusterQueryFilter:
+    """Filter criteria for an EPS Cluster Retrieval request.
+
+    Any field left as ``None`` is omitted from the request, meaning
+    the EPS will not filter on that criterion.
+    """
+
+    cluster_id: Optional[int] = None
+    fits_id: Optional[int] = None
+    hdu_id: Optional[int] = None
+    min_sigma_x: Optional[float] = None
+    min_sigma_y: Optional[float] = None
+    min_total_energy: Optional[float] = None
+    min_total_pixels: Optional[int] = None
+    classification: Optional[str] = None
+    # TODO: Can we query by date or file? If so, we need to add the filter here and check if EPS
+    # provides the capability
+
+    def to_eps_dict(self) -> Dict[str, Any]:
+        """Builds the JSON dict expected by the EPS Cluster socket."""
+        d: Dict[str, Any] = {"Action": "Retrieval"}
+        if self.cluster_id is not None:
+            d["cluster_id"] = self.cluster_id
+        if self.fits_id is not None:
+            d["fits_id"] = self.fits_id
+        if self.hdu_id is not None:
+            d["hdu_id"] = self.hdu_id
+        if self.min_sigma_x is not None:
+            d["sigmaX"] = self.min_sigma_x
+        if self.min_sigma_y is not None:
+            d["sigmaY"] = self.min_sigma_y
+        if self.min_total_energy is not None:
+            d["total_energy"] = self.min_total_energy
+        if self.min_total_pixels is not None:
+            d["total_pixels"] = self.min_total_pixels
+        if self.classification is not None:
+            d["classification"] = self.classification
+        return d
+
+
+@dataclass(frozen=True)
+class FitsQueryFilter:
+    """Filter criteria for an EPS FITS Retrieval request."""
+
+    fits_id: Optional[int] = None
+    filename: Optional[str] = None
+    date: Optional[str] = None
+    minimum: Optional[float] = None
+    maximum: Optional[float] = None
+    exposure_time: Optional[float] = None
+
+    def to_eps_dict(self) -> Dict[str, Any]:
+        """Builds the JSON dict expected by the EPS FITS socket."""
+        d: Dict[str, Any] = {"Action": "Retrieval"}
+        if self.fits_id is not None:
+            d["fits_id"] = self.fits_id
+        if self.filename is not None:
+            d["filename"] = self.filename
+        if self.date is not None:
+            d["date"] = self.date
+        if self.minimum is not None:
+            d["minimum"] = self.minimum
+        if self.maximum is not None:
+            d["maximum"] = self.maximum
+        if self.exposure_time is not None:
+            d["exposure_time"] = self.exposure_time
+        return d
+
+
+@dataclass(frozen=True)
+class ClusterStoreRequest:
+    """Payload for an EPS Cluster Storage request."""
+
+    data: List[Any]
+    hdu_id: int
+    bounding_box: Dict[str, int]
+    sigma_x: float
+    sigma_y: float
+    total_energy: float
+    total_pixels: int
+    fits_id: int
+    classification: str = ""
+
+    def to_eps_dict(self) -> Dict[str, Any]:
+        """Builds the JSON dict expected by the EPS Cluster socket."""
+        return {
+            "Action": "Storage",
+            "data": self.data,
+            "hdu_id": self.hdu_id,
+            "bounding_box": self.bounding_box,
+            "sigmaX": self.sigma_x,
+            "sigmaY": self.sigma_y,
+            "total_energy": self.total_energy,
+            "total_pixels": self.total_pixels,
+            "fits_id": self.fits_id,
+            "classification": self.classification,
+        }
+
+
+@dataclass(frozen=True)
+class ClassificationUpdateRequest:
+    """Payload for updating a cluster's classification string."""
+
+    cluster_id: int
+    classification: str
+
+    def to_eps_dict(self) -> Dict[str, Any]:
+        """Builds the JSON dict for a classification update."""
+        return {
+            "Action": "UpdateClassification",
+            "cluster_id": self.cluster_id,
+            "classification": self.classification,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Response DTOs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EPSClusterRecord:
+    """A single cluster record from an EPS Cluster Retrieval response."""
+
+    fits_id: int
+    hdu_id: int
+    cluster_id: int
+    data: Any
+    total_energy: float
+    sigma_x: float
+    sigma_y: float
+    classification: str
+    total_pixels: int
+
+    @staticmethod
+    def from_eps_dict(d: Dict[str, Any]) -> "EPSClusterRecord":
+        """Parses one element of the ``clusters`` response array."""
+        return EPSClusterRecord(
+            fits_id=d.get("fits_id", 0),
+            hdu_id=d.get("hdu_id", 0),
+            cluster_id=d.get("cluster_id", 0),
+            data=d.get("data", []),
+            total_energy=float(d.get("total_energy", 0.0)),
+            sigma_x=float(d.get("sigmaX", 0.0)),
+            sigma_y=float(d.get("sigmaY", 0.0)),
+            classification=str(d.get("classification", "")),
+            total_pixels=int(d.get("total_pixels", 0)),
+        )
+
+
+@dataclass(frozen=True)
+class EPSFitsRecord:
+    """A single FITS file record from an EPS FITS Retrieval response."""
+
+    fits_id: int
+    filename: str
+    date: str
+    min_val: float
+    max_val: float
+    exposure_time: float
+
+    @staticmethod
+    def from_eps_dict(d: Dict[str, Any]) -> "EPSFitsRecord":
+        """Parses one element of the EPS FITS response array.
+
+        The EPS returns ``"min"`` and ``"max"`` keys (not
+        ``"minimum"``/``"maximum"``).
+        """
+        return EPSFitsRecord(
+            fits_id=int(d.get("fits_id", 0)),
+            filename=str(d.get("filename", "")),
+            date=str(d.get("date", "")),
+            min_val=float(d.get("min", 0.0)),
+            max_val=float(d.get("max", 0.0)),
+            exposure_time=float(d.get("exposure_time", 0.0)),
+        )

--- a/src/le_beta_vis/common/EventRepository.py
+++ b/src/le_beta_vis/common/EventRepository.py
@@ -1,7 +1,13 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
 
 from .Cluster import Cluster
+from .EPSDataClasses import (
+    ClassificationUpdateRequest,
+    ClusterQueryFilter,
+    ClusterStoreRequest,
+    EPSFitsRecord,
+)
 
 
 class EventRepository(ABC):
@@ -19,5 +25,53 @@ class EventRepository(ABC):
         Implementations should return a list of ``Cluster``
         objects with classification scores and pixel data
         populated.
+        """
+        raise NotImplementedError
+
+    def query_clusters(
+        self, query_filter: Optional[ClusterQueryFilter] = None
+    ) -> List[Cluster]:
+        """Filtered cluster query.
+
+        Args:
+            query_filter: Optional filter criteria.  ``None``
+                means return all clusters (same as
+                ``fetch_events``).
+
+        Returns:
+            Matching ``Cluster`` objects.
+        """
+        raise NotImplementedError
+
+    def store_cluster(
+        self, request: ClusterStoreRequest
+    ) -> Optional[int]:
+        """Persist a cluster to the backend.
+
+        Returns:
+            The new cluster ID on success, or ``None``.
+        """
+        raise NotImplementedError
+
+    def update_classification(
+        self, request: ClassificationUpdateRequest
+    ) -> bool:
+        """Update classification on an existing cluster.
+
+        Returns:
+            ``True`` on success.
+        """
+        raise NotImplementedError
+
+    def query_fits(
+        self, fits_id: Optional[int] = None
+    ) -> List[EPSFitsRecord]:
+        """Retrieve FITS metadata.
+
+        Args:
+            fits_id: Optional filter by FITS ID.
+
+        Returns:
+            Matching FITS records.
         """
         raise NotImplementedError

--- a/src/le_beta_vis/common/MockEventRepository.py
+++ b/src/le_beta_vis/common/MockEventRepository.py
@@ -1,9 +1,10 @@
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 
 from .BoundingBox import BoundingBox
 from .Cluster import Cluster
+from .EPSDataClasses import ClusterQueryFilter
 from .EventRepository import EventRepository
 
 
@@ -80,3 +81,42 @@ class MockEventRepository(EventRepository):
             )
             clusters.append(cluster)
         return clusters
+
+    def query_clusters(
+        self, query_filter: Optional[ClusterQueryFilter] = None
+    ) -> List[Cluster]:
+        """Returns synthetic clusters, optionally filtered.
+
+        Applies Python-side filtering to match EPS behaviour.
+        """
+        clusters = self.fetch_events()
+        if query_filter is None:
+            return clusters
+        return [c for c in clusters if self._matches(c, query_filter)]
+
+    @staticmethod
+    def _matches(
+        cluster: Cluster, qf: ClusterQueryFilter
+    ) -> bool:
+        """Returns True if *cluster* satisfies all filter criteria."""
+        if qf.cluster_id is not None and cluster.clusterId != qf.cluster_id:
+            return False
+        if qf.fits_id is not None and cluster.fitsId != qf.fits_id:
+            return False
+        if qf.min_sigma_x is not None and cluster.sigmaX < qf.min_sigma_x:
+            return False
+        if qf.min_sigma_y is not None and cluster.sigmaY < qf.min_sigma_y:
+            return False
+        if (
+            qf.min_total_energy is not None
+            and cluster.energy < qf.min_total_energy
+        ):
+            return False
+        if (
+            qf.min_total_pixels is not None
+            and cluster.pixelCount < qf.min_total_pixels
+        ):
+            return False
+        if qf.classification is not None:
+            return False
+        return True

--- a/src/le_beta_vis/common/NoOpEventRepository.py
+++ b/src/le_beta_vis/common/NoOpEventRepository.py
@@ -1,0 +1,64 @@
+"""No-op fallback repository used when the EPS backend is unavailable.
+
+Every method returns an empty/default value and logs a warning.
+"""
+
+import logging
+from typing import List, Optional
+
+from .Cluster import Cluster
+from .EPSDataClasses import (
+    ClassificationUpdateRequest,
+    ClusterQueryFilter,
+    ClusterStoreRequest,
+    EPSFitsRecord,
+)
+from .EventRepository import EventRepository
+
+logger = logging.getLogger(__name__)
+
+
+class NoOpEventRepository(EventRepository):
+    """Fallback EventRepository that returns empty results.
+
+    All methods log a warning indicating the EPS is unavailable
+    and return safe defaults.
+    """
+
+    def fetch_events(self) -> List[Cluster]:
+        """Returns an empty list — EPS is unavailable."""
+        logger.warning(
+            "NoOpEventRepository: fetch_events called but " "EPS is unavailable"
+        )
+        return []
+
+    def query_clusters(
+        self, query_filter: Optional[ClusterQueryFilter] = None
+    ) -> List[Cluster]:
+        """Returns an empty list — EPS is unavailable."""
+        logger.warning(
+            "NoOpEventRepository: query_clusters called but " "EPS is unavailable"
+        )
+        return []
+
+    def store_cluster(self, request: ClusterStoreRequest) -> Optional[int]:
+        """Returns None — EPS is unavailable."""
+        logger.warning(
+            "NoOpEventRepository: store_cluster called but " "EPS is unavailable"
+        )
+        return None
+
+    def update_classification(self, request: ClassificationUpdateRequest) -> bool:
+        """Returns False — EPS is unavailable."""
+        logger.warning(
+            "NoOpEventRepository: update_classification called "
+            "but EPS is unavailable"
+        )
+        return False
+
+    def query_fits(self, fits_id: Optional[int] = None) -> List[EPSFitsRecord]:
+        """Returns an empty list — EPS is unavailable."""
+        logger.warning(
+            "NoOpEventRepository: query_fits called but " "EPS is unavailable"
+        )
+        return []

--- a/src/le_beta_vis/common/__init__.py
+++ b/src/le_beta_vis/common/__init__.py
@@ -2,7 +2,10 @@
 # pylint: disable=unused-import
 # pyright: reportUnusedImport=false
 from .ConfigurationService import ConfigurationService, MockConfigurationService
-from .PhysicsConversionManager import PhysicsConversionManager, PhysicsConversionManagerImpl
+from .PhysicsConversionManager import (
+    PhysicsConversionManager,
+    PhysicsConversionManagerImpl,
+)
 from .CCDCaptureModel import CCDCaptureModel
 from .RegionOfInterest import RegionOfInterest
 from .RoiRect import RoiRect
@@ -10,8 +13,19 @@ from .BoundingBox import BoundingBox
 from .ClusterExtractor import ClusterExtractor, ClusteredEventInfo
 from .Cluster import Cluster
 from .ParticleType import ParticleType, classify_particle, CLASSIFICATION_THRESHOLD
+from .EPSDataClasses import (
+    ClusterQueryFilter,
+    ClusterStoreRequest,
+    ClassificationUpdateRequest,
+    FitsQueryFilter,
+    EPSClusterRecord,
+    EPSFitsRecord,
+)
 from .EventRepository import EventRepository
 from .MockEventRepository import MockEventRepository
+from .NoOpEventRepository import NoOpEventRepository
+
+# from .ZMQBasedEventRepository import ZMQBasedEventRepository
 from .HistogramDataModel import HistogramDataModel
 from .ROIStatistics import ROIStatistics
 from .HistogramRenderer import HistogramRenderer, MatplotlibHistogramRenderer

--- a/src/le_beta_vis/frontend/viewmodels/HistoricalViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/HistoricalViewModel.py
@@ -1,6 +1,7 @@
 from typing import List, Callable, Optional
 from enum import Enum
 from le_beta_vis.common.ConfigurationService import ConfigurationService
+from le_beta_vis.common.EPSDataClasses import ClusterQueryFilter
 from le_beta_vis.common.HistogramRenderer import (
     HistogramRenderer,
     MatplotlibHistogramRenderer,
@@ -51,6 +52,7 @@ class HistoricalViewModel:
         self._events: List[Cluster] = []
         self._selectedIndex: int = -1
         self._loading: bool = False
+        self._query_filter: Optional[ClusterQueryFilter] = None
 
         # Callbacks
         self._on_mode_changed_callbacks: List[
@@ -147,15 +149,35 @@ class HistoricalViewModel:
         )
         self.setMode(new_mode)
 
+    def setQueryFilter(
+        self, query_filter: Optional[ClusterQueryFilter]
+    ) -> None:
+        """Sets filter criteria for the next ``loadEvents`` call.
+
+        Args:
+            query_filter: Filter to apply, or ``None`` to clear.
+        """
+        self._query_filter = query_filter
+
     def loadEvents(self) -> None:
         """Fetches events from the repository and notifies observers.
 
-        Sets loading state before/after the fetch.  On success
-        the events list is replaced and any selection is cleared.
+        Sets loading state before/after the fetch.  When a query
+        filter is set, ``query_clusters`` is attempted first; if the
+        repository does not implement it, falls back to
+        ``fetch_events``.
         """
         self._setLoading(True)
         try:
-            self._events = self._repository.fetch_events()
+            if self._query_filter is not None:
+                try:
+                    self._events = self._repository.query_clusters(
+                        self._query_filter
+                    )
+                except NotImplementedError:
+                    self._events = self._repository.fetch_events()
+            else:
+                self._events = self._repository.fetch_events()
             self._selectedIndex = 0 if self._events else -1
         finally:
             self._setLoading(False)

--- a/tests/test_EPSDataClasses.py
+++ b/tests/test_EPSDataClasses.py
@@ -1,0 +1,188 @@
+"""Tests for EPSDataClasses request/response DTOs.
+
+Pure data-mapping tests — no ZMQ dependency.
+"""
+from le_beta_vis.common.EPSDataClasses import (
+    ClassificationUpdateRequest,
+    ClusterQueryFilter,
+    ClusterStoreRequest,
+    EPSClusterRecord,
+    EPSFitsRecord,
+    FitsQueryFilter,
+)
+
+
+# -------------------------------------------------------------------
+# ClusterQueryFilter
+# -------------------------------------------------------------------
+
+class TestClusterQueryFilter:
+
+    def test_empty_filter_to_eps_dict(self):
+        """An all-None filter should produce only the Action key."""
+        qf = ClusterQueryFilter()
+        d = qf.to_eps_dict()
+        assert d == {"Action": "Retrieval"}
+
+    def test_single_field_maps_correctly(self):
+        qf = ClusterQueryFilter(fits_id=42)
+        d = qf.to_eps_dict()
+        assert d["fits_id"] == 42
+        assert d["Action"] == "Retrieval"
+        assert "cluster_id" not in d
+
+    def test_all_fields_map_correctly(self):
+        qf = ClusterQueryFilter(
+            cluster_id=1, fits_id=2, hdu_id=3,
+            min_sigma_x=0.5, min_sigma_y=0.6,
+            min_total_energy=100.0, min_total_pixels=10,
+            classification="tritium",
+        )
+        d = qf.to_eps_dict()
+        assert d["cluster_id"] == 1
+        assert d["fits_id"] == 2
+        assert d["hdu_id"] == 3
+        assert d["sigmaX"] == 0.5
+        assert d["sigmaY"] == 0.6
+        assert d["total_energy"] == 100.0
+        assert d["total_pixels"] == 10
+        assert d["classification"] == "tritium"
+
+    def test_frozen(self):
+        """ClusterQueryFilter should be immutable."""
+        qf = ClusterQueryFilter(fits_id=1)
+        try:
+            qf.fits_id = 99
+            assert False, "Should have raised"
+        except AttributeError:
+            pass
+
+
+# -------------------------------------------------------------------
+# FitsQueryFilter
+# -------------------------------------------------------------------
+
+class TestFitsQueryFilter:
+
+    def test_empty_filter(self):
+        d = FitsQueryFilter().to_eps_dict()
+        assert d == {"Action": "Retrieval"}
+
+    def test_fits_id_maps(self):
+        d = FitsQueryFilter(fits_id=7).to_eps_dict()
+        assert d["fits_id"] == 7
+
+
+# -------------------------------------------------------------------
+# ClusterStoreRequest
+# -------------------------------------------------------------------
+
+class TestClusterStoreRequest:
+
+    def test_to_eps_dict_action(self):
+        req = ClusterStoreRequest(
+            data=[1, 2, 3], hdu_id=0,
+            bounding_box={"top": 0, "left": 0, "bottom": 5, "right": 5},
+            sigma_x=1.0, sigma_y=1.0,
+            total_energy=100.0, total_pixels=25,
+            fits_id=1, classification="tritium",
+        )
+        d = req.to_eps_dict()
+        assert d["Action"] == "Storage"
+        assert d["data"] == [1, 2, 3]
+        assert d["fits_id"] == 1
+        assert d["sigmaX"] == 1.0
+        assert d["classification"] == "tritium"
+
+    def test_default_classification(self):
+        req = ClusterStoreRequest(
+            data=[], hdu_id=0,
+            bounding_box={}, sigma_x=0.0, sigma_y=0.0,
+            total_energy=0.0, total_pixels=0, fits_id=0,
+        )
+        assert req.classification == ""
+
+
+# -------------------------------------------------------------------
+# ClassificationUpdateRequest
+# -------------------------------------------------------------------
+
+class TestClassificationUpdateRequest:
+
+    def test_to_eps_dict(self):
+        req = ClassificationUpdateRequest(
+            cluster_id=42, classification="muon"
+        )
+        d = req.to_eps_dict()
+        assert d["Action"] == "UpdateClassification"
+        assert d["cluster_id"] == 42
+        assert d["classification"] == "muon"
+
+
+# -------------------------------------------------------------------
+# EPSClusterRecord
+# -------------------------------------------------------------------
+
+class TestEPSClusterRecord:
+
+    def test_from_full_dict(self):
+        raw = {
+            "fits_id": 1, "hdu_id": 2, "cluster_id": 3,
+            "data": [1.0, 2.0, 3.0, 4.0],
+            "total_energy": 500.0,
+            "sigmaX": 1.5, "sigmaY": 2.0,
+            "classification": "tritium",
+            "total_pixels": 20,
+        }
+        rec = EPSClusterRecord.from_eps_dict(raw)
+        assert rec.fits_id == 1
+        assert rec.hdu_id == 2
+        assert rec.cluster_id == 3
+        assert rec.data == [1.0, 2.0, 3.0, 4.0]
+        assert rec.total_energy == 500.0
+        assert rec.sigma_x == 1.5
+        assert rec.sigma_y == 2.0
+        assert rec.classification == "tritium"
+        assert rec.total_pixels == 20
+
+    def test_from_empty_dict_uses_defaults(self):
+        rec = EPSClusterRecord.from_eps_dict({})
+        assert rec.fits_id == 0
+        assert rec.cluster_id == 0
+        assert rec.total_energy == 0.0
+        assert rec.classification == ""
+        assert rec.data == []
+
+    def test_from_partial_dict(self):
+        raw = {"fits_id": 99, "total_energy": 42.0}
+        rec = EPSClusterRecord.from_eps_dict(raw)
+        assert rec.fits_id == 99
+        assert rec.total_energy == 42.0
+        assert rec.hdu_id == 0
+
+
+# -------------------------------------------------------------------
+# EPSFitsRecord
+# -------------------------------------------------------------------
+
+class TestEPSFitsRecord:
+
+    def test_from_full_dict(self):
+        raw = {
+            "fits_id": 5, "filename": "capture.fits",
+            "date": "2025-01-01", "min": 0.1,
+            "max": 99.9, "exposure_time": 300.0,
+        }
+        rec = EPSFitsRecord.from_eps_dict(raw)
+        assert rec.fits_id == 5
+        assert rec.filename == "capture.fits"
+        assert rec.date == "2025-01-01"
+        assert rec.min_val == 0.1
+        assert rec.max_val == 99.9
+        assert rec.exposure_time == 300.0
+
+    def test_from_empty_dict_uses_defaults(self):
+        rec = EPSFitsRecord.from_eps_dict({})
+        assert rec.fits_id == 0
+        assert rec.filename == ""
+        assert rec.exposure_time == 0.0

--- a/tests/test_MockEventRepository.py
+++ b/tests/test_MockEventRepository.py
@@ -13,6 +13,7 @@ from le_beta_vis.common.MockEventRepository import (
 )
 from le_beta_vis.common.Cluster import Cluster
 from le_beta_vis.common.BoundingBox import BoundingBox
+from le_beta_vis.common.EPSDataClasses import ClusterQueryFilter
 
 
 def test_returns_list_of_clusters():
@@ -92,3 +93,70 @@ def test_cluster_id_unique():
     events = repo.fetch_events()
     ids = [e.clusterId for e in events]
     assert len(ids) == len(set(ids))
+
+
+# -------------------------------------------------------------------
+# query_clusters filtering
+# -------------------------------------------------------------------
+
+def test_query_clusters_none_returns_all():
+    """query_clusters(None) should return the same as fetch_events."""
+    repo = MockEventRepository()
+    assert len(repo.query_clusters(None)) == len(repo.fetch_events())
+
+
+def test_query_clusters_by_fits_id():
+    """Filtering by fits_id should only return matching clusters."""
+    repo = MockEventRepository()
+    qf = ClusterQueryFilter(fits_id=1)
+    results = repo.query_clusters(qf)
+    assert len(results) > 0
+    for c in results:
+        assert c.fitsId == 1
+
+
+def test_query_clusters_by_cluster_id():
+    """Filtering by cluster_id should return exactly one cluster."""
+    repo = MockEventRepository()
+    qf = ClusterQueryFilter(cluster_id=1)
+    results = repo.query_clusters(qf)
+    assert len(results) == 1
+    assert results[0].clusterId == 1
+
+
+def test_query_clusters_by_min_energy():
+    """Filtering by min_total_energy should exclude low-energy clusters."""
+    repo = MockEventRepository()
+    threshold = 5000.0
+    qf = ClusterQueryFilter(min_total_energy=threshold)
+    results = repo.query_clusters(qf)
+    assert len(results) > 0
+    for c in results:
+        assert c.energy >= threshold
+
+
+def test_query_clusters_by_min_pixels():
+    """Filtering by min_total_pixels should exclude small clusters."""
+    repo = MockEventRepository()
+    qf = ClusterQueryFilter(min_total_pixels=50)
+    results = repo.query_clusters(qf)
+    assert len(results) > 0
+    for c in results:
+        assert c.pixelCount >= 50
+
+
+def test_query_clusters_multiple_filters():
+    """Multiple filters should be AND-combined."""
+    repo = MockEventRepository()
+    qf = ClusterQueryFilter(fits_id=1, min_total_energy=2000.0)
+    results = repo.query_clusters(qf)
+    for c in results:
+        assert c.fitsId == 1
+        assert c.energy >= 2000.0
+
+
+def test_query_clusters_no_match_returns_empty():
+    """A filter that matches nothing should return an empty list."""
+    repo = MockEventRepository()
+    qf = ClusterQueryFilter(cluster_id=9999)
+    assert repo.query_clusters(qf) == []

--- a/tests/test_NoOpEventRepository.py
+++ b/tests/test_NoOpEventRepository.py
@@ -1,0 +1,70 @@
+"""Tests for NoOpEventRepository.
+
+Verifies that all methods return safe defaults and emit warnings.
+"""
+import logging
+
+from le_beta_vis.common.NoOpEventRepository import NoOpEventRepository
+from le_beta_vis.common.EPSDataClasses import (
+    ClassificationUpdateRequest,
+    ClusterQueryFilter,
+    ClusterStoreRequest,
+)
+
+
+def _make_repo() -> NoOpEventRepository:
+    return NoOpEventRepository()
+
+
+def test_fetch_events_returns_empty(caplog):
+    repo = _make_repo()
+    with caplog.at_level(logging.WARNING):
+        result = repo.fetch_events()
+    assert result == []
+    assert "fetch_events" in caplog.text
+
+
+def test_query_clusters_returns_empty(caplog):
+    repo = _make_repo()
+    qf = ClusterQueryFilter(fits_id=1)
+    with caplog.at_level(logging.WARNING):
+        result = repo.query_clusters(qf)
+    assert result == []
+    assert "query_clusters" in caplog.text
+
+
+def test_query_clusters_none_filter(caplog):
+    repo = _make_repo()
+    with caplog.at_level(logging.WARNING):
+        result = repo.query_clusters(None)
+    assert result == []
+
+
+def test_store_cluster_returns_none(caplog):
+    repo = _make_repo()
+    req = ClusterStoreRequest(
+        data=[], hdu_id=0, bounding_box={},
+        sigma_x=0.0, sigma_y=0.0,
+        total_energy=0.0, total_pixels=0, fits_id=0,
+    )
+    with caplog.at_level(logging.WARNING):
+        result = repo.store_cluster(req)
+    assert result is None
+    assert "store_cluster" in caplog.text
+
+
+def test_update_classification_returns_false(caplog):
+    repo = _make_repo()
+    req = ClassificationUpdateRequest(cluster_id=1, classification="x")
+    with caplog.at_level(logging.WARNING):
+        result = repo.update_classification(req)
+    assert result is False
+    assert "update_classification" in caplog.text
+
+
+def test_query_fits_returns_empty(caplog):
+    repo = _make_repo()
+    with caplog.at_level(logging.WARNING):
+        result = repo.query_fits(fits_id=1)
+    assert result == []
+    assert "query_fits" in caplog.text


### PR DESCRIPTION
- Add data class to dictionary mappers to interface with EPS
- Extend EventRepository interface with methods needed to fetching, filtering, classifying and training
- Introduce NoOpEventRepository to simulate when the backend is not present
- Add ZMQBasedEventRepository concrete implementation of EventRepository. This implementation is responsible of talking directly with EPS via ZMQ
- Add configuration keys for the IPC comm
- Add test cases for the EPS data classes and mapper
- Update MockEventRepository to follow the new additions to EventRepository