### PR TITLE
feat: Implement Configuration Settings UI

### DIFF
--- a/src/le_beta_vis/common/ConfigurationService.py
+++ b/src/le_beta_vis/common/ConfigurationService.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 
 class ConfigurationService(ABC):
@@ -21,4 +21,14 @@ class ConfigurationService(ABC):
     @abstractmethod
     def get_description(self, key: str) -> Optional[str]:
         """Return the human-readable description for *key*, or None."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def reset_to_defaults(self) -> None:
+        """Reset all keys to their bundled default values."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_metadata(self) -> Dict[str, Dict[str, Any]]:
+        """Return structured metadata for all configuration keys."""
         raise NotImplementedError

--- a/src/le_beta_vis/common/YAMLBackedConfigurationService.py
+++ b/src/le_beta_vis/common/YAMLBackedConfigurationService.py
@@ -82,6 +82,12 @@ class YAMLBackedConfigurationService(ConfigurationService):
         """
         return self._load_bundled_defaults_metadata()
 
+    def reset_to_defaults(self) -> None:
+        """Reset all configuration keys to bundled default values."""
+        with self._lock:
+            self._store = self._load_bundled_defaults()
+            self._persist()
+
     # ------------------------------------------------------------------
     # Path resolution
     # ------------------------------------------------------------------

--- a/src/le_beta_vis/config/defaults.yaml
+++ b/src/le_beta_vis/config/defaults.yaml
@@ -63,7 +63,8 @@ global:physics:ped_width:
 # ---------------------------------------------------------------------------
 
 gui:raw_analysis:default_colormap:
-  type: str
+  type: enum
+  choices: ["viridis", "plasma", "inferno", "magma", "jet", "bone", "hot", "cool"]
   default: "viridis"
   description: >-
     Initial colormap applied when opening a new FITS file.
@@ -97,7 +98,8 @@ gui:raw_analysis:clustering_threshold:
     event clusters.
 
 gui:raw_analysis:cluster_extractor_method:
-  type: str
+  type: enum
+  choices: ["mock", "lbnl_classical", "lbnl_optimized", "general"]
   default: "lbnl_classical"
   description: >-
     Backend algorithm for cluster extraction.
@@ -219,7 +221,8 @@ gui:mosaic:thumbnail_height:
     inside the strip. Width is calculated dynamically.
 
 gui:mosaic:scaling_function:
-  type: str
+  type: enum
+  choices: ["linear", "log", "sqrt"]
   default: "log"
   description: >-
     Transfer function used to render thumbnails.
@@ -243,7 +246,8 @@ gui:historical:live_update_rate_ms:
     Refresh rate (in milliseconds) for the live monitoring dashboard.
 
 gui:historical:mode:
-  type: str
+  type: enum
+  choices: ["live", "historical"]
   default: "historical"
   description: >-
     Operational mode of the Historical View.
@@ -298,7 +302,7 @@ gui:inspector:histogram_bins:
 # ---------------------------------------------------------------------------
 
 gui:export:default_path:
-  type: str
+  type: directory_path
   default: "~/Data"
   description: >-
     Default file system path presented in the "Save As" dialog.
@@ -314,7 +318,7 @@ gui:export:image_format:
 # ---------------------------------------------------------------------------
 
 pipeline:ingress:polling_location:
-  type: str
+  type: directory_path
   default: "~/Google\\ Drive\\/My\\ Drive/FITS"
   description: >-
     File path on local system to poll for new FITS data.

--- a/src/le_beta_vis/frontend/MainWindow.py
+++ b/src/le_beta_vis/frontend/MainWindow.py
@@ -1,7 +1,11 @@
 import sys
 
 from PySide6.QtWidgets import (
-    QMainWindow, QTabWidget, QWidget, QVBoxLayout, QFileDialog,
+    QMainWindow,
+    QTabWidget,
+    QWidget,
+    QVBoxLayout,
+    QFileDialog,
 )
 from PySide6.QtGui import QAction, QIcon, QKeySequence
 from .viewmodels.MainViewModel import MainViewModel
@@ -9,19 +13,14 @@ from .views.RawDataView import RawDataView
 from .views.HistoricalView import HistoricalView
 from .viewmodels.RawDataViewModel import RawDataViewModel
 from .viewmodels.HistoricalViewModel import (
-    HistoricalViewModel, HistoricalMode,
+    HistoricalViewModel,
+    HistoricalMode,
 )
 from le_beta_vis.common.ClusterExtractorFactory import (
     create_cluster_extractor,
 )
-from le_beta_vis.common.MockEventRepository import (
-    MockEventRepository, 
-)
 from le_beta_vis.common.ZMQBasedEventRepository import (
     ZMQBasedEventRepository,
-)
-from le_beta_vis.common.ConfigurationService import(
-    MockConfigurationService,
 )
 from pathlib import Path
 
@@ -37,18 +36,16 @@ class MainWindow(QMainWindow):
 
         icon_path = (
             Path(__file__).resolve().parent.parent
-            / "resources" / "icons" / "lbnl-logo.png"
+            / "resources"
+            / "icons"
+            / "lbnl-logo.png"
         )
         self.setWindowIcon(QIcon(str(icon_path)))
 
         # Window Geometry
         self.setMinimumSize(960, 600)
-        width = self.viewModel.configService.get(
-            "gui:window:default_width", 1024
-        )
-        height = self.viewModel.configService.get(
-            "gui:window:default_height", 700
-        )
+        width = self.viewModel.configService.get("gui:window:default_width", 1024)
+        height = self.viewModel.configService.get("gui:window:default_height", 700)
         self.resize(width, height)
 
         # Central Widget
@@ -72,7 +69,7 @@ class MainWindow(QMainWindow):
         self.historicalViewModel = HistoricalViewModel(
             self.viewModel.configService,
             self.viewModel.physicsManager,
-            ZMQBasedEventRepository(MockConfigurationService()),
+            ZMQBasedEventRepository(self.viewModel.configService),
         )
 
         # Initialize Child Views
@@ -111,9 +108,7 @@ class MainWindow(QMainWindow):
             settingsAction.setMenuRole(QAction.MenuRole.PreferencesRole)
         else:
             settingsAction = QAction(self.tr("&Settings"), self)
-        settingsAction.setStatusTip(
-            self.tr("Configure application settings")
-        )
+        settingsAction.setStatusTip(self.tr("Configure application settings"))
         settingsAction.triggered.connect(self._onOpenSettings)
         fileMenu.addAction(settingsAction)
 
@@ -133,9 +128,7 @@ class MainWindow(QMainWindow):
         self.toggleLiveAction = QAction(self.tr("Switch to Live Mode"), self)
         self.toggleLiveAction.setCheckable(True)
         self.toggleLiveAction.setChecked(False)  # Initial state
-        self.toggleLiveAction.triggered.connect(
-            self.onToggleLiveMode
-        )
+        self.toggleLiveAction.triggered.connect(self.onToggleLiveMode)
         viewMenu.addAction(self.toggleLiveAction)
 
         # Sync initial state

--- a/src/le_beta_vis/frontend/MainWindow.py
+++ b/src/le_beta_vis/frontend/MainWindow.py
@@ -1,3 +1,5 @@
+import sys
+
 from PySide6.QtWidgets import (
     QMainWindow, QTabWidget, QWidget, QVBoxLayout, QFileDialog,
 )
@@ -102,6 +104,21 @@ class MainWindow(QMainWindow):
 
         fileMenu.addSeparator()
 
+        # Settings Action
+        if sys.platform == "darwin":
+            settingsAction = QAction(self.tr("&Preferences"), self)
+            settingsAction.setShortcut(QKeySequence("Ctrl+,"))
+            settingsAction.setMenuRole(QAction.MenuRole.PreferencesRole)
+        else:
+            settingsAction = QAction(self.tr("&Settings"), self)
+        settingsAction.setStatusTip(
+            self.tr("Configure application settings")
+        )
+        settingsAction.triggered.connect(self._onOpenSettings)
+        fileMenu.addAction(settingsAction)
+
+        fileMenu.addSeparator()
+
         # Exit Action
         exitAction = QAction(self.tr("E&xit"), self)
         exitAction.setShortcut(QKeySequence.Quit)
@@ -123,6 +140,15 @@ class MainWindow(QMainWindow):
 
         # Sync initial state
         self.onModeChanged(self.historicalViewModel.mode)
+
+    def _onOpenSettings(self):
+        """Open the Settings dialog."""
+        from .viewmodels.SettingsViewModel import SettingsViewModel
+        from .widgets.SettingsDialog import SettingsDialog
+
+        vm = SettingsViewModel(self.viewModel.configService)
+        dialog = SettingsDialog(vm, parent=self)
+        dialog.exec()
 
     def onOpenFile(self):
         """Open a file dialog and load it into the Raw Data view."""

--- a/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
@@ -566,6 +566,7 @@ class RawDataViewModel:
                     viz_data, self._colormap, self._vrange
                 )
             except Exception:
+                logger.exception("Render failed")
                 self._current_buffer = None
 
         self._notify_image_changed()

--- a/src/le_beta_vis/frontend/viewmodels/SettingsViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/SettingsViewModel.py
@@ -11,8 +11,8 @@ from typing import (
 
 from le_beta_vis.common.ConfigurationService import ConfigurationService
 
-# (key, display_label, type_str, current_value, default_value, description)
-SettingEntry = Tuple[str, str, str, Any, Any, str]
+# (key, display_label, type_str, current_value, default_value, description, choices)
+SettingEntry = Tuple[str, str, str, Any, Any, str, List[Any]]
 
 # {group: {subgroup: [entries]}}
 GroupedSettings = Dict[str, Dict[str, List[SettingEntry]]]
@@ -114,9 +114,10 @@ class SettingsViewModel:
             current = self.get_current_value(key)
             default = meta.get("default")
             type_str = meta.get("type", "str")
+            choices = meta.get("choices", [])
 
             entry: SettingEntry = (
-                key, leaf, type_str, current, default, desc,
+                key, leaf, type_str, current, default, desc, choices,
             )
             result.setdefault(group, {}).setdefault(
                 subgroup, [],

--- a/src/le_beta_vis/frontend/viewmodels/SettingsViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/SettingsViewModel.py
@@ -1,0 +1,203 @@
+"""Pure-Python ViewModel for the Settings dialog.
+
+Tracks pending changes separately from live configuration values,
+supports grouping by key namespace, and provides text filtering.
+No Qt dependencies — testable in headless CI.
+"""
+
+from typing import (
+    Any, Callable, Dict, List, Tuple,
+)
+
+from le_beta_vis.common.ConfigurationService import ConfigurationService
+
+# (key, display_label, type_str, current_value, default_value, description)
+SettingEntry = Tuple[str, str, str, Any, Any, str]
+
+# {group: {subgroup: [entries]}}
+GroupedSettings = Dict[str, Dict[str, List[SettingEntry]]]
+
+_ACRONYM_OVERRIDES: Dict[str, str] = {
+    "gui": "GUI",
+    "eps": "EPS",
+    "db": "Database",
+    "ipc": "IPC",
+}
+
+
+def _humanize(token: str) -> str:
+    """Convert a snake_case token to Title Case with acronym overrides."""
+    lower = token.lower()
+    if lower in _ACRONYM_OVERRIDES:
+        return _ACRONYM_OVERRIDES[lower]
+    return token.replace("_", " ").title()
+
+
+def _parse_key(key: str) -> Tuple[str, str, str]:
+    """Split a colon-delimited key into (group, subgroup, leaf).
+
+    Examples
+    --------
+    >>> _parse_key("gui:raw_analysis:clustering_threshold")
+    ('GUI', 'Raw Analysis', 'Clustering Threshold')
+    >>> _parse_key("eps:timeout_ms")
+    ('EPS', 'General', 'Timeout Ms')
+    """
+    parts = key.split(":")
+    if len(parts) >= 3:
+        group = _humanize(parts[0])
+        subgroup = _humanize(":".join(parts[1:-1]))
+        leaf = _humanize(parts[-1])
+    elif len(parts) == 2:
+        group = _humanize(parts[0])
+        subgroup = "General"
+        leaf = _humanize(parts[1])
+    else:
+        group = "General"
+        subgroup = "General"
+        leaf = _humanize(parts[0])
+    return group, subgroup, leaf
+
+
+class SettingsViewModel:
+    """ViewModel for the application Settings dialog.
+
+    Loads all known configuration keys and their metadata from the
+    ``ConfigurationService``, supports pending (uncommitted) edits,
+    text filtering, and batch apply/cancel/restore-defaults.
+    """
+
+    def __init__(self, config: ConfigurationService) -> None:
+        self._config = config
+        self._metadata: Dict[str, Dict[str, Any]] = config.get_metadata()
+        self._current_values: Dict[str, Any] = {}
+        self._pending: Dict[str, Any] = {}
+        self._filter_text: str = ""
+
+        self._on_values_changed: List[Callable[[], None]] = []
+        self._on_pending_changed: List[Callable[[], None]] = []
+
+        self._reload_values()
+
+    # ------------------------------------------------------------------
+    # Callback registration
+    # ------------------------------------------------------------------
+
+    def add_values_changed_callback(
+        self, cb: Callable[[], None],
+    ) -> None:
+        """Register a callback fired when values are applied or reset."""
+        self._on_values_changed.append(cb)
+
+    def add_pending_changed_callback(
+        self, cb: Callable[[], None],
+    ) -> None:
+        """Register a callback fired when pending changes or filter update."""
+        self._on_pending_changed.append(cb)
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    def filtered_grouped_settings(self) -> GroupedSettings:
+        """Return the full settings hierarchy filtered by current text."""
+        result: GroupedSettings = {}
+        needle = self._filter_text.lower()
+
+        for key, meta in self._metadata.items():
+            group, subgroup, leaf = _parse_key(key)
+            desc = meta.get("description", "")
+
+            if needle and not self._matches(key, leaf, desc, needle):
+                continue
+
+            current = self.get_current_value(key)
+            default = meta.get("default")
+            type_str = meta.get("type", "str")
+
+            entry: SettingEntry = (
+                key, leaf, type_str, current, default, desc,
+            )
+            result.setdefault(group, {}).setdefault(
+                subgroup, [],
+            ).append(entry)
+
+        return result
+
+    def get_current_value(self, key: str) -> Any:
+        """Return pending value if it exists, else the live value."""
+        if key in self._pending:
+            return self._pending[key]
+        return self._current_values.get(key)
+
+    @property
+    def has_pending_changes(self) -> bool:
+        """True when there are uncommitted edits."""
+        return len(self._pending) > 0
+
+    @property
+    def all_keys(self) -> List[str]:
+        """Return the list of all known configuration keys."""
+        return list(self._metadata.keys())
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    def set_pending(self, key: str, value: Any) -> None:
+        """Record an uncommitted change for *key*."""
+        self._pending[key] = value
+        self._notify_pending_changed()
+
+    def apply(self) -> None:
+        """Write all pending changes to the config service."""
+        for key, value in self._pending.items():
+            self._config.set(key, value)
+        self._pending.clear()
+        self._reload_values()
+        self._notify_values_changed()
+
+    def cancel(self) -> None:
+        """Discard all pending changes without writing to disk."""
+        self._pending.clear()
+
+    def restore_defaults(self) -> None:
+        """Reset all keys to bundled defaults."""
+        self._config.reset_to_defaults()
+        self._pending.clear()
+        self._reload_values()
+        self._notify_values_changed()
+
+    def filter(self, text: str) -> None:
+        """Set the filter text and notify for view rebuild."""
+        self._filter_text = text
+        self._notify_pending_changed()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _reload_values(self) -> None:
+        """Refresh current values from the config service."""
+        for key, meta in self._metadata.items():
+            default = meta.get("default")
+            self._current_values[key] = self._config.get(key, default)
+
+    @staticmethod
+    def _matches(
+        key: str, label: str, description: str, needle: str,
+    ) -> bool:
+        """Return True if *needle* appears in key, label, or description."""
+        return (
+            needle in key.lower()
+            or needle in label.lower()
+            or needle in description.lower()
+        )
+
+    def _notify_values_changed(self) -> None:
+        for cb in self._on_values_changed:
+            cb()
+
+    def _notify_pending_changed(self) -> None:
+        for cb in self._on_pending_changed:
+            cb()

--- a/src/le_beta_vis/frontend/viewmodels/__init__.py
+++ b/src/le_beta_vis/frontend/viewmodels/__init__.py
@@ -8,3 +8,4 @@ from .HistoricalEventInspectorViewModel import (
     HistoricalEventInspectorViewModel,
 )
 from .HistoricalFilterBarViewModel import HistoricalFilterBarViewModel
+from .SettingsViewModel import SettingsViewModel

--- a/src/le_beta_vis/frontend/views/ClusterAnalysisView.py
+++ b/src/le_beta_vis/frontend/views/ClusterAnalysisView.py
@@ -45,21 +45,22 @@ class ClusterAnalysisView(QWidget):
 
     def _addExtractionSection(self, parent_layout: QVBoxLayout) -> None:
         group = QGroupBox(self.tr("Cluster Extraction"))
-        row = QHBoxLayout(group)
+        vbox = QVBoxLayout(group)
 
+        row = QHBoxLayout()
         row.addWidget(QLabel(self.tr("\u03c3 threshold")))
-
         self._thresholdSpinBox = QDoubleSpinBox()
         self._thresholdSpinBox.setRange(0.1, 100.0)
         self._thresholdSpinBox.setSingleStep(0.5)
         self._thresholdSpinBox.setDecimals(1)
         self._thresholdSpinBox.setValue(self._vm.clusteringThreshold)
         row.addWidget(self._thresholdSpinBox)
+        vbox.addLayout(row)
 
         self._btnRunExtraction = QPushButton(self.tr("Run Extraction"))
         self._btnRunExtraction.setEnabled(False)
         self._btnRunExtraction.clicked.connect(self._vm.triggerClustering)
-        row.addWidget(self._btnRunExtraction)
+        vbox.addWidget(self._btnRunExtraction)
 
         parent_layout.addWidget(group)
 

--- a/src/le_beta_vis/frontend/views/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/RawDataView.py
@@ -101,6 +101,24 @@ class _Style:
     )
     RIGHT_SIDEBAR = """
         QFrame { background-color: #f0f0f0; border-left: 1px solid #ccc; }
+        QWidget { background-color: #f0f0f0; }
+        QTabWidget::pane {
+            background-color: #f0f0f0;
+            border: 1px solid #ccc;
+            border-top: none;
+        }
+        QTabBar::tab {
+            background-color: #e0e0e0;
+            color: #000000;
+            padding: 6px 12px;
+            border: 1px solid #ccc;
+            border-bottom: none;
+            border-top-left-radius: 4px;
+            border-top-right-radius: 4px;
+        }
+        QTabBar::tab:selected {
+            background-color: #f0f0f0;
+        }
         QGroupBox { color: #000000; }
         QGroupBox::title { color: #000000; }
         QLabel { color: #000000; background: transparent; }

--- a/src/le_beta_vis/frontend/views/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/RawDataView.py
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QMessageBox,
+    QStyleFactory,
     QTabWidget,
     QToolButton,
     QVBoxLayout,
@@ -119,7 +120,7 @@ class _Style:
         QTabBar::tab:selected {
             background-color: #f0f0f0;
         }
-        QGroupBox { color: #000000; }
+        QGroupBox { color: #000000; background-color: #f0f0f0; }
         QGroupBox::title { color: #000000; }
         QLabel { color: #000000; background: transparent; }
         QPushButton { color: #000000; }
@@ -386,6 +387,7 @@ class RawDataView(QWidget):
     def _setupRightSidebar(self):
         self.rightSidebar = QFrame()
         self.rightSidebar.setFixedWidth(300)
+        self.rightSidebar.setStyle(QStyleFactory.create("Fusion"))
         self.rightSidebar.setStyleSheet(_Style.RIGHT_SIDEBAR)
         self.rightLayout = QVBoxLayout(self.rightSidebar)
         self.rightLayout.setContentsMargins(10, 10, 10, 10)

--- a/src/le_beta_vis/frontend/views/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/RawDataView.py
@@ -442,6 +442,7 @@ class RawDataView(QWidget):
         vmin, vmax = self.viewModel.visualizationRange
         self.rangeControl.setValues(vmin, vmax)
         self.rangeControl.setColormap(self.viewModel.colormap)
+        self.cmapSelector.setCurrentText(self.viewModel.colormap)
 
     def _bindToolCallbacks(self):
         """Wire active tool, magnifier, and pointer hover callbacks."""

--- a/src/le_beta_vis/frontend/widgets/SettingsDialog.py
+++ b/src/le_beta_vis/frontend/widgets/SettingsDialog.py
@@ -1,0 +1,364 @@
+"""Settings dialog for editing application configuration.
+
+Displays all configuration keys grouped by namespace with type-dispatched
+input widgets.  Pending changes are tracked in the SettingsViewModel and
+only written to disk on Apply.
+"""
+
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..viewmodels.SettingsViewModel import SettingsViewModel
+
+
+class _Style:
+    DIALOG = "background-color: #2d2d2d; color: #eeeeee;"
+    GROUP_BOX = (
+        "QGroupBox {"
+        "  color: #eeeeee;"
+        "  font-weight: bold;"
+        "  font-size: 13px;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 4px;"
+        "  margin-top: 12px;"
+        "  padding-top: 16px;"
+        "}"
+        "QGroupBox::title {"
+        "  subcontrol-origin: margin;"
+        "  left: 10px;"
+        "  padding: 0 4px;"
+        "}"
+    )
+    SUBGROUP_HEADER = (
+        "color: #0078d7;"
+        "font-weight: bold;"
+        "font-size: 12px;"
+        "padding-top: 6px;"
+    )
+    LABEL = "color: #cccccc; font-size: 12px;"
+    DESC_LABEL = "color: #888888; font-size: 10px;"
+    INPUT = (
+        "QLineEdit, QSpinBox, QDoubleSpinBox {"
+        "  background-color: #3d3d3d;"
+        "  color: #eeeeee;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 3px;"
+        "  padding: 3px;"
+        "}"
+        "QLineEdit:focus, QSpinBox:focus, QDoubleSpinBox:focus {"
+        "  border: 1px solid #0078d7;"
+        "}"
+    )
+    CHECKBOX = (
+        "QCheckBox {"
+        "  color: #eeeeee;"
+        "  spacing: 6px;"
+        "}"
+        "QCheckBox::indicator {"
+        "  width: 16px;"
+        "  height: 16px;"
+        "}"
+    )
+    FILTER_INPUT = (
+        "QLineEdit {"
+        "  background-color: #3d3d3d;"
+        "  color: #eeeeee;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 3px;"
+        "  padding: 5px;"
+        "  font-size: 12px;"
+        "}"
+        "QLineEdit:focus {"
+        "  border: 1px solid #0078d7;"
+        "}"
+    )
+    APPLY_BTN = (
+        "QPushButton {"
+        "  background-color: #0078d7;"
+        "  color: white;"
+        "  border: none;"
+        "  border-radius: 4px;"
+        "  padding: 6px 16px;"
+        "  font-weight: bold;"
+        "}"
+        "QPushButton:hover {"
+        "  background-color: #005fa3;"
+        "}"
+    )
+    CANCEL_BTN = (
+        "QPushButton {"
+        "  background-color: #3d3d3d;"
+        "  color: #cccccc;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 4px;"
+        "  padding: 6px 16px;"
+        "}"
+        "QPushButton:hover {"
+        "  background-color: #505050;"
+        "}"
+    )
+    RESTORE_BTN = (
+        "QPushButton {"
+        "  background-color: #8b0000;"
+        "  color: white;"
+        "  border: none;"
+        "  border-radius: 4px;"
+        "  padding: 6px 16px;"
+        "  font-weight: bold;"
+        "}"
+        "QPushButton:hover {"
+        "  background-color: #a00000;"
+        "}"
+    )
+    CLEAR_BTN = (
+        "QPushButton {"
+        "  background-color: #3d3d3d;"
+        "  color: #cccccc;"
+        "  border: 1px solid #555555;"
+        "  border-radius: 4px;"
+        "  padding: 5px 10px;"
+        "}"
+        "QPushButton:hover {"
+        "  background-color: #505050;"
+        "}"
+    )
+
+
+class SettingsDialog(QDialog):
+    """Modal dialog for editing all application configuration keys.
+
+    Groups settings by namespace, provides type-dispatched input widgets,
+    text filtering, and Apply/Cancel/Restore Defaults actions.
+    """
+
+    _DEBOUNCE_MS = 200
+
+    def __init__(
+        self,
+        viewModel: SettingsViewModel,
+        parent: QWidget = None,
+    ) -> None:
+        super().__init__(parent)
+        self._vm = viewModel
+        self._debounce_timer_id: int = 0
+
+        self.setWindowTitle(self.tr("Settings"))
+        self.setMinimumSize(600, 500)
+        self.setStyleSheet(_Style.DIALOG)
+        self.setWindowFlags(
+            self.windowFlags() & ~Qt.WindowContextHelpButtonHint
+        )
+
+        self._initUI()
+        self._buildSettings()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _initUI(self) -> None:
+        root = QVBoxLayout(self)
+        root.setSpacing(8)
+
+        # Filter bar
+        filterRow = QHBoxLayout()
+        self._filterEdit = QLineEdit()
+        self._filterEdit.setPlaceholderText(self.tr("Filter settings..."))
+        self._filterEdit.setClearButtonEnabled(True)
+        self._filterEdit.setStyleSheet(_Style.FILTER_INPUT)
+        self._filterEdit.textChanged.connect(self._onFilterTextChanged)
+        filterRow.addWidget(self._filterEdit)
+
+        clearBtn = QPushButton(self.tr("Clear"))
+        clearBtn.setStyleSheet(_Style.CLEAR_BTN)
+        clearBtn.clicked.connect(self._onClearFilter)
+        filterRow.addWidget(clearBtn)
+        root.addLayout(filterRow)
+
+        # Scroll area
+        self._scrollArea = QScrollArea()
+        self._scrollArea.setWidgetResizable(True)
+        self._scrollArea.setFrameShape(QScrollArea.Shape.NoFrame)
+        root.addWidget(self._scrollArea, stretch=1)
+
+        # Button row
+        btnRow = QHBoxLayout()
+        restoreBtn = QPushButton(self.tr("Restore Defaults"))
+        restoreBtn.setStyleSheet(_Style.RESTORE_BTN)
+        restoreBtn.clicked.connect(self._onRestoreDefaults)
+        btnRow.addWidget(restoreBtn)
+
+        btnRow.addStretch()
+
+        cancelBtn = QPushButton(self.tr("Cancel"))
+        cancelBtn.setStyleSheet(_Style.CANCEL_BTN)
+        cancelBtn.clicked.connect(self._onCancel)
+        btnRow.addWidget(cancelBtn)
+
+        applyBtn = QPushButton(self.tr("Apply"))
+        applyBtn.setStyleSheet(_Style.APPLY_BTN)
+        applyBtn.clicked.connect(self._onApply)
+        btnRow.addWidget(applyBtn)
+
+        root.addLayout(btnRow)
+
+    def _buildSettings(self) -> None:
+        """Tear down and rebuild the scroll area content."""
+        grouped = self._vm.filtered_grouped_settings()
+
+        content = QWidget()
+        layout = QVBoxLayout(content)
+        layout.setSpacing(4)
+
+        for group_name in sorted(grouped.keys()):
+            subgroups = grouped[group_name]
+            groupBox = QGroupBox(group_name)
+            groupBox.setStyleSheet(_Style.GROUP_BOX)
+            groupLayout = QVBoxLayout(groupBox)
+            groupLayout.setSpacing(4)
+
+            for sg_name in sorted(subgroups.keys()):
+                entries = subgroups[sg_name]
+                header = QLabel(sg_name)
+                header.setStyleSheet(_Style.SUBGROUP_HEADER)
+                groupLayout.addWidget(header)
+
+                form = QFormLayout()
+                form.setLabelAlignment(Qt.AlignRight)
+                form.setSpacing(6)
+
+                for entry in entries:
+                    key, label, type_str, value, _default, desc = entry
+                    row = self._createInputWidget(
+                        key, type_str, value,
+                    )
+                    labelWidget = QLabel(label)
+                    labelWidget.setStyleSheet(_Style.LABEL)
+
+                    container = QVBoxLayout()
+                    container.setSpacing(2)
+                    container.addWidget(row)
+                    if desc:
+                        descLabel = QLabel(desc)
+                        descLabel.setStyleSheet(_Style.DESC_LABEL)
+                        descLabel.setWordWrap(True)
+                        container.addWidget(descLabel)
+
+                    form.addRow(labelWidget, container)
+
+                groupLayout.addLayout(form)
+
+            layout.addWidget(groupBox)
+
+        layout.addStretch()
+        self._scrollArea.setWidget(content)
+
+    def _createInputWidget(
+        self, key: str, type_str: str, value,
+    ) -> QWidget:
+        """Return a type-dispatched input widget for *key*."""
+        if type_str == "bool":
+            cb = QCheckBox()
+            cb.setStyleSheet(_Style.CHECKBOX)
+            cb.setChecked(bool(value))
+            cb.toggled.connect(
+                lambda checked, k=key: self._vm.set_pending(k, checked),
+            )
+            return cb
+
+        if type_str == "int":
+            spin = QSpinBox()
+            spin.setStyleSheet(_Style.INPUT)
+            spin.setRange(-999999, 999999)
+            spin.setValue(int(value) if value is not None else 0)
+            spin.valueChanged.connect(
+                lambda v, k=key: self._vm.set_pending(k, v),
+            )
+            return spin
+
+        if type_str == "float":
+            spin = QDoubleSpinBox()
+            spin.setStyleSheet(_Style.INPUT)
+            spin.setRange(-999999.0, 999999.0)
+            spin.setDecimals(4)
+            spin.setValue(float(value) if value is not None else 0.0)
+            spin.valueChanged.connect(
+                lambda v, k=key: self._vm.set_pending(k, v),
+            )
+            return spin
+
+        # Default: str
+        edit = QLineEdit()
+        edit.setStyleSheet(_Style.INPUT)
+        edit.setText(str(value) if value is not None else "")
+        if "password" in key.lower():
+            edit.setEchoMode(QLineEdit.EchoMode.Password)
+        edit.textChanged.connect(
+            lambda text, k=key: self._vm.set_pending(k, text),
+        )
+        return edit
+
+    # ------------------------------------------------------------------
+    # Slots
+    # ------------------------------------------------------------------
+
+    def _onFilterTextChanged(self, text: str) -> None:
+        QTimer.singleShot(
+            self._DEBOUNCE_MS,
+            lambda: self._applyFilter(text),
+        )
+
+    def _applyFilter(self, text: str) -> None:
+        if self._filterEdit.text() != text:
+            return
+        self._vm.filter(text)
+        self._buildSettings()
+
+    def _onClearFilter(self) -> None:
+        self._filterEdit.clear()
+
+    def _onCancel(self) -> None:
+        self._vm.cancel()
+        self.reject()
+
+    def _onApply(self) -> None:
+        reply = QMessageBox.question(
+            self,
+            self.tr("Apply Settings"),
+            self.tr("Save all changes to the configuration file?"),
+            QMessageBox.StandardButton.Yes
+            | QMessageBox.StandardButton.No,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            self._vm.apply()
+            self.accept()
+
+    def _onRestoreDefaults(self) -> None:
+        reply = QMessageBox.warning(
+            self,
+            self.tr("Restore Defaults"),
+            self.tr(
+                "This will reset ALL settings to their default values. "
+                "This action cannot be undone.\n\nContinue?"
+            ),
+            QMessageBox.StandardButton.Yes
+            | QMessageBox.StandardButton.No,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            self._vm.restore_defaults()
+            self._buildSettings()

--- a/src/le_beta_vis/frontend/widgets/SettingsDialog.py
+++ b/src/le_beta_vis/frontend/widgets/SettingsDialog.py
@@ -8,8 +8,10 @@ only written to disk on Apply.
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import (
     QCheckBox,
+    QComboBox,
     QDialog,
     QDoubleSpinBox,
+    QFileDialog,
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
@@ -243,9 +245,9 @@ class SettingsDialog(QDialog):
                 form.setSpacing(6)
 
                 for entry in entries:
-                    key, label, type_str, value, _default, desc = entry
+                    key, label, type_str, value, _default, desc, choices = entry
                     row = self._createInputWidget(
-                        key, type_str, value,
+                        key, type_str, value, choices
                     )
                     labelWidget = QLabel(label)
                     labelWidget.setStyleSheet(_Style.LABEL)
@@ -269,7 +271,7 @@ class SettingsDialog(QDialog):
         self._scrollArea.setWidget(content)
 
     def _createInputWidget(
-        self, key: str, type_str: str, value,
+        self, key: str, type_str: str, value, choices: list = None
     ) -> QWidget:
         """Return a type-dispatched input widget for *key*."""
         if type_str == "bool":
@@ -280,6 +282,18 @@ class SettingsDialog(QDialog):
                 lambda checked, k=key: self._vm.set_pending(k, checked),
             )
             return cb
+
+        if type_str == "enum":
+            combo = QComboBox()
+            combo.setStyleSheet(_Style.INPUT)
+            if choices:
+                combo.addItems([str(c) for c in choices])
+            if value is not None:
+                combo.setCurrentText(str(value))
+            combo.currentTextChanged.connect(
+                lambda text, k=key: self._vm.set_pending(k, text),
+            )
+            return combo
 
         if type_str == "int":
             spin = QSpinBox()
@@ -301,6 +315,37 @@ class SettingsDialog(QDialog):
                 lambda v, k=key: self._vm.set_pending(k, v),
             )
             return spin
+
+        if type_str in ("directory_path", "file_path"):
+            container = QWidget()
+            layout = QHBoxLayout(container)
+            layout.setContentsMargins(0, 0, 0, 0)
+            layout.setSpacing(4)
+            
+            edit = QLineEdit()
+            edit.setStyleSheet(_Style.INPUT)
+            edit.setText(str(value) if value is not None else "")
+            edit.textChanged.connect(
+                lambda text, k=key: self._vm.set_pending(k, text),
+            )
+            layout.addWidget(edit, stretch=1)
+            
+            browseBtn = QPushButton(self.tr("Browse..."))
+            # Re-use clear button style for a small neutral button
+            browseBtn.setStyleSheet(_Style.CLEAR_BTN)
+            
+            def browse(checked=False, edit_widget=edit, t=type_str):
+                current_path = edit_widget.text()
+                if t == "directory_path":
+                    path = QFileDialog.getExistingDirectory(self, self.tr("Select Directory"), current_path)
+                else:
+                    path, _ = QFileDialog.getOpenFileName(self, self.tr("Select File"), current_path)
+                if path:
+                    edit_widget.setText(path)
+                    
+            browseBtn.clicked.connect(browse)
+            layout.addWidget(browseBtn)
+            return container
 
         # Default: str
         edit = QLineEdit()

--- a/src/le_beta_vis/frontend/widgets/SettingsDialog.py
+++ b/src/le_beta_vis/frontend/widgets/SettingsDialog.py
@@ -160,7 +160,7 @@ class SettingsDialog(QDialog):
         self._debounce_timer_id: int = 0
 
         self.setWindowTitle(self.tr("Settings"))
-        self.setMinimumSize(600, 500)
+        self.setMinimumSize(700, 500)
         self.setStyleSheet(_Style.DIALOG)
         self.setWindowFlags(
             self.windowFlags() & ~Qt.WindowContextHelpButtonHint
@@ -242,6 +242,9 @@ class SettingsDialog(QDialog):
 
                 form = QFormLayout()
                 form.setLabelAlignment(Qt.AlignRight)
+                form.setFieldGrowthPolicy(
+                    QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow
+                )
                 form.setSpacing(6)
 
                 for entry in entries:
@@ -252,7 +255,9 @@ class SettingsDialog(QDialog):
                     labelWidget = QLabel(label)
                     labelWidget.setStyleSheet(_Style.LABEL)
 
-                    container = QVBoxLayout()
+                    wrapper = QWidget()
+                    container = QVBoxLayout(wrapper)
+                    container.setContentsMargins(0, 0, 0, 0)
                     container.setSpacing(2)
                     container.addWidget(row)
                     if desc:
@@ -261,7 +266,7 @@ class SettingsDialog(QDialog):
                         descLabel.setWordWrap(True)
                         container.addWidget(descLabel)
 
-                    form.addRow(labelWidget, container)
+                    form.addRow(labelWidget, wrapper)
 
                 groupLayout.addLayout(form)
 

--- a/src/le_beta_vis/frontend/widgets/__init__.py
+++ b/src/le_beta_vis/frontend/widgets/__init__.py
@@ -14,3 +14,4 @@ from .HistoricalFilterBar import HistoricalFilterBar
 from .HistoricalAdvancedFilterDialog import (
     HistoricalAdvancedFilterDialog,
 )
+from .SettingsDialog import SettingsDialog

--- a/tests/mock_configuration_service.py
+++ b/tests/mock_configuration_service.py
@@ -83,3 +83,14 @@ class MockConfigurationService(ConfigurationService):
     def get_description(self, key: str) -> Optional[str]:
         """Return None — the mock carries no key descriptions."""
         return None
+
+    def reset_to_defaults(self) -> None:
+        """No-op reset for the mock service."""
+        pass
+
+    def get_metadata(self) -> Dict[str, Dict[str, Any]]:
+        """Return minimal metadata for testing."""
+        return {
+            k: {"type": type(v).__name__, "default": v, "description": ""}
+            for k, v in self._store.items()
+        }

--- a/tests/test_RawDataViewModel.py
+++ b/tests/test_RawDataViewModel.py
@@ -14,6 +14,7 @@ import pytest
 from le_beta_vis.common.CCDCaptureModel import CCDCaptureModel
 from mock_configuration_service import MockConfigurationService
 from le_beta_vis.common.PhysicsConversionManager import PhysicsConversionManagerImpl
+from le_beta_vis.frontend.fitsconverters import OpenCVBasedConverter
 from le_beta_vis.frontend.viewmodels.RawDataViewModel import (
     ActiveTool,
     RawDataViewModel,
@@ -42,7 +43,7 @@ def test_initial_colormap_from_config():
     config = MockConfigurationService()
     config.set("gui:raw_analysis:default_colormap", "plasma")
     physics_manager = PhysicsConversionManagerImpl(config)
-    
+
     vm = RawDataViewModel(config, physics_manager)
     assert vm.colormap == "plasma"
 
@@ -286,3 +287,130 @@ def test_clear_pointer_hover_noop_when_already_none(view_model):
 
     view_model.clearPointerHover()
     cb.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: initial render with real converter (issue: blank FITS)
+# ---------------------------------------------------------------------------
+
+
+def _make_vm_with_real_converter(config):
+    """Helper: build a RawDataViewModel with OpenCVBasedConverter and sync render."""
+    physics = PhysicsConversionManagerImpl(config)
+    vm = RawDataViewModel(config, physics)
+    vm._converter = OpenCVBasedConverter()
+
+    def sync_render():
+        vm._render_worker_logic()
+
+    vm._request_render = sync_render
+    return vm
+
+
+def test_loadfile_produces_buffer_with_real_converter():
+    """loadFile with OpenCVBasedConverter must produce a non-None buffer."""
+    config = MockConfigurationService()
+    vm = _make_vm_with_real_converter(config)
+
+    mock_capture = MagicMock(spec=CCDCaptureModel)
+    mock_capture.rawData.return_value = np.random.randint(
+        0, 65535, (64, 64), dtype=np.uint16
+    ).astype(np.float64)
+    mock_capture.info.return_value.rows = 64
+    mock_capture.info.return_value.cols = 64
+    mock_capture.info.return_value.min = 0
+    mock_capture.info.return_value.max = 65535
+
+    module = sys.modules["le_beta_vis.frontend.viewmodels.RawDataViewModel"]
+    with patch.object(module, "Path") as MockPath:
+        MockPath.return_value.exists.return_value = True
+        with patch.object(CCDCaptureModel, "load", return_value=[mock_capture]):
+            vm.loadFile("test.fits")
+
+    assert vm.currentBuffer is not None
+    assert vm.currentBuffer.dtype == np.uint8
+    assert len(vm.currentBuffer.shape) == 3
+
+
+def test_render_with_yaml_backed_config(tmp_path):
+    """Render pipeline works with YAMLBackedConfigurationService."""
+    from le_beta_vis.common.YAMLBackedConfigurationService import (
+        YAMLBackedConfigurationService,
+    )
+
+    config = YAMLBackedConfigurationService(yaml_path=tmp_path / "test.yaml")
+    vm = _make_vm_with_real_converter(config)
+
+    mock_capture = MagicMock(spec=CCDCaptureModel)
+    mock_capture.rawData.return_value = np.ones((32, 32), dtype=np.float64)
+    mock_capture.info.return_value.rows = 32
+    mock_capture.info.return_value.cols = 32
+    mock_capture.info.return_value.min = 0
+    mock_capture.info.return_value.max = 1
+
+    module = sys.modules["le_beta_vis.frontend.viewmodels.RawDataViewModel"]
+    with patch.object(module, "Path") as MockPath:
+        MockPath.return_value.exists.return_value = True
+        with patch.object(CCDCaptureModel, "load", return_value=[mock_capture]):
+            vm.loadFile("test.fits")
+
+    assert vm.currentBuffer is not None
+
+
+def test_render_with_wide_vis_range():
+    """Render must not throw with vis_range_max=700.0 (user-reported config)."""
+    config = MockConfigurationService()
+    config.set("gui:raw_analysis:vis_range_max", 700.0)
+    config.set("gui:raw_analysis:default_colormap", "inferno")
+    vm = _make_vm_with_real_converter(config)
+
+    mock_capture = MagicMock(spec=CCDCaptureModel)
+    mock_capture.rawData.return_value = np.zeros((16, 16), dtype=np.float64)
+    mock_capture.info.return_value.rows = 16
+    mock_capture.info.return_value.cols = 16
+    mock_capture.info.return_value.min = 0
+    mock_capture.info.return_value.max = 0
+
+    vm._captures = [mock_capture]
+    vm._activeIndex = 0
+    vm._render_worker_logic()
+
+    assert vm.currentBuffer is not None
+
+
+def test_render_exception_is_logged():
+    """Exceptions in render are logged via logger.exception."""
+    config = MockConfigurationService()
+    vm = _make_vm_with_real_converter(config)
+
+    mock_capture = MagicMock(spec=CCDCaptureModel)
+    mock_capture.rawData.side_effect = RuntimeError("boom")
+    vm._captures = [mock_capture]
+    vm._activeIndex = 0
+
+    module = sys.modules["le_beta_vis.frontend.viewmodels.RawDataViewModel"]
+    with patch.object(module, "logger") as mock_logger:
+        vm._render_worker_logic()
+
+    mock_logger.exception.assert_called_once()
+    assert vm.currentBuffer is None
+
+
+def test_request_render_skips_when_no_data():
+    """_request_render is a no-op when no captures are loaded.
+
+    Prevents stale renders during View initialisation (e.g. colormap
+    selector emitting currentTextChanged) from enqueuing a render that
+    clears the display buffer.
+    """
+    config = MockConfigurationService()
+    vm = _make_vm_with_real_converter(config)
+
+    assert vm._activeIndex == -1
+    assert vm._captures == []
+
+    # Trigger setColormap which calls _request_render internally
+    vm.setColormap("inferno")
+
+    # Queue should be empty — render was skipped
+    assert vm._render_queue.empty()

--- a/tests/test_RawDataViewModel.py
+++ b/tests/test_RawDataViewModel.py
@@ -37,6 +37,16 @@ def view_model():
     return vm
 
 
+def test_initial_colormap_from_config():
+    """Test that RawDataViewModel initializes its colormap from config."""
+    config = MockConfigurationService()
+    config.set("gui:raw_analysis:default_colormap", "plasma")
+    physics_manager = PhysicsConversionManagerImpl(config)
+    
+    vm = RawDataViewModel(config, physics_manager)
+    assert vm.colormap == "plasma"
+
+
 def test_initial_state(view_model):
     """Test the initial state of the ViewModel."""
     assert view_model.activeIndex == -1

--- a/tests/test_SettingsViewModel.py
+++ b/tests/test_SettingsViewModel.py
@@ -1,0 +1,321 @@
+"""Tests for SettingsViewModel — pure Python, no QApplication required."""
+
+import pytest
+
+from le_beta_vis.frontend.viewmodels.SettingsViewModel import (
+    SettingsViewModel,
+    _parse_key,
+    _humanize,
+)
+from le_beta_vis.common.ConfigurationService import ConfigurationService
+from typing import Any, Dict, Optional
+
+
+# ------------------------------------------------------------------
+# Minimal mock that satisfies ConfigurationService + get_metadata
+# ------------------------------------------------------------------
+
+_TEST_METADATA: Dict[str, Dict[str, Any]] = {
+    "gui:raw_analysis:clustering_threshold": {
+        "type": "float",
+        "default": 4.0,
+        "description": "Signal-to-noise ratio for clustering.",
+    },
+    "gui:raw_analysis:default_colormap": {
+        "type": "str",
+        "default": "viridis",
+        "description": "Initial colormap for FITS files.",
+    },
+    "gui:raw_analysis:show_tool_hints": {
+        "type": "bool",
+        "default": True,
+        "description": "Show inline usage hints on interactive tools.",
+    },
+    "gui:window:default_width": {
+        "type": "int",
+        "default": 1024,
+        "description": "Default initial width of the application window.",
+    },
+    "eps:timeout_ms": {
+        "type": "int",
+        "default": 5000,
+        "description": "Timeout in milliseconds for ZMQ operations.",
+    },
+    "global:db:connection_string": {
+        "type": "str",
+        "default": "mysql://localhost/le_beta_vis",
+        "description": "Database connection URI.",
+    },
+}
+
+
+class _TestConfigService(ConfigurationService):
+    """Minimal config service for SettingsViewModel testing."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Any] = {
+            k: v["default"] for k, v in _TEST_METADATA.items()
+        }
+        self._defaults = dict(self._store)
+        self.set_calls: list = []
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._store.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        self._store[key] = value
+        self.set_calls.append((key, value))
+
+    def get_description(self, key: str) -> Optional[str]:
+        meta = _TEST_METADATA.get(key)
+        return meta["description"] if meta else None
+
+    def reset_to_defaults(self) -> None:
+        self._store = dict(self._defaults)
+
+    def get_metadata(self) -> Dict[str, Dict[str, Any]]:
+        return dict(_TEST_METADATA)
+
+
+@pytest.fixture
+def config():
+    return _TestConfigService()
+
+
+@pytest.fixture
+def vm(config):
+    return SettingsViewModel(config)
+
+
+# ------------------------------------------------------------------
+# TestInitialization
+# ------------------------------------------------------------------
+
+class TestInitialization:
+    def test_metadata_loaded(self, vm):
+        assert len(vm.all_keys) == len(_TEST_METADATA)
+
+    def test_current_values_populated(self, vm):
+        assert vm.get_current_value(
+            "gui:raw_analysis:clustering_threshold"
+        ) == 4.0
+
+    def test_no_pending_changes(self, vm):
+        assert vm.has_pending_changes is False
+
+
+# ------------------------------------------------------------------
+# TestNamespaceParsing
+# ------------------------------------------------------------------
+
+class TestNamespaceParsing:
+    def test_three_part_key(self):
+        g, s, l = _parse_key("gui:raw_analysis:clustering_threshold")
+        assert g == "GUI"
+        assert s == "Raw Analysis"
+        assert l == "Clustering Threshold"
+
+    def test_two_part_key(self):
+        g, s, l = _parse_key("eps:timeout_ms")
+        assert g == "EPS"
+        assert s == "General"
+        assert l == "Timeout Ms"
+
+    def test_single_part_key(self):
+        g, s, l = _parse_key("standalone")
+        assert g == "General"
+        assert s == "General"
+        assert l == "Standalone"
+
+    def test_acronym_override_gui(self):
+        assert _humanize("gui") == "GUI"
+
+    def test_acronym_override_eps(self):
+        assert _humanize("eps") == "EPS"
+
+    def test_acronym_override_db(self):
+        assert _humanize("db") == "Database"
+
+    def test_humanize_snake_case(self):
+        assert _humanize("raw_analysis") == "Raw Analysis"
+
+
+# ------------------------------------------------------------------
+# TestGrouping
+# ------------------------------------------------------------------
+
+class TestGrouping:
+    def test_correct_group_names(self, vm):
+        grouped = vm.filtered_grouped_settings()
+        assert "GUI" in grouped
+        assert "EPS" in grouped
+        assert "Global" in grouped
+
+    def test_subgroup_names(self, vm):
+        grouped = vm.filtered_grouped_settings()
+        assert "Raw Analysis" in grouped["GUI"]
+        assert "Window" in grouped["GUI"]
+        assert "General" in grouped["EPS"]
+
+    def test_entry_counts(self, vm):
+        grouped = vm.filtered_grouped_settings()
+        # gui:raw_analysis has 3 keys
+        assert len(grouped["GUI"]["Raw Analysis"]) == 3
+        # gui:window has 1 key
+        assert len(grouped["GUI"]["Window"]) == 1
+        # eps has 1 key
+        assert len(grouped["EPS"]["General"]) == 1
+
+
+# ------------------------------------------------------------------
+# TestPendingChanges
+# ------------------------------------------------------------------
+
+class TestPendingChanges:
+    def test_set_pending_records_change(self, vm):
+        vm.set_pending("eps:timeout_ms", 9999)
+        assert vm.has_pending_changes is True
+
+    def test_get_current_value_prefers_pending(self, vm):
+        vm.set_pending("eps:timeout_ms", 9999)
+        assert vm.get_current_value("eps:timeout_ms") == 9999
+
+    def test_get_current_value_returns_live_without_pending(self, vm):
+        assert vm.get_current_value("eps:timeout_ms") == 5000
+
+
+# ------------------------------------------------------------------
+# TestFilter
+# ------------------------------------------------------------------
+
+class TestFilter:
+    def test_empty_filter_returns_all(self, vm):
+        vm.filter("")
+        grouped = vm.filtered_grouped_settings()
+        total = sum(
+            len(entries)
+            for subs in grouped.values()
+            for entries in subs.values()
+        )
+        assert total == len(_TEST_METADATA)
+
+    def test_match_by_key(self, vm):
+        vm.filter("timeout")
+        grouped = vm.filtered_grouped_settings()
+        total = sum(
+            len(entries)
+            for subs in grouped.values()
+            for entries in subs.values()
+        )
+        assert total == 1
+
+    def test_match_by_description(self, vm):
+        vm.filter("colormap")
+        grouped = vm.filtered_grouped_settings()
+        total = sum(
+            len(entries)
+            for subs in grouped.values()
+            for entries in subs.values()
+        )
+        assert total == 1
+
+    def test_case_insensitive(self, vm):
+        vm.filter("TIMEOUT")
+        grouped = vm.filtered_grouped_settings()
+        total = sum(
+            len(entries)
+            for subs in grouped.values()
+            for entries in subs.values()
+        )
+        assert total == 1
+
+    def test_empty_groups_pruned(self, vm):
+        vm.filter("timeout")
+        grouped = vm.filtered_grouped_settings()
+        assert "GUI" not in grouped
+        assert "EPS" in grouped
+
+
+# ------------------------------------------------------------------
+# TestApply
+# ------------------------------------------------------------------
+
+class TestApply:
+    def test_writes_to_config_service(self, config, vm):
+        vm.set_pending("eps:timeout_ms", 9999)
+        vm.apply()
+        assert config.get("eps:timeout_ms") == 9999
+
+    def test_clears_pending(self, vm):
+        vm.set_pending("eps:timeout_ms", 9999)
+        vm.apply()
+        assert vm.has_pending_changes is False
+
+    def test_refreshes_values(self, vm):
+        vm.set_pending("eps:timeout_ms", 9999)
+        vm.apply()
+        assert vm.get_current_value("eps:timeout_ms") == 9999
+
+
+# ------------------------------------------------------------------
+# TestCancel
+# ------------------------------------------------------------------
+
+class TestCancel:
+    def test_discards_pending(self, vm):
+        vm.set_pending("eps:timeout_ms", 9999)
+        vm.cancel()
+        assert vm.has_pending_changes is False
+
+    def test_no_writes(self, config, vm):
+        vm.set_pending("eps:timeout_ms", 9999)
+        vm.cancel()
+        assert config.get("eps:timeout_ms") == 5000
+        assert len(config.set_calls) == 0
+
+
+# ------------------------------------------------------------------
+# TestRestoreDefaults
+# ------------------------------------------------------------------
+
+class TestRestoreDefaults:
+    def test_calls_reset_to_defaults(self, config, vm):
+        config.set("eps:timeout_ms", 9999)
+        vm.restore_defaults()
+        assert vm.get_current_value("eps:timeout_ms") == 5000
+
+    def test_clears_pending(self, vm):
+        vm.set_pending("eps:timeout_ms", 9999)
+        vm.restore_defaults()
+        assert vm.has_pending_changes is False
+
+
+# ------------------------------------------------------------------
+# TestCallbacks
+# ------------------------------------------------------------------
+
+class TestCallbacks:
+    def test_values_changed_fires_on_apply(self, vm):
+        calls = []
+        vm.add_values_changed_callback(lambda: calls.append("v"))
+        vm.set_pending("eps:timeout_ms", 9999)
+        vm.apply()
+        assert calls == ["v"]
+
+    def test_values_changed_fires_on_restore(self, vm):
+        calls = []
+        vm.add_values_changed_callback(lambda: calls.append("v"))
+        vm.restore_defaults()
+        assert calls == ["v"]
+
+    def test_pending_changed_fires_on_set_pending(self, vm):
+        calls = []
+        vm.add_pending_changed_callback(lambda: calls.append("p"))
+        vm.set_pending("eps:timeout_ms", 9999)
+        assert calls == ["p"]
+
+    def test_pending_changed_fires_on_filter(self, vm):
+        calls = []
+        vm.add_pending_changed_callback(lambda: calls.append("p"))
+        vm.filter("timeout")
+        assert calls == ["p"]

--- a/tests/test_SettingsViewModel.py
+++ b/tests/test_SettingsViewModel.py
@@ -22,7 +22,8 @@ _TEST_METADATA: Dict[str, Dict[str, Any]] = {
         "description": "Signal-to-noise ratio for clustering.",
     },
     "gui:raw_analysis:default_colormap": {
-        "type": "str",
+        "type": "enum",
+        "choices": ["viridis", "plasma", "magma"],
         "default": "viridis",
         "description": "Initial colormap for FITS files.",
     },
@@ -165,6 +166,17 @@ class TestGrouping:
         assert len(grouped["GUI"]["Window"]) == 1
         # eps has 1 key
         assert len(grouped["EPS"]["General"]) == 1
+
+    def test_enum_choices_passed(self, vm):
+        grouped = vm.filtered_grouped_settings()
+        entries = grouped["GUI"]["Raw Analysis"]
+        
+        # Find the colormap entry
+        colormap_entry = next(e for e in entries if e[0] == "gui:raw_analysis:default_colormap")
+        
+        # entry tuple: (key, leaf, type_str, current, default, desc, choices)
+        choices = colormap_entry[6]
+        assert choices == ["viridis", "plasma", "magma"]
 
 
 # ------------------------------------------------------------------

--- a/tests/test_YAMLBackedConfigurationService.py
+++ b/tests/test_YAMLBackedConfigurationService.py
@@ -197,6 +197,31 @@ class TestGetMetadata:
 
 
 # ------------------------------------------------------------------
+# reset_to_defaults()
+# ------------------------------------------------------------------
+
+class TestResetToDefaults:
+    def test_reset_restores_all_defaults(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        # Trigger lazy load then override a key
+        svc.get("gui:raw_analysis:default_colormap")
+        svc.set("gui:raw_analysis:default_colormap", "plasma")
+        assert svc.get("gui:raw_analysis:default_colormap") == "plasma"
+
+        svc.reset_to_defaults()
+        assert svc.get("gui:raw_analysis:default_colormap") == "viridis"
+
+    def test_reset_persists_to_disk(self, tmp_path):
+        svc, path = _make_service(tmp_path)
+        svc.get("eps:timeout_ms")
+        svc.set("eps:timeout_ms", 9999)
+        svc.reset_to_defaults()
+
+        data = _read_yaml(path)
+        assert data["eps:timeout_ms"] == 5000
+
+
+# ------------------------------------------------------------------
 # Thread safety
 # ------------------------------------------------------------------
 

--- a/tests/test_YAMLBackedConfigurationService.py
+++ b/tests/test_YAMLBackedConfigurationService.py
@@ -101,6 +101,28 @@ class TestTypeCoercion:
         svc, _ = _make_service(tmp_path, initial={"name": "viridis"})
         assert svc.get("name") == "viridis"
 
+    def test_custom_types_coerced_as_strings(self, tmp_path):
+        svc, _ = _make_service(tmp_path, initial={"dir": "~/data", "file": "data.csv", "mode": "live"})
+        # Manually register the custom types
+        svc._type_registry["dir"] = "directory_path"
+        svc._type_registry["file"] = "file_path"
+        svc._type_registry["mode"] = "enum"
+        
+        # Test they load their current values ok
+        assert svc.get("dir") == "~/data"
+        assert svc.get("file") == "data.csv"
+        assert svc.get("mode") == "live"
+        
+        # Test they coerce non-string values correctly through set() + get()
+        svc.set("dir", 1234)
+        assert svc.get("dir") == "1234"
+        
+        svc.set("file", 5678)
+        assert svc.get("file") == "5678"
+        
+        svc.set("mode", 1)
+        assert svc.get("mode") == "1"
+
     def test_yaml_native_types_without_registry(self, tmp_path):
         """Values loaded from YAML that have no registry entry
         should pass through unchanged."""


### PR DESCRIPTION
Introduces a new graphical interface for managing application configuration, providing users with a dedicated panel to tune runtime parameters.

- Added a `SettingsDialog` accessible via the File menu in `MainWindow` (with cross-platform shortcut support).
- Implemented `SettingsViewModel` to manage configuration state, handle uncommitted pending edits, and support text filtering without depending on Qt components.
- Automatically groups configuration keys based on their namespaces with human-readable labels.
- Provided type-dispatched input widgets (e.g., `QSpinBox`, `QDoubleSpinBox`, `QLineEdit`, `QCheckBox`, `QComboBox`) based on configuration metadata.
- Implemented "Apply", "Cancel", and "Restore Defaults" workflows.
- Extended `ConfigurationService` contract and `YAMLBackedConfigurationService` implementation with `reset_to_defaults` and `get_metadata` methods.
- Added comprehensive unit tests for `SettingsViewModel` and expanded `YAMLBackedConfigurationService` coverage.

## User Interface

https://github.com/user-attachments/assets/57c74a13-7076-4c13-8b9b-4a7aee6ea99c

Closes #37