### PR TITLE
feat: Implement historical event query interface

### DIFF
--- a/src/le_beta_vis/common/EPSDataClasses.py
+++ b/src/le_beta_vis/common/EPSDataClasses.py
@@ -30,8 +30,11 @@ class ClusterQueryFilter:
     min_total_energy: Optional[float] = None
     min_total_pixels: Optional[int] = None
     classification: Optional[str] = None
-    # TODO: Can we query by date or file? If so, we need to add the filter here and check if EPS
-    # provides the capability
+    # TODO: Date-based filtering — the UI already collects
+    # start/end datetimes via HistoricalFilterBarViewModel
+    # (start_datetime / end_datetime).  When the EPS supports
+    # date-range queries, add start_date and end_date fields
+    # here and populate them in build_filter().
 
     def to_eps_dict(self) -> Dict[str, Any]:
         """Builds the JSON dict expected by the EPS Cluster socket."""

--- a/src/le_beta_vis/frontend/viewmodels/HistoricalFilterBarViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/HistoricalFilterBarViewModel.py
@@ -1,0 +1,290 @@
+"""ViewModel for the Historical Filter Bar.
+
+Pure Python — no Qt imports — so it runs in headless CI.
+Manages filter field state and builds ``ClusterQueryFilter``
+instances for the ``HistoricalViewModel`` to execute.
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Callable, List, Optional, Tuple
+
+from le_beta_vis.common.ConfigurationService import ConfigurationService
+from le_beta_vis.common.EPSDataClasses import ClusterQueryFilter
+from le_beta_vis.common.ParticleType import ParticleType
+from le_beta_vis.common.PhysicsConversionManager import (
+    PhysicsConversionManager,
+)
+
+logger = logging.getLogger(__name__)
+
+# Maps config default_query_hours to a preset key
+_HOURS_TO_PRESET = {24: "24h", 72: "3d", 168: "7d", 720: "30d"}
+
+# Maps preset key to number of hours for date computation
+_PRESET_TO_HOURS = {"24h": 24, "3d": 72, "7d": 168, "30d": 720}
+
+
+class HistoricalFilterBarViewModel:
+    """Pure Python ViewModel for the filter toolbar.
+
+    Manages filter-field state, converts display units to storage
+    units (keV -> ADU), and notifies observers when a filter is
+    applied or reset.
+    """
+
+    def __init__(
+        self,
+        configService: ConfigurationService,
+        physicsManager: PhysicsConversionManager,
+    ):
+        self._config = configService
+        self._physics = physicsManager
+
+        # Resolve default time preset from config
+        default_hours = int(self._config.get(
+            "gui:historical:default_query_hours", 24
+        ))
+        self._default_time_preset = _HOURS_TO_PRESET.get(
+            default_hours, "24h"
+        )
+
+        # Filter fields (all default to "no filter")
+        self._time_preset: str = self._default_time_preset
+        self._cluster_id: Optional[int] = None
+        self._fits_id: Optional[int] = None
+        self._hdu_id: Optional[int] = None
+        self._min_sigma_x: Optional[float] = None
+        self._min_sigma_y: Optional[float] = None
+        self._min_total_energy: Optional[float] = None
+        self._min_total_pixels: Optional[int] = None
+        self._classification: Optional[str] = None
+        self._start_datetime: Optional[datetime] = None
+        self._end_datetime: Optional[datetime] = None
+
+        # Callbacks
+        self._on_filter_applied: List[
+            Callable[[ClusterQueryFilter], None]
+        ] = []
+        self._on_filter_reset: List[Callable[[], None]] = []
+
+    # --- Properties ---
+
+    @property
+    def time_preset(self) -> str:
+        """Current time-range preset key."""
+        return self._time_preset
+
+    @time_preset.setter
+    def time_preset(self, value: str) -> None:
+        self._time_preset = value
+
+    @property
+    def cluster_id(self) -> Optional[int]:
+        """Cluster ID filter, or ``None`` for any."""
+        return self._cluster_id
+
+    @cluster_id.setter
+    def cluster_id(self, value: Optional[int]) -> None:
+        self._cluster_id = value
+
+    @property
+    def fits_id(self) -> Optional[int]:
+        """FITS ID filter, or ``None`` for any."""
+        return self._fits_id
+
+    @fits_id.setter
+    def fits_id(self, value: Optional[int]) -> None:
+        self._fits_id = value
+
+    @property
+    def hdu_id(self) -> Optional[int]:
+        """HDU ID filter, or ``None`` for any."""
+        return self._hdu_id
+
+    @hdu_id.setter
+    def hdu_id(self, value: Optional[int]) -> None:
+        self._hdu_id = value
+
+    @property
+    def min_sigma_x(self) -> Optional[float]:
+        """Minimum sigma-X filter, or ``None`` for any."""
+        return self._min_sigma_x
+
+    @min_sigma_x.setter
+    def min_sigma_x(self, value: Optional[float]) -> None:
+        self._min_sigma_x = value
+
+    @property
+    def min_sigma_y(self) -> Optional[float]:
+        """Minimum sigma-Y filter, or ``None`` for any."""
+        return self._min_sigma_y
+
+    @min_sigma_y.setter
+    def min_sigma_y(self, value: Optional[float]) -> None:
+        self._min_sigma_y = value
+
+    @property
+    def min_total_energy(self) -> Optional[float]:
+        """Minimum energy in display units (keV or ADU), or ``None``."""
+        return self._min_total_energy
+
+    @min_total_energy.setter
+    def min_total_energy(self, value: Optional[float]) -> None:
+        self._min_total_energy = value
+
+    @property
+    def min_total_pixels(self) -> Optional[int]:
+        """Minimum pixel count filter, or ``None`` for any."""
+        return self._min_total_pixels
+
+    @min_total_pixels.setter
+    def min_total_pixels(self, value: Optional[int]) -> None:
+        self._min_total_pixels = value
+
+    @property
+    def classification(self) -> Optional[str]:
+        """Classification string filter, or ``None`` for all."""
+        return self._classification
+
+    @classification.setter
+    def classification(self, value: Optional[str]) -> None:
+        self._classification = value
+
+    @property
+    def start_datetime(self) -> Optional[datetime]:
+        """Start of the date range filter, or ``None``."""
+        return self._start_datetime
+
+    @start_datetime.setter
+    def start_datetime(self, value: Optional[datetime]) -> None:
+        self._start_datetime = value
+
+    @property
+    def end_datetime(self) -> Optional[datetime]:
+        """End of the date range filter, or ``None``."""
+        return self._end_datetime
+
+    @end_datetime.setter
+    def end_datetime(self, value: Optional[datetime]) -> None:
+        self._end_datetime = value
+
+    @property
+    def display_energy_in_kev(self) -> bool:
+        """Whether the UI should show energy values in keV."""
+        return bool(self._config.get(
+            "gui:raw_analysis:display_energy_in_kev", True
+        ))
+
+    @property
+    def energy_unit_label(self) -> str:
+        """Display label for the energy unit ('keV' or 'ADU')."""
+        return "keV" if self.display_energy_in_kev else "ADU"
+
+    @property
+    def classification_options(
+        self,
+    ) -> List[Tuple[str, Optional[str]]]:
+        """Available classification choices for the combo box.
+
+        Returns a list of ``(display_text, filter_value)`` tuples.
+        The first entry is always ``("All", None)`` (no filter).
+        """
+        options: List[Tuple[str, Optional[str]]] = [("All", None)]
+        for pt in ParticleType:
+            label = (
+                f"{pt.display_name} {pt.symbol}"
+                if pt != ParticleType.UNCLASSIFIED
+                else pt.display_name
+            )
+            options.append((label, pt.name.lower()))
+        return options
+
+    # --- Commands ---
+
+    @staticmethod
+    def compute_dates_for_preset(
+        preset: str,
+    ) -> Tuple[datetime, datetime]:
+        """Returns ``(start, end)`` for the given time-preset key.
+
+        Unknown keys fall back to 24 hours.
+        """
+        hours = _PRESET_TO_HOURS.get(preset, 24)
+        end = datetime.now()
+        start = end - timedelta(hours=hours)
+        return start, end
+
+    def build_filter(self) -> ClusterQueryFilter:
+        """Constructs a ``ClusterQueryFilter`` from current field state.
+
+        Energy values in keV are converted back to ADU for the query.
+        Spinbox values of 0 are treated as "no filter" (``None``).
+        """
+        energy_adu: Optional[float] = None
+        if self._min_total_energy is not None:
+            if self.display_energy_in_kev:
+                factor = self._physics.kev_conversion_factor
+                energy_adu = (
+                    self._min_total_energy / factor
+                    if factor != 0 else None
+                )
+            else:
+                energy_adu = self._min_total_energy
+
+        # TODO: Wire start_datetime / end_datetime into the
+        # ClusterQueryFilter once the EPS supports date-based
+        # filtering — see EPSDataClasses.py TODO.
+        if self._time_preset != self._default_time_preset:
+            logger.info(
+                "Time preset '%s' selected but date filtering is "
+                "not yet supported by the EPS backend.",
+                self._time_preset,
+            )
+
+        return ClusterQueryFilter(
+            cluster_id=self._cluster_id,
+            fits_id=self._fits_id,
+            hdu_id=self._hdu_id,
+            min_sigma_x=self._min_sigma_x,
+            min_sigma_y=self._min_sigma_y,
+            min_total_energy=energy_adu,
+            min_total_pixels=self._min_total_pixels,
+            classification=self._classification,
+        )
+
+    def apply(self) -> None:
+        """Builds the current filter and notifies observers."""
+        query_filter = self.build_filter()
+        for callback in self._on_filter_applied:
+            callback(query_filter)
+
+    def reset(self) -> None:
+        """Resets all fields to defaults and notifies observers."""
+        self._time_preset = self._default_time_preset
+        self._cluster_id = None
+        self._fits_id = None
+        self._hdu_id = None
+        self._min_sigma_x = None
+        self._min_sigma_y = None
+        self._min_total_energy = None
+        self._min_total_pixels = None
+        self._classification = None
+        self._start_datetime = None
+        self._end_datetime = None
+        for callback in self._on_filter_reset:
+            callback()
+
+    # --- Observer pattern ---
+
+    def add_filter_applied_callback(
+        self, callback: Callable[[ClusterQueryFilter], None]
+    ) -> None:
+        """Registers a callback fired when ``apply()`` is called."""
+        self._on_filter_applied.append(callback)
+
+    def add_filter_reset_callback(
+        self, callback: Callable[[], None]
+    ) -> None:
+        """Registers a callback fired when ``reset()`` is called."""
+        self._on_filter_reset.append(callback)

--- a/src/le_beta_vis/frontend/viewmodels/__init__.py
+++ b/src/le_beta_vis/frontend/viewmodels/__init__.py
@@ -7,3 +7,4 @@ from .HistoricalViewModel import HistoricalViewModel
 from .HistoricalEventInspectorViewModel import (
     HistoricalEventInspectorViewModel,
 )
+from .HistoricalFilterBarViewModel import HistoricalFilterBarViewModel

--- a/src/le_beta_vis/frontend/views/HistoricalView.py
+++ b/src/le_beta_vis/frontend/views/HistoricalView.py
@@ -1,8 +1,5 @@
 from PySide6.QtCore import Qt, Slot, QMetaObject
 from PySide6.QtWidgets import (
-    QHBoxLayout,
-    QLabel,
-    QPushButton,
     QSplitter,
     QVBoxLayout,
     QWidget,
@@ -12,6 +9,9 @@ from ..viewmodels.HistoricalViewModel import (
     HistoricalViewModel,
     HistoricalMode,
 )
+from ..viewmodels.HistoricalFilterBarViewModel import (
+    HistoricalFilterBarViewModel,
+)
 from ..viewmodels.HistoricalEventInspectorViewModel import (
     HistoricalEventInspectorViewModel,
 )
@@ -19,37 +19,14 @@ from ..views.HistoricalEventInspector import (
     HistoricalEventInspector,
 )
 from ..widgets.EventGridWidget import EventGridWidget
+from ..widgets.HistoricalFilterBar import HistoricalFilterBar
 
 
 class _Style:
     BROWSER_PANEL = "background-color: #2d2d2d;"
     INSPECTOR_PANEL = "background-color: #f0f0f0; color: #000000;"
-    HEADER = (
-        "font-weight: bold;"
-        "font-size: 14px;"
-        "color: white;"
-    )
     MODE_LIVE = "color: red; font-weight: bold;"
     MODE_HISTORICAL = "color: #cccccc;"
-    LOAD_BTN = (
-        "QPushButton {"
-        "  background-color: #0078d7;"
-        "  color: white;"
-        "  border: none;"
-        "  border-radius: 4px;"
-        "  padding: 6px 16px;"
-        "  font-weight: bold;"
-        "}"
-        "QPushButton:hover {"
-        "  background-color: #005fa3;"
-        "}"
-        "QPushButton:disabled {"
-        "  background-color: #555555;"
-        "  color: #999999;"
-        "}"
-    )
-    HEADER_BAR = "background-color: #1e1e1e; padding: 4px;"
-    COUNT_LABEL = "color: #aaaaaa; font-size: 11px;"
 
 
 class HistoricalView(QWidget):
@@ -57,12 +34,14 @@ class HistoricalView(QWidget):
 
     Provides a two-panel layout with an event grid browser
     on the left and a detail inspector on the right, connected
-    via a ``QSplitter``.
+    via a ``QSplitter``.  A filter toolbar between the header
+    and splitter lets scientists constrain queries.
     """
 
     def __init__(self, viewModel: HistoricalViewModel):
         super().__init__()
         self.viewModel = viewModel
+        self._pendingFilter = None
         self._initUI()
         self._bindViewModel()
 
@@ -71,37 +50,19 @@ class HistoricalView(QWidget):
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(0)
 
-        root.addWidget(self._buildHeaderBar())
+        root.addWidget(self._buildFilterBar())
         root.addWidget(self._buildSplitter(), 1)
         self._applyGridConfig()
 
-    def _buildHeaderBar(self) -> QWidget:
-        """Creates the top bar with title, mode, count and load button."""
-        header = QWidget()
-        header.setStyleSheet(_Style.HEADER_BAR)
-        layout = QHBoxLayout(header)
-        layout.setContentsMargins(8, 4, 8, 4)
-
-        self._titleLabel = QLabel(
-            self.tr("Historical Event Analysis")
+    def _buildFilterBar(self) -> QWidget:
+        """Creates the filter toolbar below the header."""
+        self._filterBarVM = HistoricalFilterBarViewModel(
+            configService=self.viewModel._config,
+            physicsManager=self.viewModel.physicsManager,
         )
-        self._titleLabel.setStyleSheet(_Style.HEADER)
-        layout.addWidget(self._titleLabel)
-
-        self._modeLabel = QLabel()
-        layout.addWidget(self._modeLabel)
-        layout.addStretch()
-
-        self._countLabel = QLabel()
-        self._countLabel.setStyleSheet(_Style.COUNT_LABEL)
-        layout.addWidget(self._countLabel)
-
-        self._loadBtn = QPushButton(self.tr("Load Events"))
-        self._loadBtn.setStyleSheet(_Style.LOAD_BTN)
-        self._loadBtn.clicked.connect(self._onLoadClicked)
-        layout.addWidget(self._loadBtn)
-
-        return header
+        self._filterBarVM.add_filter_applied_callback(self._onFilterApplied)
+        self._filterBar = HistoricalFilterBar(self._filterBarVM)
+        return self._filterBar
 
     def _buildSplitter(self) -> QSplitter:
         """Creates the horizontal splitter with grid and inspector."""
@@ -117,9 +78,7 @@ class HistoricalView(QWidget):
             displayKeV=self.viewModel.displayEnergyInKev,
             histogramRenderer=self.viewModel.histogramRenderer,
         )
-        self._inspector = HistoricalEventInspector(
-            self._inspectorVM
-        )
+        self._inspector = HistoricalEventInspector(self._inspectorVM)
         self._splitter.addWidget(self._inspector)
 
         # Grid takes only its preferred width; inspector fills the rest
@@ -135,15 +94,9 @@ class HistoricalView(QWidget):
         h = int(cfg.get("gui:historical:grid_item_height", 160))
         self._gridWidget.setGridSize(w, h)
 
-        default_cols = int(cfg.get(
-            "gui:historical:grid_default_columns", 2
-        ))
-        max_cols = int(cfg.get(
-            "gui:historical:grid_max_columns", 3
-        ))
-        self._gridWidget.setColumnConstraints(
-            default_cols, max_cols
-        )
+        default_cols = int(cfg.get("gui:historical:grid_default_columns", 2))
+        max_cols = int(cfg.get("gui:historical:grid_max_columns", 3))
+        self._gridWidget.setColumnConstraints(default_cols, max_cols)
 
     def _bindViewModel(self) -> None:
         """Connects ViewModel callbacks to View update slots."""
@@ -160,9 +113,7 @@ class HistoricalView(QWidget):
             )
         )
         self.viewModel.add_events_changed_callback(
-            lambda: QMetaObject.invokeMethod(
-                self, "_updateEvents", Qt.AutoConnection
-            )
+            lambda: QMetaObject.invokeMethod(self, "_updateEvents", Qt.AutoConnection)
         )
         self.viewModel.add_selected_event_changed_callback(
             lambda: QMetaObject.invokeMethod(
@@ -174,9 +125,7 @@ class HistoricalView(QWidget):
                 self, "_updateLoading", Qt.AutoConnection
             )
         )
-        self._gridWidget.eventSelected.connect(
-            self._onGridItemSelected
-        )
+        self._gridWidget.eventSelected.connect(self._onGridItemSelected)
 
     def _configureInspector(self) -> None:
         """Applies view-level settings to the inspector.
@@ -189,12 +138,8 @@ class HistoricalView(QWidget):
 
     def _configureGridWidget(self) -> None:
         """Wires ViewModel properties into the event grid."""
-        self._gridWidget.setPhysicsManager(
-            self.viewModel.physicsManager
-        )
-        self._gridWidget.setDisplayEnergyInKev(
-            self.viewModel.displayEnergyInKev
-        )
+        self._gridWidget.setPhysicsManager(self.viewModel.physicsManager)
+        self._gridWidget.setDisplayEnergyInKev(self.viewModel.displayEnergyInKev)
         self._gridWidget.setClassificationThreshold(
             self.viewModel.classificationThreshold
         )
@@ -204,30 +149,26 @@ class HistoricalView(QWidget):
     @Slot()
     def _updateMode(self) -> None:
         mode = self.viewModel.mode
+        lbl = self._filterBar.modeLabel
         if mode == HistoricalMode.LIVE:
-            self._modeLabel.setText(
-                self.tr("LIVE MONITORING")
-            )
-            self._modeLabel.setStyleSheet(_Style.MODE_LIVE)
+            lbl.setText(self.tr("LIVE MONITORING"))
+            lbl.setStyleSheet(_Style.MODE_LIVE)
         else:
-            self._modeLabel.setText(
-                self.tr("Historical")
-            )
-            self._modeLabel.setStyleSheet(_Style.MODE_HISTORICAL)
+            lbl.setText(self.tr("Historical"))
+            lbl.setStyleSheet(_Style.MODE_HISTORICAL)
 
     @Slot()
     def _updateEvents(self) -> None:
         events = self.viewModel.events
         self._gridWidget.setEvents(events)
         count = len(events)
+        lbl = self._filterBar.countLabel
         if count == 0:
-            self._countLabel.setText(self.tr("No events"))
+            lbl.setText(self.tr("No events"))
         elif count == 1:
-            self._countLabel.setText(self.tr("1 event"))
+            lbl.setText(self.tr("1 event"))
         else:
-            self._countLabel.setText(
-                self.tr("{count} events").format(count=count)
-            )
+            lbl.setText(self.tr("{count} events").format(count=count))
 
     @Slot()
     def _updateSelection(self) -> None:
@@ -239,13 +180,28 @@ class HistoricalView(QWidget):
     @Slot()
     def _updateLoading(self) -> None:
         loading = self.viewModel.isLoading
-        self._loadBtn.setEnabled(not loading)
+        self._filterBar._applyBtn.setEnabled(not loading)
         if loading:
-            self._loadBtn.setText(self.tr("Loading..."))
+            self._filterBar._applyBtn.setText(self.tr("Loading..."))
         else:
-            self._loadBtn.setText(self.tr("Load Events"))
+            self._filterBar._applyBtn.setText(self.tr("Apply"))
 
-    def _onLoadClicked(self) -> None:
+    def _onFilterApplied(self, query_filter) -> None:
+        """Receives filter from the filter bar VM and triggers load.
+
+        Stores the filter and uses ``QMetaObject.invokeMethod``
+        with ``Qt.AutoConnection`` to marshal to the main thread
+        when the callback fires from a background thread.
+        """
+        self._pendingFilter = query_filter
+        QMetaObject.invokeMethod(self, "_applyPendingFilter", Qt.AutoConnection)
+
+    @Slot()
+    def _applyPendingFilter(self) -> None:
+        """Applies the stored filter and loads events."""
+        if self._pendingFilter is not None:
+            self.viewModel.setQueryFilter(self._pendingFilter)
+            self._pendingFilter = None
         self.viewModel.loadEvents()
 
     def _onGridItemSelected(self, index: int) -> None:

--- a/src/le_beta_vis/frontend/widgets/HistoricalAdvancedFilterDialog.py
+++ b/src/le_beta_vis/frontend/widgets/HistoricalAdvancedFilterDialog.py
@@ -1,0 +1,365 @@
+"""Advanced filter dialog exposing all ClusterQueryFilter fields.
+
+Opened from the HistoricalFilterBar via the "Advanced..." button
+or by selecting "Custom..." in the time combo.
+"""
+
+from PySide6.QtCore import QDate, QDateTime, QTime, Qt
+from PySide6.QtWidgets import (
+    QDateTimeEdit,
+    QComboBox,
+    QDialog,
+    QDoubleSpinBox,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..viewmodels.HistoricalFilterBarViewModel import (
+    HistoricalFilterBarViewModel,
+)
+
+
+class _Style:
+    DIALOG = "background-color: #2d2d2d; color: #eeeeee;"
+    LABEL = "color: #cccccc; font-size: 12px;"
+    SPINBOX = (
+        "QDoubleSpinBox, QSpinBox {"
+        "  background-color: #3d3d3d;"
+        "  color: #eeeeee;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 3px;"
+        "  padding: 3px;"
+        "}"
+        "QDoubleSpinBox:focus, QSpinBox:focus {"
+        "  border: 1px solid #0078d7;"
+        "}"
+    )
+    COMBO = (
+        "QComboBox {"
+        "  background-color: #3d3d3d;"
+        "  color: #eeeeee;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 3px;"
+        "  padding: 3px;"
+        "}"
+        "QComboBox:focus {"
+        "  border: 1px solid #0078d7;"
+        "}"
+        "QComboBox::drop-down {"
+        "  border: none;"
+        "}"
+        "QComboBox QAbstractItemView {"
+        "  background-color: #3d3d3d;"
+        "  color: #eeeeee;"
+        "  selection-background-color: #0078d7;"
+        "}"
+    )
+    APPLY_BTN = (
+        "QPushButton {"
+        "  background-color: #0078d7;"
+        "  color: white;"
+        "  border: none;"
+        "  border-radius: 4px;"
+        "  padding: 6px 16px;"
+        "  font-weight: bold;"
+        "}"
+        "QPushButton:hover {"
+        "  background-color: #005fa3;"
+        "}"
+    )
+    RESET_BTN = (
+        "QPushButton {"
+        "  background-color: #3d3d3d;"
+        "  color: #cccccc;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 4px;"
+        "  padding: 6px 16px;"
+        "}"
+        "QPushButton:hover {"
+        "  background-color: #505050;"
+        "}"
+    )
+    DATETIME_EDIT = (
+        "QDateTimeEdit {"
+        "  background-color: #3d3d3d;"
+        "  color: #eeeeee;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 3px;"
+        "  padding: 3px;"
+        "}"
+        "QDateTimeEdit:focus {"
+        "  border: 1px solid #0078d7;"
+        "}"
+    )
+
+
+_TIME_PRESETS = [
+    ("24h", "Last 24 hours"),
+    ("3d", "Last 3 days"),
+    ("7d", "Last 7 days"),
+    ("30d", "Last 30 days"),
+]
+
+
+class HistoricalAdvancedFilterDialog(QDialog):
+    """Modal dialog exposing every ``ClusterQueryFilter`` field.
+
+    Reads/writes filter state through the shared
+    ``HistoricalFilterBarViewModel``.
+    """
+
+    def __init__(
+        self,
+        viewModel: HistoricalFilterBarViewModel,
+        parent: QWidget = None,
+    ):
+        super().__init__(parent)
+        self._vm = viewModel
+        self.setWindowTitle(self.tr("Advanced Filters"))
+        self.setMinimumWidth(360)
+        self.setStyleSheet(_Style.DIALOG)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        self._initUI()
+        self._syncFromViewModel()
+
+    # --- UI ---
+
+    def _initUI(self) -> None:
+        root = QVBoxLayout(self)
+        root.setSpacing(12)
+
+        form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignRight)
+        form.setSpacing(8)
+
+        # Time
+        self._timeCombo = QComboBox()
+        self._timeCombo.setStyleSheet(_Style.COMBO)
+        for key, label in _TIME_PRESETS:
+            self._timeCombo.addItem(self.tr(label), key)
+        form.addRow(self._styledLabel(self.tr("Time Range:")), self._timeCombo)
+
+        # Start / End date-time
+        self._startEdit = self._makeDateTimeEdit()
+        form.addRow(
+            self._styledLabel(self.tr("Start:")),
+            self._startEdit,
+        )
+        self._endEdit = self._makeDateTimeEdit()
+        form.addRow(
+            self._styledLabel(self.tr("End:")),
+            self._endEdit,
+        )
+
+        self._timeCombo.currentIndexChanged.connect(self._onTimePresetChanged)
+
+        # Cluster ID
+        self._clusterIdSpin = self._makeIntSpin()
+        form.addRow(self._styledLabel(self.tr("Cluster ID:")), self._clusterIdSpin)
+
+        # FITS ID
+        self._fitsIdSpin = self._makeIntSpin()
+        form.addRow(self._styledLabel(self.tr("FITS ID:")), self._fitsIdSpin)
+
+        # HDU ID
+        self._hduIdSpin = self._makeIntSpin()
+        form.addRow(self._styledLabel(self.tr("HDU ID:")), self._hduIdSpin)
+
+        # Min sigma-x
+        self._sigmaXSpin = self._makeDoubleSpin()
+        form.addRow(
+            self._styledLabel(self.tr("Min \u03c3\u2093:")),
+            self._sigmaXSpin,
+        )
+
+        # Min sigma-y
+        self._sigmaYSpin = self._makeDoubleSpin()
+        form.addRow(
+            self._styledLabel(self.tr("Min \u03c3\u1d67:")),
+            self._sigmaYSpin,
+        )
+
+        # Min Energy
+        unit = self._vm.energy_unit_label
+        self._energySpin = self._makeDoubleSpin()
+        self._energyLabel = self._styledLabel(
+            self.tr("Min Energy ({unit}):").format(unit=unit)
+        )
+        form.addRow(self._energyLabel, self._energySpin)
+
+        # Min Pixels
+        self._pixelsSpin = self._makeIntSpin()
+        form.addRow(self._styledLabel(self.tr("Min Pixels:")), self._pixelsSpin)
+
+        # Classification
+        self._classCombo = QComboBox()
+        self._classCombo.setStyleSheet(_Style.COMBO)
+        for label, value in self._vm.classification_options:
+            self._classCombo.addItem(self.tr(label), value)
+        form.addRow(
+            self._styledLabel(self.tr("Classification:")),
+            self._classCombo,
+        )
+
+        root.addLayout(form)
+        root.addStretch()
+
+        # Buttons
+        btnRow = QHBoxLayout()
+        btnRow.addStretch()
+
+        resetBtn = QPushButton(self.tr("Reset"))
+        resetBtn.setStyleSheet(_Style.RESET_BTN)
+        resetBtn.clicked.connect(self._onResetClicked)
+        btnRow.addWidget(resetBtn)
+
+        applyBtn = QPushButton(self.tr("Apply"))
+        applyBtn.setStyleSheet(_Style.APPLY_BTN)
+        applyBtn.clicked.connect(self._onApplyClicked)
+        btnRow.addWidget(applyBtn)
+
+        root.addLayout(btnRow)
+
+    # --- Helpers ---
+
+    def _styledLabel(self, text: str) -> QLabel:
+        lbl = QLabel(text)
+        lbl.setStyleSheet(_Style.LABEL)
+        return lbl
+
+    def _makeIntSpin(self) -> QSpinBox:
+        spin = QSpinBox()
+        spin.setStyleSheet(_Style.SPINBOX)
+        spin.setRange(0, 999999)
+        spin.setSingleStep(1)
+        spin.setSpecialValueText(self.tr("Any"))
+        spin.setButtonSymbols(QSpinBox.ButtonSymbols.UpDownArrows)
+        spin.setValue(0)
+        return spin
+
+    def _makeDoubleSpin(self) -> QDoubleSpinBox:
+        spin = QDoubleSpinBox()
+        spin.setStyleSheet(_Style.SPINBOX)
+        spin.setRange(0.0, 999999.0)
+        spin.setDecimals(4)
+        spin.setSingleStep(0.01)
+        spin.setSpecialValueText(self.tr("Any"))
+        spin.setButtonSymbols(QDoubleSpinBox.ButtonSymbols.UpDownArrows)
+        spin.setValue(0.0)
+        return spin
+
+    def _makeDateTimeEdit(self) -> QDateTimeEdit:
+        edit = QDateTimeEdit()
+        edit.setStyleSheet(_Style.DATETIME_EDIT)
+        edit.setDisplayFormat("yyyy-MM-dd HH:mm")
+        edit.setCalendarPopup(True)
+        return edit
+
+    # --- Sync ---
+
+    def _syncFromViewModel(self) -> None:
+        """Pulls VM state into all dialog widgets."""
+        self._selectComboByData(self._timeCombo, self._vm.time_preset)
+        self._syncDateEdits()
+
+        self._setIntSpin(self._clusterIdSpin, self._vm.cluster_id)
+        self._setIntSpin(self._fitsIdSpin, self._vm.fits_id)
+        self._setIntSpin(self._hduIdSpin, self._vm.hdu_id)
+
+        self._setDoubleSpin(self._sigmaXSpin, self._vm.min_sigma_x)
+        self._setDoubleSpin(self._sigmaYSpin, self._vm.min_sigma_y)
+        self._setDoubleSpin(self._energySpin, self._vm.min_total_energy)
+
+        self._setIntSpin(self._pixelsSpin, self._vm.min_total_pixels)
+
+        self._selectComboByData(self._classCombo, self._vm.classification)
+
+    def _syncDateEdits(self) -> None:
+        """Fills start/end date edits from VM or preset."""
+        start = self._vm.start_datetime
+        end = self._vm.end_datetime
+        if start is None or end is None:
+            key = self._timeCombo.currentData()
+            start, end = self._vm.compute_dates_for_preset(key)
+        self._startEdit.setDateTime(self._toQDateTime(start))
+        self._endEdit.setDateTime(self._toQDateTime(end))
+
+    def _pushToViewModel(self) -> None:
+        """Writes all dialog widget values into the VM."""
+        key = self._timeCombo.currentData()
+        self._vm.time_preset = key
+
+        # TODO: Dates are stored in the VM but not yet sent to the
+        # EPS — wire into ClusterQueryFilter once supported.
+        self._vm.start_datetime = self._startEdit.dateTime().toPython()
+        self._vm.end_datetime = self._endEdit.dateTime().toPython()
+
+        self._vm.cluster_id = self._intOrNone(self._clusterIdSpin)
+        self._vm.fits_id = self._intOrNone(self._fitsIdSpin)
+        self._vm.hdu_id = self._intOrNone(self._hduIdSpin)
+
+        self._vm.min_sigma_x = self._floatOrNone(self._sigmaXSpin)
+        self._vm.min_sigma_y = self._floatOrNone(self._sigmaYSpin)
+        self._vm.min_total_energy = self._floatOrNone(self._energySpin)
+        self._vm.min_total_pixels = self._intOrNone(self._pixelsSpin)
+
+        self._vm.classification = self._classCombo.currentData()
+
+    # --- Slots ---
+
+    def _onTimePresetChanged(self, _index: int) -> None:
+        """Updates date edits when the user picks a preset."""
+        key = self._timeCombo.currentData()
+        start, end = self._vm.compute_dates_for_preset(key)
+        self._startEdit.setDateTime(self._toQDateTime(start))
+        self._endEdit.setDateTime(self._toQDateTime(end))
+
+    def _onResetClicked(self) -> None:
+        self._vm.reset()
+        self._syncFromViewModel()
+
+    def _onApplyClicked(self) -> None:
+        self._pushToViewModel()
+        self._vm.apply()
+        self.accept()
+
+    # --- Utilities ---
+
+    @staticmethod
+    def _selectComboByData(combo: QComboBox, data) -> None:
+        for i in range(combo.count()):
+            if combo.itemData(i) == data:
+                combo.setCurrentIndex(i)
+                return
+        combo.setCurrentIndex(0)
+
+    @staticmethod
+    def _setIntSpin(spin: QSpinBox, value) -> None:
+        spin.setValue(value if value is not None else 0)
+
+    @staticmethod
+    def _setDoubleSpin(spin: QDoubleSpinBox, value) -> None:
+        spin.setValue(value if value is not None else 0.0)
+
+    @staticmethod
+    def _intOrNone(spin: QSpinBox):
+        v = spin.value()
+        return v if v > 0 else None
+
+    @staticmethod
+    def _floatOrNone(spin: QDoubleSpinBox):
+        v = spin.value()
+        return v if v > 0.0 else None
+
+    @staticmethod
+    def _toQDateTime(dt) -> QDateTime:
+        """Converts a Python ``datetime`` to a ``QDateTime``."""
+        return QDateTime(
+            QDate(dt.year, dt.month, dt.day),
+            QTime(dt.hour, dt.minute, dt.second),
+        )

--- a/src/le_beta_vis/frontend/widgets/HistoricalFilterBar.py
+++ b/src/le_beta_vis/frontend/widgets/HistoricalFilterBar.py
@@ -1,0 +1,291 @@
+"""Compact filter toolbar for the Historical Analysis tab.
+
+Provides quick access to the most common filter fields (time range,
+minimum energy, minimum pixel count) and an Advanced button that
+opens the full filter dialog.
+"""
+
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDoubleSpinBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSpinBox,
+    QStyle,
+    QWidget,
+)
+
+from ..viewmodels.HistoricalFilterBarViewModel import (
+    HistoricalFilterBarViewModel,
+)
+from .HistoricalAdvancedFilterDialog import (
+    HistoricalAdvancedFilterDialog,
+)
+
+
+class _Style:
+    BAR = "background-color: #1e1e1e; padding: 2px 4px;"
+    LABEL = "color: #cccccc; font-size: 11px;"
+    COUNT_LABEL = "color: #aaaaaa; font-size: 11px;"
+    COMBO = (
+        "QComboBox {"
+        "  background-color: #3d3d3d;"
+        "  color: #eeeeee;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 3px;"
+        "  padding: 2px 4px;"
+        "  font-size: 11px;"
+        "  min-width: 110px;"
+        "}"
+        "QComboBox:focus {"
+        "  border: 1px solid #0078d7;"
+        "}"
+        "QComboBox::drop-down {"
+        "  border: none;"
+        "}"
+        "QComboBox QAbstractItemView {"
+        "  background-color: #3d3d3d;"
+        "  color: #eeeeee;"
+        "  selection-background-color: #0078d7;"
+        "}"
+    )
+    SPINBOX = (
+        "QDoubleSpinBox, QSpinBox {"
+        "  background-color: #3d3d3d;"
+        "  color: #eeeeee;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 3px;"
+        "  padding: 2px;"
+        "  font-size: 11px;"
+        "  min-width: 80px;"
+        "}"
+        "QDoubleSpinBox:focus, QSpinBox:focus {"
+        "  border: 1px solid #0078d7;"
+        "}"
+    )
+    APPLY_BTN = (
+        "QPushButton {"
+        "  background-color: #0078d7;"
+        "  color: white;"
+        "  border: none;"
+        "  border-radius: 4px;"
+        "  padding: 4px 14px;"
+        "  font-weight: bold;"
+        "  font-size: 11px;"
+        "}"
+        "QPushButton:hover {"
+        "  background-color: #005fa3;"
+        "}"
+    )
+    ADVANCED_BTN = (
+        "QPushButton {"
+        "  background-color: #3d3d3d;"
+        "  color: #cccccc;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 4px;"
+        "  padding: 4px 10px;"
+        "  font-size: 11px;"
+        "}"
+        "QPushButton:hover {"
+        "  background-color: #505050;"
+        "}"
+    )
+    ICON_BTN = (
+        "QPushButton {"
+        "  background-color: #3d3d3d;"
+        "  color: #cccccc;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 4px;"
+        "  padding: 4px;"
+        "}"
+        "QPushButton:hover {"
+        "  background-color: #505050;"
+        "}"
+    )
+
+
+# Time-preset display labels, in combo order.
+_TIME_PRESETS = [
+    ("24h", "Last 24 hours"),
+    ("3d", "Last 3 days"),
+    ("7d", "Last 7 days"),
+    ("30d", "Last 30 days"),
+    ("custom", "Custom"),
+]
+
+
+class HistoricalFilterBar(QFrame):
+    """Horizontal filter toolbar for the Historical Analysis tab.
+
+    Presents the most-used filter fields inline and delegates
+    to ``HistoricalAdvancedFilterDialog`` for the full set.
+    """
+
+    def __init__(
+        self,
+        viewModel: HistoricalFilterBarViewModel,
+        parent: QWidget = None,
+    ):
+        super().__init__(parent)
+        self._vm = viewModel
+        self._initUI()
+        self._bindViewModel()
+
+    # --- UI Construction ---
+
+    def _initUI(self) -> None:
+        self.setStyleSheet(_Style.BAR)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 3, 8, 3)
+        layout.setSpacing(6)
+
+        # Mode label (updated by HistoricalView)
+        self._modeLabel = QLabel()
+        layout.addWidget(self._modeLabel)
+
+        # Time combo
+        lbl = QLabel(self.tr("Time:"))
+        lbl.setStyleSheet(_Style.LABEL)
+        layout.addWidget(lbl)
+
+        self._timeCombo = QComboBox()
+        self._timeCombo.setStyleSheet(_Style.COMBO)
+        for key, label in _TIME_PRESETS:
+            self._timeCombo.addItem(self.tr(label), key)
+        self._selectTimePreset(self._vm.time_preset)
+        self._timeCombo.currentIndexChanged.connect(self._onTimeComboChanged)
+        layout.addWidget(self._timeCombo)
+
+        # Energy spinbox
+        unit = self._vm.energy_unit_label
+        self._energyLabel = QLabel(self.tr("Min Energy ({unit}):").format(unit=unit))
+        self._energyLabel.setStyleSheet(_Style.LABEL)
+        layout.addWidget(self._energyLabel)
+
+        self._energySpin = QDoubleSpinBox()
+        self._energySpin.setStyleSheet(_Style.SPINBOX)
+        self._energySpin.setRange(0.0, 999999.0)
+        self._energySpin.setDecimals(2)
+        self._energySpin.setSingleStep(0.01)
+        self._energySpin.setSpecialValueText(self.tr("Any"))
+        self._energySpin.setButtonSymbols(QDoubleSpinBox.ButtonSymbols.UpDownArrows)
+        self._energySpin.setValue(0.0)
+        layout.addWidget(self._energySpin)
+
+        # Pixels spinbox
+        lbl2 = QLabel(self.tr("Min Pixels:"))
+        lbl2.setStyleSheet(_Style.LABEL)
+        layout.addWidget(lbl2)
+
+        self._pixelsSpin = QSpinBox()
+        self._pixelsSpin.setStyleSheet(_Style.SPINBOX)
+        self._pixelsSpin.setRange(0, 999999)
+        self._pixelsSpin.setSingleStep(1)
+        self._pixelsSpin.setSpecialValueText(self.tr("Any"))
+        self._pixelsSpin.setButtonSymbols(QSpinBox.ButtonSymbols.UpDownArrows)
+        self._pixelsSpin.setValue(0)
+        layout.addWidget(self._pixelsSpin)
+
+        layout.addStretch()
+
+        # Reset button
+        self._resetBtn = QPushButton()
+        self._resetBtn.setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_BrowserReload))
+        self._resetBtn.setToolTip(self.tr("Reset Filters"))
+        self._resetBtn.setStyleSheet(_Style.ICON_BTN)
+        self._resetBtn.clicked.connect(self._onResetClicked)
+        layout.addWidget(self._resetBtn)
+
+        # Advanced button
+        self._advancedBtn = QPushButton(self.tr("Advanced\u2026"))
+        self._advancedBtn.setStyleSheet(_Style.ADVANCED_BTN)
+        self._advancedBtn.clicked.connect(self._onAdvancedClicked)
+        layout.addWidget(self._advancedBtn)
+
+        # Apply button
+        self._applyBtn = QPushButton(self.tr("Apply"))
+        self._applyBtn.setStyleSheet(_Style.APPLY_BTN)
+        self._applyBtn.clicked.connect(self._onApplyClicked)
+        layout.addWidget(self._applyBtn)
+
+        # Count label (updated by HistoricalView)
+        self._countLabel = QLabel()
+        self._countLabel.setStyleSheet(_Style.COUNT_LABEL)
+        layout.addWidget(self._countLabel)
+
+    @property
+    def modeLabel(self) -> QLabel:
+        """The mode label widget (written by HistoricalView)."""
+        return self._modeLabel
+
+    @property
+    def countLabel(self) -> QLabel:
+        """The event-count label widget (written by HistoricalView)."""
+        return self._countLabel
+
+    # --- ViewModel binding ---
+
+    def _bindViewModel(self) -> None:
+        self._vm.add_filter_reset_callback(self._syncFromViewModel)
+
+    def _syncFromViewModel(self) -> None:
+        """Pulls current VM state into all widgets."""
+        self._selectTimePreset(self._vm.time_preset)
+
+        energy = self._vm.min_total_energy
+        self._energySpin.setValue(energy if energy is not None else 0.0)
+
+        pixels = self._vm.min_total_pixels
+        self._pixelsSpin.setValue(pixels if pixels is not None else 0)
+
+        unit = self._vm.energy_unit_label
+        self._energyLabel.setText(self.tr("Min Energy ({unit}):").format(unit=unit))
+
+    # --- Slots ---
+
+    def _onTimeComboChanged(self, index: int) -> None:
+        key = self._timeCombo.itemData(index)
+        if key == "custom":
+            self._openAdvancedDialog()
+            return
+        self._vm.time_preset = key
+
+    def _onApplyClicked(self) -> None:
+        self._pushToViewModel()
+        self._vm.apply()
+
+    def _onResetClicked(self) -> None:
+        self._vm.reset()
+        self._vm.apply()
+
+    def _onAdvancedClicked(self) -> None:
+        self._openAdvancedDialog()
+
+    # --- Helpers ---
+
+    def _pushToViewModel(self) -> None:
+        """Writes inline widget values into the VM fields."""
+        energy = self._energySpin.value()
+        self._vm.min_total_energy = energy if energy > 0.0 else None
+
+        pixels = self._pixelsSpin.value()
+        self._vm.min_total_pixels = pixels if pixels > 0 else None
+
+        self._vm.time_preset = self._timeCombo.currentData()
+
+    def _selectTimePreset(self, preset: str) -> None:
+        """Sets the combo to match a preset key."""
+        for i in range(self._timeCombo.count()):
+            if self._timeCombo.itemData(i) == preset:
+                self._timeCombo.setCurrentIndex(i)
+                return
+
+    def _openAdvancedDialog(self) -> None:
+        """Opens the advanced filter dialog."""
+        self._pushToViewModel()
+        dlg = HistoricalAdvancedFilterDialog(self._vm, parent=self)
+        dlg.exec()
+        # After the dialog closes, sync widgets from VM state
+        self._syncFromViewModel()

--- a/src/le_beta_vis/frontend/widgets/__init__.py
+++ b/src/le_beta_vis/frontend/widgets/__init__.py
@@ -10,3 +10,7 @@ from .ClusteringProgressOverlay import ClusteringProgressOverlay
 from .ClusteredEventWidget import ClusteredEventWidget
 from .EnergyClusterWidget import EnergyClusterWidget
 from .InteractiveHistogramWidget import InteractiveHistogramWidget
+from .HistoricalFilterBar import HistoricalFilterBar
+from .HistoricalAdvancedFilterDialog import (
+    HistoricalAdvancedFilterDialog,
+)

--- a/tests/test_HistoricalFilterBarViewModel.py
+++ b/tests/test_HistoricalFilterBarViewModel.py
@@ -1,0 +1,374 @@
+# Citation for Unit Tests: HistoricalFilterBarViewModel
+# Date: 02/03/2026
+# Adapted from Claude Code:
+# Write pure Python unit tests for HistoricalFilterBarViewModel covering
+# initialization, setters, build_filter() keV/ADU conversion, apply/reset
+# callbacks, and classification_options.
+
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+from le_beta_vis.common.ConfigurationService import (
+    MockConfigurationService,
+)
+from le_beta_vis.common.EPSDataClasses import ClusterQueryFilter
+from le_beta_vis.common.ParticleType import ParticleType
+from le_beta_vis.frontend.viewmodels.HistoricalFilterBarViewModel import (
+    HistoricalFilterBarViewModel,
+    _PRESET_TO_HOURS,
+)
+
+
+def _make_physics_mock(factor: float = 1.02857e-5):
+    mock = MagicMock()
+    mock.kev_conversion_factor = factor
+    return mock
+
+
+@pytest.fixture
+def config():
+    return MockConfigurationService()
+
+
+@pytest.fixture
+def physics():
+    return _make_physics_mock()
+
+
+@pytest.fixture
+def vm(config, physics):
+    return HistoricalFilterBarViewModel(config, physics)
+
+
+# --- Initialization ---
+
+
+class TestInitialization:
+    def test_default_time_preset_24h(self, config, physics):
+        """Default query hours 24 maps to '24h' preset."""
+        config.set("gui:historical:default_query_hours", 24)
+        vm = HistoricalFilterBarViewModel(config, physics)
+        assert vm.time_preset == "24h"
+
+    def test_default_time_preset_3d(self, config, physics):
+        """Default query hours 72 maps to '3d' preset."""
+        config.set("gui:historical:default_query_hours", 72)
+        vm = HistoricalFilterBarViewModel(config, physics)
+        assert vm.time_preset == "3d"
+
+    def test_default_time_preset_7d(self, config, physics):
+        """Default query hours 168 maps to '7d' preset."""
+        config.set("gui:historical:default_query_hours", 168)
+        vm = HistoricalFilterBarViewModel(config, physics)
+        assert vm.time_preset == "7d"
+
+    def test_default_time_preset_30d(self, config, physics):
+        """Default query hours 720 maps to '30d' preset."""
+        config.set("gui:historical:default_query_hours", 720)
+        vm = HistoricalFilterBarViewModel(config, physics)
+        assert vm.time_preset == "30d"
+
+    def test_default_time_preset_unknown_hours(self, config, physics):
+        """Unknown default_query_hours falls back to '24h'."""
+        config.set("gui:historical:default_query_hours", 999)
+        vm = HistoricalFilterBarViewModel(config, physics)
+        assert vm.time_preset == "24h"
+
+    def test_energy_unit_label_kev(self, vm):
+        """Energy unit label defaults to 'keV'."""
+        assert vm.energy_unit_label == "keV"
+
+    def test_energy_unit_label_adu(self, config, physics):
+        """Energy unit label is 'ADU' when keV display is off."""
+        config.set("gui:raw_analysis:display_energy_in_kev", False)
+        vm = HistoricalFilterBarViewModel(config, physics)
+        assert vm.energy_unit_label == "ADU"
+
+    def test_all_fields_none(self, vm):
+        """All filter fields start as None."""
+        assert vm.cluster_id is None
+        assert vm.fits_id is None
+        assert vm.hdu_id is None
+        assert vm.min_sigma_x is None
+        assert vm.min_sigma_y is None
+        assert vm.min_total_energy is None
+        assert vm.min_total_pixels is None
+        assert vm.classification is None
+
+
+# --- Setters ---
+
+
+class TestSetters:
+    def test_cluster_id(self, vm):
+        vm.cluster_id = 42
+        assert vm.cluster_id == 42
+
+    def test_fits_id(self, vm):
+        vm.fits_id = 7
+        assert vm.fits_id == 7
+
+    def test_hdu_id(self, vm):
+        vm.hdu_id = 3
+        assert vm.hdu_id == 3
+
+    def test_min_sigma_x(self, vm):
+        vm.min_sigma_x = 1.5
+        assert vm.min_sigma_x == 1.5
+
+    def test_min_sigma_y(self, vm):
+        vm.min_sigma_y = 2.0
+        assert vm.min_sigma_y == 2.0
+
+    def test_min_total_energy(self, vm):
+        vm.min_total_energy = 0.05
+        assert vm.min_total_energy == 0.05
+
+    def test_min_total_pixels(self, vm):
+        vm.min_total_pixels = 10
+        assert vm.min_total_pixels == 10
+
+    def test_classification(self, vm):
+        vm.classification = "tritium"
+        assert vm.classification == "tritium"
+
+    def test_time_preset(self, vm):
+        vm.time_preset = "7d"
+        assert vm.time_preset == "7d"
+
+
+# --- build_filter() ---
+
+
+class TestBuildFilter:
+    def test_empty_filter(self, vm):
+        """No fields set produces a default filter."""
+        f = vm.build_filter()
+        assert f == ClusterQueryFilter()
+
+    def test_energy_kev_to_adu_conversion(self, config, physics):
+        """Energy in keV is converted to ADU via physics factor."""
+        config.set("gui:raw_analysis:display_energy_in_kev", True)
+        vm = HistoricalFilterBarViewModel(config, physics)
+        vm.min_total_energy = 0.5  # 0.5 keV
+        f = vm.build_filter()
+        expected_adu = 0.5 / physics.kev_conversion_factor
+        assert f.min_total_energy == pytest.approx(expected_adu)
+
+    def test_energy_adu_passthrough(self, config, physics):
+        """When display is ADU, energy passes through unchanged."""
+        config.set("gui:raw_analysis:display_energy_in_kev", False)
+        vm = HistoricalFilterBarViewModel(config, physics)
+        vm.min_total_energy = 50000.0
+        f = vm.build_filter()
+        assert f.min_total_energy == 50000.0
+
+    def test_all_fields_populated(self, vm):
+        """All fields are forwarded to ClusterQueryFilter."""
+        vm.cluster_id = 1
+        vm.fits_id = 2
+        vm.hdu_id = 3
+        vm.min_sigma_x = 0.5
+        vm.min_sigma_y = 0.6
+        vm.min_total_energy = 0.1
+        vm.min_total_pixels = 5
+        vm.classification = "tritium"
+        f = vm.build_filter()
+        assert f.cluster_id == 1
+        assert f.fits_id == 2
+        assert f.hdu_id == 3
+        assert f.min_sigma_x == 0.5
+        assert f.min_sigma_y == 0.6
+        assert f.min_total_pixels == 5
+        assert f.classification == "tritium"
+
+    def test_none_fields_stay_none(self, vm):
+        """Only populated fields appear in the filter."""
+        vm.cluster_id = 5
+        f = vm.build_filter()
+        assert f.cluster_id == 5
+        assert f.fits_id is None
+        assert f.min_total_energy is None
+
+    def test_zero_kev_conversion_factor(self, config):
+        """Zero conversion factor produces None energy."""
+        config.set("gui:raw_analysis:display_energy_in_kev", True)
+        physics = _make_physics_mock(factor=0.0)
+        vm = HistoricalFilterBarViewModel(config, physics)
+        vm.min_total_energy = 0.5
+        f = vm.build_filter()
+        assert f.min_total_energy is None
+
+
+# --- apply() ---
+
+
+class TestApply:
+    def test_fires_callback_with_filter(self, vm):
+        """apply() fires callback with the built filter."""
+        received = []
+        vm.add_filter_applied_callback(received.append)
+        vm.min_total_pixels = 10
+        vm.apply()
+        assert len(received) == 1
+        assert received[0].min_total_pixels == 10
+
+    def test_multiple_callbacks(self, vm):
+        """apply() fires all registered callbacks."""
+        cb1 = MagicMock()
+        cb2 = MagicMock()
+        vm.add_filter_applied_callback(cb1)
+        vm.add_filter_applied_callback(cb2)
+        vm.apply()
+        cb1.assert_called_once()
+        cb2.assert_called_once()
+
+
+# --- reset() ---
+
+
+class TestReset:
+    def test_clears_all_fields(self, vm):
+        """reset() sets all fields back to None."""
+        vm.cluster_id = 1
+        vm.fits_id = 2
+        vm.hdu_id = 3
+        vm.min_sigma_x = 1.0
+        vm.min_sigma_y = 2.0
+        vm.min_total_energy = 3.0
+        vm.min_total_pixels = 4
+        vm.classification = "tritium"
+        vm.time_preset = "30d"
+        vm.start_datetime = datetime(2025, 1, 1)
+        vm.end_datetime = datetime(2025, 6, 1)
+
+        vm.reset()
+
+        assert vm.cluster_id is None
+        assert vm.fits_id is None
+        assert vm.hdu_id is None
+        assert vm.min_sigma_x is None
+        assert vm.min_sigma_y is None
+        assert vm.min_total_energy is None
+        assert vm.min_total_pixels is None
+        assert vm.classification is None
+        assert vm.start_datetime is None
+        assert vm.end_datetime is None
+
+    def test_restores_default_time_preset(self, config, physics):
+        """reset() restores the default time preset from config."""
+        config.set("gui:historical:default_query_hours", 168)
+        vm = HistoricalFilterBarViewModel(config, physics)
+        vm.time_preset = "30d"
+        vm.reset()
+        assert vm.time_preset == "7d"
+
+    def test_fires_reset_callback(self, vm):
+        """reset() fires registered callbacks."""
+        cb = MagicMock()
+        vm.add_filter_reset_callback(cb)
+        vm.reset()
+        cb.assert_called_once()
+
+
+# --- classification_options ---
+
+
+class TestClassificationOptions:
+    def test_starts_with_all(self, vm):
+        """First option is ('All', None)."""
+        options = vm.classification_options
+        assert options[0] == ("All", None)
+
+    def test_contains_particle_types(self, vm):
+        """Options include all ParticleType members."""
+        options = vm.classification_options
+        values = [v for _, v in options]
+        for pt in ParticleType:
+            assert pt.name.lower() in values
+
+    def test_tritium_label_includes_symbol(self, vm):
+        """Tritium option uses display name and symbol."""
+        options = vm.classification_options
+        tritium_opts = [
+            (label, val) for label, val in options
+            if val == "tritium"
+        ]
+        assert len(tritium_opts) == 1
+        label = tritium_opts[0][0]
+        assert "\u00b3H" in label
+        assert "Tritium" in label
+
+    def test_unclassified_label(self, vm):
+        """Unclassified option shows display name only."""
+        options = vm.classification_options
+        unclass = [
+            (label, val) for label, val in options
+            if val == "unclassified"
+        ]
+        assert len(unclass) == 1
+        assert unclass[0][0] == "Unknown"
+
+    def test_option_count(self, vm):
+        """Total options = 1 (All) + len(ParticleType)."""
+        options = vm.classification_options
+        assert len(options) == 1 + len(ParticleType)
+
+
+# --- datetime properties ---
+
+
+class TestDateTimeProperties:
+    def test_start_datetime_default_none(self, vm):
+        """start_datetime defaults to None."""
+        assert vm.start_datetime is None
+
+    def test_end_datetime_default_none(self, vm):
+        """end_datetime defaults to None."""
+        assert vm.end_datetime is None
+
+    def test_start_datetime_setter(self, vm):
+        dt = datetime(2025, 6, 15, 12, 0)
+        vm.start_datetime = dt
+        assert vm.start_datetime == dt
+
+    def test_end_datetime_setter(self, vm):
+        dt = datetime(2025, 6, 15, 18, 30)
+        vm.end_datetime = dt
+        assert vm.end_datetime == dt
+
+    def test_clear_to_none(self, vm):
+        """Setting back to None clears the value."""
+        vm.start_datetime = datetime(2025, 1, 1)
+        vm.start_datetime = None
+        assert vm.start_datetime is None
+
+
+# --- compute_dates_for_preset() ---
+
+
+class TestComputeDatesForPreset:
+    @pytest.mark.parametrize("preset,hours", list(_PRESET_TO_HOURS.items()))
+    def test_known_presets(self, preset, hours):
+        """Each known preset produces the correct interval."""
+        start, end = HistoricalFilterBarViewModel.compute_dates_for_preset(
+            preset
+        )
+        delta = end - start
+        assert delta == timedelta(hours=hours)
+
+    def test_unknown_preset_falls_back_to_24h(self):
+        """Unknown key defaults to 24 hours."""
+        start, end = HistoricalFilterBarViewModel.compute_dates_for_preset(
+            "unknown"
+        )
+        delta = end - start
+        assert delta == timedelta(hours=24)
+
+    def test_end_close_to_now(self):
+        """The end datetime should be very close to now."""
+        _, end = HistoricalFilterBarViewModel.compute_dates_for_preset(
+            "24h"
+        )
+        assert abs((datetime.now() - end).total_seconds()) < 2


### PR DESCRIPTION
- Introduce `HistoricalFilterBarViewModel` to manage filter state and build `ClusterQueryFilter` instances without Qt dependencies.
- Implement `HistoricalFilterBar`, a compact horizontal toolbar for quick access to common filters like time preset, min energy, and min pixels.
- Implement `HistoricalAdvancedFilterDialog`, a modal dialog exposing the full suite of filters including classification, cluster IDs, and date ranges.

## User Interface

https://github.com/user-attachments/assets/a83ac5e7-eb6f-41f3-ad7b-055f3d0b63f6

Closes #32