### PR TITLE
feat: enable open clusters in Raw Data Analysis

### DIFF
--- a/src/le_beta_vis/config/defaults.yaml
+++ b/src/le_beta_vis/config/defaults.yaml
@@ -261,6 +261,16 @@ gui:historical:classification_threshold:
     Min confidence for positive classification in the
     Historical Analysis grid and inspector.
 
+gui:historical:roi_padding_factor:
+  type: float
+  default: 2.0
+  description: >-
+    Multiplier applied to a cluster's bounding box when the
+    Historical Inspector "Open in Raw Data" action drops an
+    ROI rectangle in the Raw Data Analysis tab. A factor of
+    2.0 produces a box twice the cluster geometry, centered
+    on the cluster.
+
 gui:historical:grid_item_width:
   type: int
   default: 140

--- a/src/le_beta_vis/frontend/MainWindow.py
+++ b/src/le_beta_vis/frontend/MainWindow.py
@@ -3,6 +3,7 @@ import sys
 from PySide6.QtCore import Qt, QMetaObject, Slot
 from PySide6.QtWidgets import (
     QMainWindow,
+    QMessageBox,
     QTabWidget,
     QWidget,
     QVBoxLayout,
@@ -23,6 +24,7 @@ from .views.HistoricalView import HistoricalView
 from .viewmodels.RawDataViewModel import RawDataViewModel
 from .viewmodels.HistoricalViewModel import HistoricalViewModel
 from . import theme
+from le_beta_vis.common.Cluster import Cluster
 from le_beta_vis.common.ClusterExtractorFactory import (
     create_cluster_extractor,
 )
@@ -214,6 +216,7 @@ class MainWindow(QMainWindow):
         self.historicalView = HistoricalView(
             self.historicalViewModel,
             statusViewModel=self.statusViewModel,
+            openInRawDataHandler=self._openClusterInRawData,
         )
         self.tabs.addTab(self.rawDataView, self.tr("Raw Data Analysis"))
         self.tabs.addTab(self.historicalView, self.tr("Historical Analysis"))
@@ -321,3 +324,43 @@ class MainWindow(QMainWindow):
         if filePath:
             self.tabs.setCurrentWidget(self.rawDataView)
             self.rawDataViewModel.loadFile(filePath)
+
+    def _openClusterInRawData(self, cluster: Cluster) -> None:
+        """Navigates from the Historical Inspector to Raw Data Analysis.
+
+        Performs a preflight check on the cluster's FITS path, switches
+        to the Raw Data Analysis tab, computes a padded ROI rectangle
+        around the cluster's bounding box, and delegates the load /
+        HDU select / fit-to-ROI sequence to ``RawDataView``.
+        """
+        path = cluster.fitsFilename
+        if not path or not Path(path).exists():
+            msg = self.tr(
+                "FITS file not found:\n{path}"
+            ).format(path=path or self.tr("(no path on cluster)"))
+            self.statusViewModel.set_message(msg, severity=Severity.WARNING)
+            QMessageBox.warning(self, self.tr("Open in Raw Data"), msg)
+            return
+
+        self.tabs.setCurrentWidget(self.rawDataView)
+
+        bb = cluster.boundingBox
+        pad = float(
+            self.viewModel.configService.get(
+                "gui:historical:roi_padding_factor", 2.0,
+            )
+        )
+        # Center the ROI on the bounding-box geometric center so the
+        # cluster sits in the middle of the rectangle. The peak-energy
+        # pixel (cluster.centerX/Y) is often offset within the bbox.
+        cx = (bb.left + bb.right) / 2.0
+        cy = (bb.top + bb.bottom) / 2.0
+        half_w = ((bb.right - bb.left) * pad) / 2.0
+        half_h = ((bb.bottom - bb.top) * pad) / 2.0
+        roi = (
+            int(round(cy - half_h)),
+            int(round(cx - half_w)),
+            int(round(cy + half_h)),
+            int(round(cx + half_w)),
+        )
+        self.rawDataView.openClusterForAnalysis(path, cluster.hdu_id, roi)

--- a/src/le_beta_vis/frontend/livemode/widgets/FeaturedClusterWidget.py
+++ b/src/le_beta_vis/frontend/livemode/widgets/FeaturedClusterWidget.py
@@ -78,6 +78,7 @@ class FeaturedClusterWidget(QWidget):
         self._statsWidget = ClusterDetailWidget(
             self._inspector_vm,
             show_filename=False,
+            show_open_action=False,
         )
         self._statsWidget.setStyleSheet(
             f"background-color: {LiveModeColors.STATS_BACKGROUND};"

--- a/src/le_beta_vis/frontend/viewmodels/HistoricalEventInspectorViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/HistoricalEventInspectorViewModel.py
@@ -81,6 +81,9 @@ class HistoricalEventInspectorViewModel:
         self._threshold = threshold
         self._displayKeV = displayKeV
         self._on_event_changed: List[Callable[[Optional[Cluster]], None]] = []
+        self._open_in_raw_data_handler: Optional[
+            Callable[[Cluster], None]
+        ] = None
 
     # --- Properties ---
 
@@ -130,6 +133,36 @@ class HistoricalEventInspectorViewModel:
             enabled: True for keV, False for raw ADU.
         """
         self._displayKeV = enabled
+
+    def setOpenInRawDataHandler(
+        self, handler: Optional[Callable[[Cluster], None]]
+    ) -> None:
+        """Injects the cross-tab navigation handler.
+
+        Pure-Python ViewModels can't switch a QTabWidget; the host
+        (MainWindow) supplies a handler that performs the navigation,
+        FITS load, HDU selection, ROI placement, and zoom/pan.
+
+        Args:
+            handler: Called with the current cluster when the user
+                requests to open it in Raw Data Analysis. Pass None
+                to clear.
+        """
+        self._open_in_raw_data_handler = handler
+
+    def openInRawData(self) -> None:
+        """Requests opening the current cluster in Raw Data Analysis.
+
+        No-ops when no cluster is loaded or no handler is wired.
+        """
+        if self._cluster is None or self._open_in_raw_data_handler is None:
+            return
+        self._open_in_raw_data_handler(self._cluster)
+
+    @property
+    def canOpenInRawData(self) -> bool:
+        """True when the current cluster has a FITS filename to open."""
+        return bool(self._cluster and self._cluster.fitsFilename)
 
     # --- Formatting ---
 

--- a/src/le_beta_vis/frontend/views/HistoricalEventInspector.py
+++ b/src/le_beta_vis/frontend/views/HistoricalEventInspector.py
@@ -112,7 +112,10 @@ class HistoricalEventInspector(QWidget):
         rightCol = QVBoxLayout()
         rightCol.setAlignment(Qt.AlignTop)
 
-        self._detailLabel = ClusterDetailWidget(self._vm, show_filename=True)
+        self._detailLabel = ClusterDetailWidget(
+            self._vm, show_filename=True, show_open_action=True,
+        )
+        self._detailLabel.openClicked.connect(self._vm.openInRawData)
         rightCol.addWidget(self._detailLabel)
 
         rightCol.addStretch()

--- a/src/le_beta_vis/frontend/views/HistoricalView.py
+++ b/src/le_beta_vis/frontend/views/HistoricalView.py
@@ -33,7 +33,9 @@ import numpy as np
 import collections
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
+
+from le_beta_vis.common.Cluster import Cluster
 
 logger = logging.getLogger(__name__)
 
@@ -61,10 +63,12 @@ class HistoricalView(QWidget):
         self,
         viewModel: HistoricalViewModel,
         statusViewModel: Optional[MainWindowStatusViewModel] = None,
+        openInRawDataHandler: Optional[Callable[[Cluster], None]] = None,
     ):
         super().__init__()
         self.viewModel = viewModel
         self._statusVM = statusViewModel
+        self._openInRawDataHandler = openInRawDataHandler
         self._pendingFilter = None
         self._pendingLoadError: Optional[str] = None
         self._thumbnailQueue: collections.deque = collections.deque()
@@ -147,6 +151,10 @@ class HistoricalView(QWidget):
             threshold=self.viewModel.classificationThreshold,
             displayKeV=self.viewModel.displayEnergyInKev,
         )
+        if self._openInRawDataHandler is not None:
+            self._inspectorVM.setOpenInRawDataHandler(
+                self._openInRawDataHandler
+            )
         self._inspector = HistoricalEventInspector(self._inspectorVM)
         self._splitter.addWidget(self._inspector)
 

--- a/src/le_beta_vis/frontend/views/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/RawDataView.py
@@ -1,3 +1,5 @@
+from typing import Optional, Tuple
+
 from PySide6.QtCore import QMetaObject, QRectF, QSize, Qt, Slot
 from PySide6.QtGui import (
     QColor,
@@ -48,6 +50,10 @@ class RawDataView(QWidget):
     def __init__(self, viewModel: RawDataViewModel):
         super().__init__()
         self.viewModel = viewModel
+        self._pendingClusterFocus: Optional[
+            Tuple[Optional[int], Tuple[int, int, int, int]]
+        ] = None
+        self._pendingClusterRoiAdded: bool = False
         self.initUI()
         self.bindViewModel()
 
@@ -523,6 +529,10 @@ class RawDataView(QWidget):
 
             # Update magnifier source data
             self._updateMagnifierSourceData(pixmap)
+
+            # Apply any deferred focus-on-ROI request now that the
+            # scene rect and viewport are valid.
+            self._consumePendingClusterFocus()
         else:
             self.pixmapItem.setPixmap(QPixmap())
 
@@ -537,6 +547,59 @@ class RawDataView(QWidget):
             hud = self._centerContainer.hudWidget
             if hud is not None:
                 hud.refreshMagnifier()
+
+    def openClusterForAnalysis(
+        self,
+        fitsPath: str,
+        hdu_id: Optional[int],
+        roi: Tuple[int, int, int, int],
+    ) -> None:
+        """Loads a FITS, selects an HDU, and pans to an ROI at 1× zoom.
+
+        Pre-selects the ROI Info tab, resets the zoom to 1×, clears
+        existing ROIs, and stashes the pending pan state. The render
+        completes asynchronously; ``updateImage`` then runs
+        ``_consumePendingClusterFocus`` which drops the ROI and pans
+        the captureView to its center. We deliberately do not zoom —
+        viewport-size measurement after a cold tab-switch + mosaic-
+        strip reveal is unreliable across platforms, and the user can
+        zoom in further with the existing controls.
+
+        Args:
+            fitsPath: Absolute path to the FITS file.
+            hdu_id: Parent HDU index, or None to keep the default.
+            roi: (top, left, bottom, right) in FITS pixel coordinates.
+        """
+        self._rightSidebarTabs.setCurrentIndex(self._roiInfoTabIndex)
+        self.viewModel.resetZoom()
+        self.viewModel.clearRois()
+        self._pendingClusterFocus = (hdu_id, roi)
+        self._pendingClusterRoiAdded = False
+        self.viewModel.loadFile(fitsPath)
+        if hdu_id is not None:
+            self.viewModel.setActiveHDU(hdu_id)
+
+    def _consumePendingClusterFocus(self) -> None:
+        """Adds the ROI and pans the captureView to its center.
+
+        Called from the tail of ``updateImage``. ``addRoi`` is
+        latched via ``_pendingClusterRoiAdded`` so multiple renders
+        (auto-HDU-0 + explicit-HDU) only add the ROI once.
+        """
+        if self._pendingClusterFocus is None:
+            return
+        _hdu_id, (top, left, bottom, right) = self._pendingClusterFocus
+
+        if not self._pendingClusterRoiAdded:
+            self.viewModel.addRoi(top, left, bottom, right)
+            self._pendingClusterRoiAdded = True
+
+        cx = (left + right) / 2.0
+        cy = (top + bottom) / 2.0
+        self.graphicsView.centerOn(cx, cy)
+
+        self._pendingClusterFocus = None
+        self._pendingClusterRoiAdded = False
 
     @Slot()
     def updateZoom(self):

--- a/src/le_beta_vis/frontend/widgets/ClusterDetailWidget.py
+++ b/src/le_beta_vis/frontend/widgets/ClusterDetailWidget.py
@@ -9,8 +9,8 @@ Used by both ``HistoricalEventInspector`` and ``LiveModeView``.
 
 from typing import Optional
 
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QLabel, QWidget
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
 
 from le_beta_vis.common.Cluster import Cluster
 from le_beta_vis.frontend.viewmodels.HistoricalEventInspectorViewModel import (
@@ -19,43 +19,93 @@ from le_beta_vis.frontend.viewmodels.HistoricalEventInspectorViewModel import (
 )
 
 
-class ClusterDetailWidget(QLabel):
-    """Rich-text cluster statistics label.
+_OPEN_LINK_HREF = "open-in-raw-data"
+
+
+class ClusterDetailWidget(QWidget):
+    """Rich-text cluster statistics with an optional Open action.
 
     The ``show_filename`` flag controls whether the FITS filename
     row is rendered — live-mode hides it because the path can be
     long and is not relevant in a presentation context.
 
+    The ``show_open_action`` flag controls the "Open in Raw Data"
+    button + clickable filename hyperlink.  Both emit
+    :pyattr:`openClicked` so the host can navigate to the Raw Data
+    Analysis tab.
+
     Args:
         viewModel: Shared inspector ViewModel for data computation.
         show_filename: Whether to include the FITS filename row.
+        show_open_action: Whether to expose the Open action.
         parent: Optional parent widget.
     """
+
+    openClicked = Signal()
 
     def __init__(
         self,
         viewModel: HistoricalEventInspectorViewModel,
         show_filename: bool = True,
+        show_open_action: bool = True,
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
         self._vm = viewModel
         self._show_filename = show_filename
-        self.setWordWrap(True)
-        self.setTextFormat(Qt.RichText)
-        self.setAlignment(Qt.AlignTop)
+        self._show_open_action = show_open_action
+        self._has_filename = False
+        # Honor caller-supplied background-color stylesheets (live mode
+        # paints a dark panel behind the stats); QWidget ignores its own
+        # stylesheet background unless WA_StyledBackground is enabled.
+        self.setAttribute(Qt.WA_StyledBackground, True)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        self._label = QLabel(self)
+        self._label.setWordWrap(True)
+        self._label.setTextFormat(Qt.RichText)
+        self._label.setAlignment(Qt.AlignTop)
+        self._label.setTextInteractionFlags(Qt.TextBrowserInteraction)
+        self._label.setOpenExternalLinks(False)
+        self._label.linkActivated.connect(self._onLinkActivated)
+        layout.addWidget(self._label)
+
+        self._openButton = QPushButton(self.tr("Open"), self)
+        self._openButton.setToolTip(
+            self.tr("Open this cluster in the Raw Data Analysis tab")
+        )
+        self._openButton.clicked.connect(self.openClicked)
+        self._openButton.setVisible(False)
+        layout.addWidget(self._openButton, 0, Qt.AlignLeft)
 
     def setCluster(self, cluster: Optional[Cluster]) -> None:
-        """Renders cluster stats into the label, or clears it.
+        """Renders cluster stats into the widget, or clears it.
 
         Args:
             cluster: The cluster to display, or None to clear.
         """
         if cluster is None:
-            self.clear()
+            self._label.clear()
+            self._has_filename = False
+            self._refreshOpenAction()
             return
         data = self._vm.formatClusterData(cluster)
-        self.setText(self._buildHtml(data))
+        self._has_filename = bool(data.fits_filename)
+        self._label.setText(self._buildHtml(data))
+        self._refreshOpenAction()
+
+    def _refreshOpenAction(self) -> None:
+        """Shows/enables the Open button based on flags + data."""
+        visible = self._show_open_action and self._show_filename
+        self._openButton.setVisible(visible)
+        self._openButton.setEnabled(visible and self._has_filename)
+
+    def _onLinkActivated(self, href: str) -> None:
+        if href == _OPEN_LINK_HREF and self._openButton.isEnabled():
+            self.openClicked.emit()
 
     def _buildHtml(self, data: ClusterDisplayData) -> str:
         """Constructs HTML from structured data with translatable labels."""
@@ -88,22 +138,22 @@ class ClusterDetailWidget(QLabel):
         cluster_id_label = self.tr("Cluster ID:")
         fits_label = self.tr("FITS File:")
         energy_label = self.tr("Energy:")
-        sigma_label = self.tr("\u03c3 spread:")
+        sigma_label = self.tr("σ spread:")
         geometry_label = self.tr("Geometry:")
         center_label = self.tr("Center:")
         pixels_label = self.tr("Pixels:")
         date_label = self.tr("Date:")
 
         sigma_val = (
-            f"\u03c3\u2093 = {data.sigma_x:.2f}, "
-            f"\u03c3\u1d67 = {data.sigma_y:.2f}"
+            f"σₓ = {data.sigma_x:.2f}, "
+            f"σᵧ = {data.sigma_y:.2f}"
         )
 
         rows = f"<tr><td><b>{cluster_id_label}</b></td><td>{data.cluster_id}</td></tr>"
         if self._show_filename:
             rows += (
                 f"<tr><td><b>{fits_label}</b></td>"
-                f"<td>{data.fits_filename}</td></tr>"
+                f"<td>{self._formatFilenameCell(data.fits_filename)}</td></tr>"
             )
         rows += (
             f"<tr><td><b>{energy_label}</b></td><td>{data.energy}</td></tr>"
@@ -114,3 +164,11 @@ class ClusterDetailWidget(QLabel):
             f"<tr><td><b>{date_label}</b></td><td>{data.date}</td></tr>"
         )
         return rows
+
+    def _formatFilenameCell(self, filename: Optional[str]) -> str:
+        """Renders the filename as a hyperlink when the Open action is live."""
+        if not filename:
+            return ""
+        if self._show_open_action:
+            return f'<a href="{_OPEN_LINK_HREF}">{filename}</a>'
+        return filename

--- a/tests/test_HistoricalEventInspectorViewModel.py
+++ b/tests/test_HistoricalEventInspectorViewModel.py
@@ -325,3 +325,54 @@ def test_set_display_kev(vm):
 def test_physics_property(vm, physics):
     """physics property should return injected manager."""
     assert vm.physics is physics
+
+
+# --- openInRawData handler ---
+
+
+def test_open_in_raw_data_invokes_handler_with_cluster(vm, cluster):
+    """openInRawData should invoke the registered handler with the current cluster."""
+    handler = MagicMock()
+    vm.setOpenInRawDataHandler(handler)
+    vm.setEvent(cluster)
+    vm.openInRawData()
+    handler.assert_called_once_with(cluster)
+
+
+def test_open_in_raw_data_no_op_without_handler(vm, cluster):
+    """openInRawData should silently no-op when no handler is wired."""
+    vm.setEvent(cluster)
+    vm.openInRawData()  # must not raise
+
+
+def test_open_in_raw_data_no_op_without_cluster(vm):
+    """openInRawData should not call the handler when no cluster is set."""
+    handler = MagicMock()
+    vm.setOpenInRawDataHandler(handler)
+    vm.openInRawData()
+    handler.assert_not_called()
+
+
+def test_can_open_in_raw_data_false_when_no_cluster(vm):
+    assert vm.canOpenInRawData is False
+
+
+def test_can_open_in_raw_data_false_when_no_filename(vm, cluster):
+    cluster.fitsFilename = None
+    vm.setEvent(cluster)
+    assert vm.canOpenInRawData is False
+
+
+def test_can_open_in_raw_data_true_with_filename(vm, cluster):
+    cluster.fitsFilename = "/data/run42.fits"
+    vm.setEvent(cluster)
+    assert vm.canOpenInRawData is True
+
+
+def test_clear_handler_via_none(vm, cluster):
+    handler = MagicMock()
+    vm.setOpenInRawDataHandler(handler)
+    vm.setOpenInRawDataHandler(None)
+    vm.setEvent(cluster)
+    vm.openInRawData()
+    handler.assert_not_called()


### PR DESCRIPTION
Connects the Historical Analysis and Raw Data Analysis workflows, allowing users to quickly transition from reviewing a processed cluster back to its original FITS exposure. By providing direct navigation to the raw context, it reduces the friction of manually finding and loading the corresponding file and visually locating the event.

The implementation introduces a padded region of interest (ROI) centered on the cluster's bounding box and pans the raw data view directly to it, ensuring the particle track is immediately identifiable without requiring additional zoom or manual searching.

## User Interface

https://github.com/user-attachments/assets/01b3511e-0840-4810-b88c-b62c36b8db03

Resolves #159.