### PR TITLE
feat: Add global status bar with logging/progress

### DIFF
--- a/src/le_beta_vis/backend/EPSRunner.py
+++ b/src/le_beta_vis/backend/EPSRunner.py
@@ -4,16 +4,25 @@ from typing import Optional
 from .EventPersistenceService import EventPersistence
 from .InitializePolling import PollingThread
 from le_beta_vis.common.YAMLBackedConfigurationService import YAMLBackedConfigurationService
+from le_beta_vis.common.ZMQEventHandlerClient import DEFAULT_EVENT_PUB_ENDPOINT
+from le_beta_vis.common.ZMQEventLoggingHandler import attach_to_root_logger
 import zmq
 
 logger = logging.getLogger(__name__)
 
+
 class EPSRunner:
     """Initializes the EventPersistenceService and maintains thread execution."""
+
     def __init__(self):
         self.thread: Optional[threading.Thread] = None
         self.running = False
         self.config = YAMLBackedConfigurationService()
+        self._log_handler = attach_to_root_logger(
+            endpoint=self.config.get("event_handler:zmq_pub_endpoint")
+            or DEFAULT_EVENT_PUB_ENDPOINT,
+            source="eps",
+        )
 
     def start(self):
         """Starts the EPS in a daemon thread, checks if already running and calls run on EPS."""
@@ -38,6 +47,7 @@ class EPSRunner:
 
     def stop(self):
         """Kills EPS by sending Kill to EPS command endpoint."""
+        logging.root.removeHandler(self._log_handler)
         try:
             context = zmq.Context()
             command_socket = context.socket(zmq.REQ)
@@ -46,7 +56,7 @@ class EPSRunner:
             command_socket.send_json({"Command": "Kill"})
             try:
                 command_socket.recv_json()
-            except:
+            except BaseException:
                 logger.warning("EPS did not respond to kill command.")
             command_socket.close()
             context.term()
@@ -58,5 +68,5 @@ class EPSRunner:
 
     def is_running(self):
         """Checks if EPS service is running."""
-        # If running and thread is alive, it counts as the EPS running. 
+        # If running and thread is alive, it counts as the EPS running.
         return self.running and self.thread.is_alive()

--- a/src/le_beta_vis/backend/EventPersistenceService.py
+++ b/src/le_beta_vis/backend/EventPersistenceService.py
@@ -1,3 +1,4 @@
+from le_beta_vis.common.ZMQEventHandlerClient import DEFAULT_EVENT_PUB_ENDPOINT
 import mysql.connector
 from le_beta_vis.common.YAMLBackedConfigurationService import (
     YAMLBackedConfigurationService,
@@ -9,7 +10,9 @@ import logging
 from datetime import datetime
 from typing import Optional, Tuple
 
+
 logger = logging.getLogger(__name__)
+
 
 _DATE_FILTER_FORMAT = "%Y-%m-%d %H:%M:%S"
 

--- a/src/le_beta_vis/common/ZMQEventHandlerClient.py
+++ b/src/le_beta_vis/common/ZMQEventHandlerClient.py
@@ -30,6 +30,16 @@ from .EventHandlerClient import EventHandlerClient
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_EVENT_PUB_ENDPOINT = "ipc:///tmp/EPCEvents.ipc"
+"""Default ZMQ endpoint for the EventHandler publish/subscribe bus.
+
+Both backend producers (:class:`ZMQEventHandlerClient` with ``bind``)
+and the frontend consumer (:class:`~le_beta_vis.common.ZMQEventHandlerSource`)
+use this endpoint when no override is present in the configuration
+(``event_handler:zmq_pub_endpoint``).  Import this constant instead of
+repeating the literal so a future path change is a one-line update.
+"""
+
 _DEFAULT_LINGER_MS = 0
 _DEFAULT_SNDHWM = 10_000
 """High-water mark for outbound messages on the PUB socket.  ZMQ

--- a/src/le_beta_vis/common/ZMQEventLoggingHandler.py
+++ b/src/le_beta_vis/common/ZMQEventLoggingHandler.py
@@ -16,7 +16,7 @@ a log record, which would be forwarded through the same
 """
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from .EventEnvelope import EventEnvelope
 from .EventHandlerClient import EventHandlerClient
@@ -93,3 +93,69 @@ class ZMQEventLoggingHandler(logging.Handler):
             "created": record.created,
             "exc_text": exc_text,
         }
+
+
+def attach_to_root_logger(
+    endpoint: str,
+    source: str,
+    level: int = logging.WARNING,
+    bind_or_connect: Literal["bind", "connect"] = "bind",
+) -> "ZMQEventLoggingHandler":
+    """Create a :class:`ZMQEventLoggingHandler` and attach it to the root logger.
+
+    This is the one-call setup for any backend service that wants its log
+    records forwarded to the frontend status bar over the EventHandler bus.
+    It creates a :class:`~le_beta_vis.common.ZMQEventHandlerClient` (a ZMQ
+    PUB socket), wraps it in a :class:`ZMQEventLoggingHandler`, registers
+    the handler on ``logging.root``, and returns the handler so the caller
+    can remove it on shutdown.
+
+    Args:
+        endpoint: ZMQ endpoint the PUB socket will bind or connect to.
+            Must match the ``event_handler:zmq_pub_endpoint`` config key
+            used by the frontend's ``ZMQEventHandlerSource``
+            (default :data:`~le_beta_vis.common.ZMQEventHandlerClient.DEFAULT_EVENT_PUB_ENDPOINT`).
+        source: Free-form identifier stored in every envelope's ``source``
+            field, e.g. ``"eps"`` or ``"classifier"``.  Appears in the
+            frontend log view so operators know which service emitted the
+            message.
+        level: Minimum :mod:`logging` level to forward.  Defaults to
+            ``logging.WARNING`` — enough to surface actionable problems
+            without flooding the bus with routine info records.
+            Pass ``logging.INFO`` if info-level progress messages should
+            also appear in the status bar.
+        bind_or_connect: Whether the PUB socket **binds** the endpoint
+            (``"bind"``, the default) or **connects** to an existing one
+            (``"connect"``).  Backend services that own the IPC path should
+            use ``"bind"``; a secondary producer joining an existing broker
+            proxy should use ``"connect"``.
+
+    Returns:
+        The :class:`ZMQEventLoggingHandler` that was added to the root
+        logger.  Keep a reference and pass it to
+        ``logging.root.removeHandler(handler)`` during graceful shutdown to
+        avoid dangling sockets.
+
+    Example::
+
+        # In a backend service __init__, after loading config:
+        self._log_handler = attach_to_root_logger(
+            endpoint=self.config.get("event_handler:zmq_pub_endpoint")
+                     or DEFAULT_EVENT_PUB_ENDPOINT,
+            source="eps",
+        )
+
+        # On shutdown:
+        logging.root.removeHandler(self._log_handler)
+    """
+    # Import here to avoid a circular dependency at module load time:
+    # ZMQEventHandlerClient → zmq → (potentially) logging.
+    from .ZMQEventHandlerClient import ZMQEventHandlerClient, DEFAULT_EVENT_PUB_ENDPOINT
+
+    client = ZMQEventHandlerClient(
+        endpoint=endpoint,
+        bind_or_connect=bind_or_connect,
+    )
+    handler = ZMQEventLoggingHandler(client, source=source, level=level)
+    logging.root.addHandler(handler)
+    return handler

--- a/src/le_beta_vis/config/defaults.yaml
+++ b/src/le_beta_vis/config/defaults.yaml
@@ -207,6 +207,14 @@ gui:window:default_height:
   description: >-
     Default initial height of the application window.
 
+gui:window:status_bar_clear_timeout_s:
+  type: int
+  default: 5
+  description: >-
+    Seconds after which a stale status-bar message is automatically
+    cleared. Set to 0 to disable auto-clear. Active progress
+    indicators are unaffected.
+
 # ---------------------------------------------------------------------------
 # GUI — Mosaic
 # ---------------------------------------------------------------------------

--- a/src/le_beta_vis/frontend/MainWindow.py
+++ b/src/le_beta_vis/frontend/MainWindow.py
@@ -1,22 +1,35 @@
 import sys
 
+from PySide6.QtCore import Qt, QMetaObject, Slot
 from PySide6.QtWidgets import (
     QMainWindow,
     QTabWidget,
     QWidget,
     QVBoxLayout,
+    QHBoxLayout,
     QFileDialog,
+    QLabel,
+    QProgressBar,
+    QToolButton,
 )
 from PySide6.QtGui import QAction, QIcon, QKeySequence
 from .viewmodels.MainViewModel import MainViewModel
+from .viewmodels.MainWindowStatusViewModel import (
+    MainWindowStatusViewModel,
+    Severity,
+)
 from .views.RawDataView import RawDataView
 from .views.HistoricalView import HistoricalView
 from .viewmodels.RawDataViewModel import RawDataViewModel
 from .viewmodels.HistoricalViewModel import HistoricalViewModel
+from . import theme
 from le_beta_vis.common.ClusterExtractorFactory import (
     create_cluster_extractor,
 )
 from pathlib import Path
+
+
+_MAX_VISIBLE_PROGRESS_ROWS = 3
 
 
 class MainWindow(QMainWindow):
@@ -29,6 +42,12 @@ class MainWindow(QMainWindow):
         self._setupViewModels()
         self._setupViews()
         self.setupMenuBar()
+        self._setupStatusBar()
+
+    def closeEvent(self, event) -> None:  # noqa: N802 - Qt override
+        if hasattr(self, "statusViewModel"):
+            self.statusViewModel.shutdown()
+        super().closeEvent(event)
 
     # -- Initialization helpers ------------------------------------------------
 
@@ -70,6 +89,125 @@ class MainWindow(QMainWindow):
             self.viewModel.eventRepository,
             self.viewModel.thumbnailService,
         )
+
+    def _setupStatusBar(self) -> None:
+        timeout = self.viewModel.configService.get(
+            "gui:window:status_bar_clear_timeout_s", 5
+        )
+        self.statusViewModel = MainWindowStatusViewModel(
+            self.viewModel.eventHandler,
+            clear_timeout_s=float(timeout),
+        )
+
+        statusBar = self.statusBar()
+        self._statusMessageLabel = QLabel("", statusBar)
+        self._statusMessageLabel.setObjectName("mainWindowStatusMessage")
+        statusBar.addWidget(self._statusMessageLabel, 1)
+
+        self._progressHost = QWidget(statusBar)
+        self._progressHostLayout = QHBoxLayout(self._progressHost)
+        self._progressHostLayout.setContentsMargins(0, 0, 0, 0)
+        self._progressHostLayout.setSpacing(8)
+        statusBar.addPermanentWidget(self._progressHost)
+
+        self.statusViewModel.add_message_changed_callback(
+            lambda: QMetaObject.invokeMethod(
+                self, "_onStatusMessageChanged", Qt.AutoConnection
+            )
+        )
+        self.statusViewModel.add_progress_changed_callback(
+            lambda: QMetaObject.invokeMethod(
+                self, "_onStatusProgressChanged", Qt.AutoConnection
+            )
+        )
+        self._onStatusMessageChanged()
+        self._onStatusProgressChanged()
+
+    @Slot()
+    def _onStatusMessageChanged(self) -> None:
+        message = self.statusViewModel.message
+        severity = self.statusViewModel.severity
+        self._statusMessageLabel.setText(message)
+        color = {
+            Severity.INFO: theme.MainWindowStatusBarColors.TEXT_INFO,
+            Severity.WARNING: theme.MainWindowStatusBarColors.TEXT_WARNING,
+            Severity.ERROR: theme.MainWindowStatusBarColors.TEXT_ERROR,
+        }.get(severity, theme.MainWindowStatusBarColors.TEXT_INFO)
+        self._statusMessageLabel.setStyleSheet(f"color: {color};")
+
+    @Slot()
+    def _onStatusProgressChanged(self) -> None:
+        while self._progressHostLayout.count():
+            item = self._progressHostLayout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+        snapshots = self.statusViewModel.active_progress
+        visible = snapshots[:_MAX_VISIBLE_PROGRESS_ROWS]
+        overflow = snapshots[_MAX_VISIBLE_PROGRESS_ROWS:]
+
+        for snap in visible:
+            self._progressHostLayout.addWidget(self._buildProgressRow(snap))
+
+        if overflow:
+            more = QLabel(
+                self.tr("+{n} more").format(n=len(overflow)),
+                self._progressHost,
+            )
+            more.setStyleSheet(
+                f"color: {theme.MainWindowStatusBarColors.PROGRESS_LABEL};"
+            )
+            more.setToolTip("\n".join(s.label for s in overflow))
+            self._progressHostLayout.addWidget(more)
+
+    def _buildProgressRow(self, snap) -> QWidget:
+        row = QWidget(self._progressHost)
+        layout = QHBoxLayout(row)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        label = QLabel(snap.label, row)
+        label.setStyleSheet(
+            f"color: {theme.MainWindowStatusBarColors.PROGRESS_LABEL};"
+        )
+        layout.addWidget(label)
+
+        if snap.message:
+            sub = QLabel(f"— {snap.message}", row)
+            sub.setStyleSheet(
+                f"color: {theme.MainWindowStatusBarColors.PROGRESS_LABEL};"
+            )
+            layout.addWidget(sub)
+
+        bar = QProgressBar(row)
+        bar.setFixedWidth(120)
+        bar.setTextVisible(False)
+        if snap.fraction < 0.0:
+            bar.setRange(0, 0)
+        else:
+            bar.setRange(0, 1000)
+            bar.setValue(int(max(0.0, min(1.0, snap.fraction)) * 1000))
+        bar.setStyleSheet(
+            "QProgressBar {{ background: {bg}; border: none; }}"
+            "QProgressBar::chunk {{ background: {chunk}; }}".format(
+                bg=theme.MainWindowStatusBarColors.PROGRESS_BACKGROUND,
+                chunk=theme.MainWindowStatusBarColors.PROGRESS_CHUNK,
+            )
+        )
+        layout.addWidget(bar)
+
+        if snap.cancelable:
+            cancel = QToolButton(row)
+            cancel.setText(self.tr("✕"))
+            cancel.setToolTip(self.tr("Cancel"))
+            token = snap.token
+            cancel.clicked.connect(
+                lambda _=False, t=token: self.statusViewModel.request_cancel(t)
+            )
+            layout.addWidget(cancel)
+
+        return row
 
     def _setupViews(self) -> None:
         self.rawDataView = RawDataView(self.rawDataViewModel)

--- a/src/le_beta_vis/frontend/theme.py
+++ b/src/le_beta_vis/frontend/theme.py
@@ -49,6 +49,17 @@ class LiveModeColors:
     TITLE_TEXT = "#ffffff"
 
 
+class MainWindowStatusBarColors:
+    """Colors for the global MainWindow QStatusBar."""
+
+    TEXT_INFO = "#d0d0d0"
+    TEXT_WARNING = "#f0b000"
+    TEXT_ERROR = "#ff5a5a"
+    PROGRESS_LABEL = "#bbbbbb"
+    PROGRESS_CHUNK = "#3daee9"
+    PROGRESS_BACKGROUND = "rgba(0, 0, 0, 40)"
+
+
 class TooltipStyle:
     """Shared QToolTip stylesheet snippets.
 

--- a/src/le_beta_vis/frontend/viewmodels/MainViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/MainViewModel.py
@@ -14,14 +14,12 @@ from le_beta_vis.common.YAMLBackedConfigurationService import (
     YAMLBackedConfigurationService,
 )
 from le_beta_vis.common.ZMQBasedEventRepository import ZMQBasedEventRepository
+from le_beta_vis.common.ZMQEventHandlerClient import DEFAULT_EVENT_PUB_ENDPOINT
 from le_beta_vis.common.ZMQEventHandlerSource import ZMQEventHandlerSource
 from le_beta_vis.frontend.fitsconverters.interface import Colormap
 
 
 logger = logging.getLogger(__name__)
-
-
-_DEFAULT_EVENT_PUB_ENDPOINT = "ipc:///tmp/EPCEvents.ipc"
 
 
 class MainViewModel(QObject):
@@ -61,7 +59,7 @@ class MainViewModel(QObject):
         endpoint = str(
             self.configService.get(
                 "event_handler:zmq_pub_endpoint",
-                _DEFAULT_EVENT_PUB_ENDPOINT,
+                DEFAULT_EVENT_PUB_ENDPOINT,
             )
         )
         return ZMQEventHandlerSource(

--- a/src/le_beta_vis/frontend/viewmodels/MainWindowStatusViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/MainWindowStatusViewModel.py
@@ -1,0 +1,337 @@
+"""Pure-Python ViewModel for the global MainWindow status bar.
+
+Subscribes to ``EventHandler`` log events (``log.info``,
+``log.warning``, ``log.error``, ``log.critical``) and renders them
+as severity-tagged messages in a native ``QStatusBar``. Also exposes
+a small multi-token progress API so arbitrary long-running operations
+(export, classification, prefetch) can surface progress without each
+spinning up a modal dialog.
+
+Pure Python — no Qt imports. Tested headlessly.
+"""
+
+from __future__ import annotations
+
+import enum
+import threading
+import uuid
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+from le_beta_vis.common.EventEnvelope import EventEnvelope
+from le_beta_vis.common.EventHandlerInterface import EventHandlerInterface
+
+
+class Severity(enum.Enum):
+    """Severity tiers used to style the status bar message."""
+
+    NONE = "none"
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+_EVENT_SEVERITY: Dict[str, Severity] = {
+    "log.info": Severity.INFO,
+    "log.warning": Severity.WARNING,
+    "log.error": Severity.ERROR,
+    "log.critical": Severity.ERROR,
+}
+
+
+@dataclass(frozen=True)
+class ProgressSnapshot:
+    """Immutable snapshot of one in-flight progress operation.
+
+    Attributes:
+        token: Opaque identifier returned by ``begin_progress``.
+        label: Human-readable label, e.g. ``"Exporting report"``.
+        fraction: Completion in ``[0.0, 1.0]``. A negative value
+            signals indeterminate progress (spinner).
+        message: Optional sub-status for the current step.
+        cancelable: Whether a cancel affordance should be offered.
+    """
+
+    token: str
+    label: str
+    fraction: float
+    message: Optional[str]
+    cancelable: bool
+
+
+@dataclass
+class _ProgressState:
+    label: str
+    fraction: float
+    message: Optional[str]
+    cancelable: bool
+    cancel_callbacks: List[Callable[[], None]] = field(default_factory=list)
+
+
+class MainWindowStatusViewModel:
+    """ViewModel for the global MainWindow status bar.
+
+    Args:
+        event_handler: The application's shared ``EventHandler``.
+        clear_timeout_s: Seconds after which a stale message is
+            auto-cleared. ``0`` (or negative) disables auto-clear.
+    """
+
+    def __init__(
+        self,
+        event_handler: EventHandlerInterface,
+        clear_timeout_s: float = 5.0,
+    ) -> None:
+        self._event_handler = event_handler
+        self._clear_timeout_s = max(0.0, float(clear_timeout_s))
+
+        self._lock = threading.Lock()
+        self._message: str = ""
+        self._severity: Severity = Severity.NONE
+        self._progress: Dict[str, _ProgressState] = {}
+        self._clear_timer: Optional[threading.Timer] = None
+
+        self._on_message_changed: List[Callable[[], None]] = []
+        self._on_progress_changed: List[Callable[[], None]] = []
+
+        self._subscription_ids: List[str] = []
+        for event_name in _EVENT_SEVERITY:
+            self._subscription_ids.append(
+                event_handler.register_callback(
+                    event_name, self._on_log_event
+                )
+            )
+
+    # ------------------------------------------------------------------
+    # Observed state
+    # ------------------------------------------------------------------
+
+    @property
+    def message(self) -> str:
+        """The current status bar message (empty when none)."""
+        with self._lock:
+            return self._message
+
+    @property
+    def severity(self) -> Severity:
+        """The severity of the current message."""
+        with self._lock:
+            return self._severity
+
+    @property
+    def active_progress(self) -> List[ProgressSnapshot]:
+        """Immutable snapshots of all active progress operations."""
+        with self._lock:
+            return [
+                ProgressSnapshot(
+                    token=token,
+                    label=state.label,
+                    fraction=state.fraction,
+                    message=state.message,
+                    cancelable=state.cancelable,
+                )
+                for token, state in self._progress.items()
+            ]
+
+    @property
+    def clear_timeout_s(self) -> float:
+        """The configured stale-message clear timeout, in seconds."""
+        return self._clear_timeout_s
+
+    # ------------------------------------------------------------------
+    # Callback registration
+    # ------------------------------------------------------------------
+
+    def add_message_changed_callback(
+        self, cb: Callable[[], None]
+    ) -> None:
+        """Register a callback fired when the message or severity changes."""
+        self._on_message_changed.append(cb)
+
+    def add_progress_changed_callback(
+        self, cb: Callable[[], None]
+    ) -> None:
+        """Register a callback fired when any progress state changes."""
+        self._on_progress_changed.append(cb)
+
+    # ------------------------------------------------------------------
+    # Message API
+    # ------------------------------------------------------------------
+
+    def set_message(self, text: str, severity: Severity = Severity.INFO) -> None:
+        """Set the current status bar message.
+
+        Args:
+            text: Message body. Empty string clears the bar.
+            severity: Severity tier used for styling. Ignored when
+                ``text`` is empty (severity forced to ``NONE``).
+        """
+        with self._lock:
+            self._message = text
+            self._severity = severity if text else Severity.NONE
+            self._reschedule_clear_locked()
+        self._notify_message_changed()
+
+    def clear_message(self) -> None:
+        """Clear the current status bar message immediately."""
+        with self._lock:
+            if not self._message and self._severity is Severity.NONE:
+                return
+            self._message = ""
+            self._severity = Severity.NONE
+            self._cancel_clear_timer_locked()
+        self._notify_message_changed()
+
+    # ------------------------------------------------------------------
+    # Progress API (callable from any thread)
+    # ------------------------------------------------------------------
+
+    def begin_progress(
+        self, label: str, cancelable: bool = False
+    ) -> str:
+        """Start tracking a new progress operation.
+
+        Args:
+            label: Human-readable label for the operation.
+            cancelable: Whether the View should render a cancel
+                affordance for this operation.
+
+        Returns:
+            An opaque token to pass to ``update_progress`` /
+            ``end_progress`` / ``request_cancel``.
+        """
+        token = uuid.uuid4().hex
+        with self._lock:
+            self._progress[token] = _ProgressState(
+                label=label,
+                fraction=-1.0,
+                message=None,
+                cancelable=cancelable,
+            )
+        self._notify_progress_changed()
+        return token
+
+    def update_progress(
+        self,
+        token: str,
+        fraction: float,
+        message: Optional[str] = None,
+    ) -> None:
+        """Update an in-flight progress operation.
+
+        A negative ``fraction`` marks indeterminate progress.
+        Unknown tokens are silently ignored.
+        """
+        with self._lock:
+            state = self._progress.get(token)
+            if state is None:
+                return
+            state.fraction = float(fraction)
+            if message is not None:
+                state.message = message
+        self._notify_progress_changed()
+
+    def end_progress(self, token: str) -> None:
+        """Remove a progress operation. Unknown tokens are ignored."""
+        with self._lock:
+            if self._progress.pop(token, None) is None:
+                return
+        self._notify_progress_changed()
+
+    def add_cancel_callback(
+        self, token: str, cb: Callable[[], None]
+    ) -> None:
+        """Register a cancel callback for a cancelable progress token.
+
+        Silently ignored if the token is unknown or not cancelable.
+        """
+        with self._lock:
+            state = self._progress.get(token)
+            if state is None or not state.cancelable:
+                return
+            state.cancel_callbacks.append(cb)
+
+    def request_cancel(self, token: str) -> None:
+        """Fire cancel callbacks for ``token`` (no-op if not cancelable)."""
+        with self._lock:
+            state = self._progress.get(token)
+            if state is None or not state.cancelable:
+                return
+            callbacks = list(state.cancel_callbacks)
+        for cb in callbacks:
+            try:
+                cb()
+            except Exception:
+                # A misbehaving consumer must not take the bar down.
+                pass
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def shutdown(self) -> None:
+        """Cancel timers and unregister from the EventHandler."""
+        with self._lock:
+            self._cancel_clear_timer_locked()
+        for cb_id in self._subscription_ids:
+            try:
+                self._event_handler.unregister(cb_id)
+            except Exception:
+                pass
+        self._subscription_ids.clear()
+
+    # ------------------------------------------------------------------
+    # Internal — event routing
+    # ------------------------------------------------------------------
+
+    def _on_log_event(self, envelope: EventEnvelope) -> None:
+        severity = _EVENT_SEVERITY.get(envelope.name)
+        if severity is None:
+            return
+        message = str(envelope.payload.get("message", "")).strip()
+        if not message:
+            return
+        self.set_message(message, severity)
+
+    # ------------------------------------------------------------------
+    # Internal — notification + auto-clear timer
+    # ------------------------------------------------------------------
+
+    def _notify_message_changed(self) -> None:
+        for cb in list(self._on_message_changed):
+            try:
+                cb()
+            except Exception:
+                pass
+
+    def _notify_progress_changed(self) -> None:
+        for cb in list(self._on_progress_changed):
+            try:
+                cb()
+            except Exception:
+                pass
+
+    def _reschedule_clear_locked(self) -> None:
+        self._cancel_clear_timer_locked()
+        if self._clear_timeout_s <= 0.0 or not self._message:
+            return
+        timer = threading.Timer(
+            self._clear_timeout_s, self._on_clear_timer_fired
+        )
+        timer.daemon = True
+        self._clear_timer = timer
+        timer.start()
+
+    def _cancel_clear_timer_locked(self) -> None:
+        if self._clear_timer is not None:
+            self._clear_timer.cancel()
+            self._clear_timer = None
+
+    def _on_clear_timer_fired(self) -> None:
+        with self._lock:
+            self._clear_timer = None
+            if not self._message:
+                return
+            self._message = ""
+            self._severity = Severity.NONE
+        self._notify_message_changed()

--- a/tests/test_MainWindowStatusViewModel.py
+++ b/tests/test_MainWindowStatusViewModel.py
@@ -1,0 +1,310 @@
+"""Tests for MainWindowStatusViewModel — pure Python, no QApplication."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Dict, List
+
+import pytest
+
+from le_beta_vis.common.EventEnvelope import EventEnvelope
+from le_beta_vis.common.EventHandlerInterface import (
+    EventCallback,
+    EventHandlerInterface,
+)
+from le_beta_vis.frontend.viewmodels.MainWindowStatusViewModel import (
+    MainWindowStatusViewModel,
+    Severity,
+)
+
+
+# ------------------------------------------------------------------
+# Fake EventHandler that invokes callbacks synchronously
+# ------------------------------------------------------------------
+
+
+class _FakeEventHandler(EventHandlerInterface):
+    """In-process stand-in for EventHandler. Dispatch is synchronous."""
+
+    def __init__(self) -> None:
+        self._cbs: Dict[str, Dict[str, EventCallback]] = {}
+        self._next_id = 0
+
+    def register_callback(
+        self, event_name: str, callback: EventCallback
+    ) -> str:
+        self._next_id += 1
+        cb_id = f"cb-{self._next_id}"
+        self._cbs.setdefault(event_name, {})[cb_id] = callback
+        return cb_id
+
+    def register_batch_callback(self, event_name, callback):  # noqa: D401
+        raise NotImplementedError
+
+    def unregister(self, callback_id: str) -> bool:
+        for bucket in self._cbs.values():
+            if callback_id in bucket:
+                del bucket[callback_id]
+                return True
+        return False
+
+    def unregister_all(self, event_name: str) -> int:
+        bucket = self._cbs.pop(event_name, {})
+        return len(bucket)
+
+    def dispatch(self, envelope: EventEnvelope) -> None:
+        for cb in list(self._cbs.get(envelope.name, {}).values()):
+            cb(envelope)
+
+    def shutdown(self, timeout_ms: int = 2000) -> None:
+        self._cbs.clear()
+
+
+@pytest.fixture
+def handler() -> _FakeEventHandler:
+    return _FakeEventHandler()
+
+
+@pytest.fixture
+def vm(handler: _FakeEventHandler) -> MainWindowStatusViewModel:
+    model = MainWindowStatusViewModel(handler, clear_timeout_s=0)
+    yield model
+    model.shutdown()
+
+
+def _wait_until(
+    predicate: Callable[[], bool], timeout: float = 1.0
+) -> None:
+    """Poll ``predicate`` until true or timeout expires."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.005)
+    raise AssertionError("predicate never became true")
+
+
+# ------------------------------------------------------------------
+# Event routing
+# ------------------------------------------------------------------
+
+
+class TestEventRouting:
+    @pytest.mark.parametrize(
+        ("event_name", "expected"),
+        [
+            ("log.info", Severity.INFO),
+            ("log.warning", Severity.WARNING),
+            ("log.error", Severity.ERROR),
+            ("log.critical", Severity.ERROR),
+        ],
+    )
+    def test_log_events_set_message_and_severity(
+        self,
+        handler: _FakeEventHandler,
+        vm: MainWindowStatusViewModel,
+        event_name: str,
+        expected: Severity,
+    ) -> None:
+        calls: List[None] = []
+        vm.add_message_changed_callback(lambda: calls.append(None))
+
+        handler.dispatch(
+            EventEnvelope(
+                name=event_name,
+                payload={"message": "hello world", "level": "INFO"},
+            )
+        )
+
+        assert vm.message == "hello world"
+        assert vm.severity is expected
+        assert len(calls) == 1
+
+    def test_log_debug_is_ignored(
+        self,
+        handler: _FakeEventHandler,
+        vm: MainWindowStatusViewModel,
+    ) -> None:
+        calls: List[None] = []
+        vm.add_message_changed_callback(lambda: calls.append(None))
+
+        handler.dispatch(
+            EventEnvelope(
+                name="log.debug",
+                payload={"message": "noisy", "level": "DEBUG"},
+            )
+        )
+
+        assert vm.message == ""
+        assert vm.severity is Severity.NONE
+        assert calls == []
+
+    def test_empty_message_is_ignored(
+        self,
+        handler: _FakeEventHandler,
+        vm: MainWindowStatusViewModel,
+    ) -> None:
+        handler.dispatch(
+            EventEnvelope(name="log.info", payload={"message": "   "})
+        )
+        assert vm.message == ""
+
+    def test_shutdown_unregisters_subscriptions(
+        self,
+        handler: _FakeEventHandler,
+    ) -> None:
+        model = MainWindowStatusViewModel(handler, clear_timeout_s=0)
+        model.shutdown()
+
+        handler.dispatch(
+            EventEnvelope(name="log.info", payload={"message": "late"})
+        )
+
+        assert model.message == ""
+
+
+# ------------------------------------------------------------------
+# Direct message API
+# ------------------------------------------------------------------
+
+
+class TestSetMessage:
+    def test_clear_message_resets_severity(
+        self, vm: MainWindowStatusViewModel
+    ) -> None:
+        vm.set_message("boom", Severity.ERROR)
+        vm.clear_message()
+        assert vm.message == ""
+        assert vm.severity is Severity.NONE
+
+    def test_empty_text_forces_none_severity(
+        self, vm: MainWindowStatusViewModel
+    ) -> None:
+        vm.set_message("", Severity.ERROR)
+        assert vm.severity is Severity.NONE
+
+
+# ------------------------------------------------------------------
+# Progress lifecycle
+# ------------------------------------------------------------------
+
+
+class TestProgressLifecycle:
+    def test_begin_returns_unique_tokens(
+        self, vm: MainWindowStatusViewModel
+    ) -> None:
+        a = vm.begin_progress("Exporting A")
+        b = vm.begin_progress("Exporting B")
+        assert a != b
+        tokens = {snap.token for snap in vm.active_progress}
+        assert tokens == {a, b}
+
+    def test_update_unknown_token_is_noop(
+        self, vm: MainWindowStatusViewModel
+    ) -> None:
+        vm.update_progress("does-not-exist", 0.5, "step")
+        assert vm.active_progress == []
+
+    def test_update_mutates_existing_snapshot(
+        self, vm: MainWindowStatusViewModel
+    ) -> None:
+        token = vm.begin_progress("Classifying")
+        vm.update_progress(token, 0.42, message="frame 7")
+        snap = next(s for s in vm.active_progress if s.token == token)
+        assert snap.fraction == pytest.approx(0.42)
+        assert snap.message == "frame 7"
+
+    def test_end_removes_token(
+        self, vm: MainWindowStatusViewModel
+    ) -> None:
+        token = vm.begin_progress("Prefetching")
+        vm.end_progress(token)
+        assert vm.active_progress == []
+
+    def test_end_unknown_token_is_noop(
+        self, vm: MainWindowStatusViewModel
+    ) -> None:
+        vm.end_progress("nope")  # must not raise
+
+    def test_progress_callback_fires(
+        self, vm: MainWindowStatusViewModel
+    ) -> None:
+        calls: List[None] = []
+        vm.add_progress_changed_callback(lambda: calls.append(None))
+        token = vm.begin_progress("x")
+        vm.update_progress(token, 0.5)
+        vm.end_progress(token)
+        assert len(calls) == 3
+
+
+# ------------------------------------------------------------------
+# Cancel
+# ------------------------------------------------------------------
+
+
+class TestCancel:
+    def test_cancel_fires_registered_callbacks(
+        self, vm: MainWindowStatusViewModel
+    ) -> None:
+        token = vm.begin_progress("Exporting", cancelable=True)
+        fired: List[None] = []
+        vm.add_cancel_callback(token, lambda: fired.append(None))
+        vm.request_cancel(token)
+        assert len(fired) == 1
+
+    def test_cancel_noncancelable_ignored(
+        self, vm: MainWindowStatusViewModel
+    ) -> None:
+        token = vm.begin_progress("Classifying", cancelable=False)
+        fired: List[None] = []
+        vm.add_cancel_callback(token, lambda: fired.append(None))
+        vm.request_cancel(token)
+        assert fired == []
+
+    def test_cancel_unknown_token_is_noop(
+        self, vm: MainWindowStatusViewModel
+    ) -> None:
+        vm.request_cancel("missing")
+
+
+# ------------------------------------------------------------------
+# Auto-clear timer
+# ------------------------------------------------------------------
+
+
+class TestAutoClear:
+    def test_timeout_clears_message(
+        self, handler: _FakeEventHandler
+    ) -> None:
+        model = MainWindowStatusViewModel(handler, clear_timeout_s=0.05)
+        try:
+            model.set_message("stale", Severity.INFO)
+            _wait_until(lambda: model.message == "", timeout=1.0)
+            assert model.severity is Severity.NONE
+        finally:
+            model.shutdown()
+
+    def test_zero_timeout_disables_autoclear(
+        self, handler: _FakeEventHandler
+    ) -> None:
+        model = MainWindowStatusViewModel(handler, clear_timeout_s=0)
+        try:
+            model.set_message("persist", Severity.INFO)
+            time.sleep(0.1)
+            assert model.message == "persist"
+        finally:
+            model.shutdown()
+
+    def test_new_message_resets_timer(
+        self, handler: _FakeEventHandler
+    ) -> None:
+        model = MainWindowStatusViewModel(handler, clear_timeout_s=0.1)
+        try:
+            model.set_message("first", Severity.INFO)
+            time.sleep(0.05)
+            model.set_message("second", Severity.INFO)
+            time.sleep(0.07)
+            assert model.message == "second"
+            _wait_until(lambda: model.message == "", timeout=1.0)
+        finally:
+            model.shutdown()


### PR DESCRIPTION
* **MainWindowStatusViewModel:** A new pure-Python ViewModel that subscribes to EventHandler log events (info, warning, error, critical) to render messages. It also provides an API for multi-token progress tracking (start, update, end, request cancel).
* **MainWindow integration:** Set up a native QStatusBar bound to the MainWindowStatusViewModel. Includes a styled message label and a dynamic progress host that shows up to 3 active progress bars with cancel buttons, along with a "+X more" indicator for overflow.
* **Configuration:** Added `gui:window:status_bar_clear_timeout_s` to `defaults.yaml` to govern how long a message persists before auto-clearing.
* **Theme:** Added `MainWindowStatusBarColors` to `theme.py` for consistent styling of progress chunks, backgrounds, and severity-specific text colors.

Resolves #186 