### PR TITLE
feat: overlay HDU ids on top of mosaics

### DIFF
--- a/src/le_beta_vis/frontend/MainWindow.py
+++ b/src/le_beta_vis/frontend/MainWindow.py
@@ -49,7 +49,7 @@ class MainWindow(QMainWindow):
             self.statusViewModel.shutdown()
         super().closeEvent(event)
 
-    # -- Initialization helpers ------------------------------------------------
+    # -- Initialization helpers -----------------------------------------------
 
     def _setupWindowIdentity(self) -> None:
         self.setWindowTitle(self.tr("LE Beta Particle Visualization"))
@@ -63,8 +63,12 @@ class MainWindow(QMainWindow):
 
     def _setupWindowGeometry(self) -> None:
         self.setMinimumSize(960, 600)
-        width = self.viewModel.configService.get("gui:window:default_width", 1024)
-        height = self.viewModel.configService.get("gui:window:default_height", 700)
+        width = self.viewModel.configService.get(
+            "gui:window:default_width", 1024
+        )
+        height = self.viewModel.configService.get(
+            "gui:window:default_height", 700
+        )
         self.resize(width, height)
 
     def _setupCentralWidget(self) -> None:
@@ -78,7 +82,7 @@ class MainWindow(QMainWindow):
         self.rawDataViewModel = RawDataViewModel(
             self.viewModel.configService, self.viewModel.physicsManager
         )
-        self.rawDataViewModel.setClusterExtractor(
+        self.rawDataViewModel.clusterAnalysisViewModel.setClusterExtractor(
             create_cluster_extractor(
                 self.viewModel.configService, self.viewModel.physicsManager
             )
@@ -218,7 +222,7 @@ class MainWindow(QMainWindow):
         self.tabs.addTab(self.rawDataView, self.tr("Raw Data Analysis"))
         self.tabs.addTab(self.historicalView, self.tr("Historical Analysis"))
 
-    # -- Menu bar --------------------------------------------------------------
+    # -- Menu bar ------------------------------------------------------------
 
     def setupMenuBar(self) -> None:
         menuBar = self.menuBar()
@@ -271,7 +275,7 @@ class MainWindow(QMainWindow):
         aboutAction.triggered.connect(self._onShowAbout)
         helpMenu.addAction(aboutAction)
 
-    # -- Slots -----------------------------------------------------------------
+    # -- Slots ---------------------------------------------------------------
 
     def _onShowAbout(self) -> None:
         """Open the About dialog."""

--- a/src/le_beta_vis/frontend/theme.py
+++ b/src/le_beta_vis/frontend/theme.py
@@ -90,6 +90,20 @@ class ExportOptionsDialogColors:
     CANCEL_BUTTON_HOVER = "#505050"
 
 
+class RawDataManipulationToolbarColors:
+    """Colors for RawDataManipulationToolbar."""
+
+    HDU_LABEL = "#aaaaaa"
+
+
+class MosaicThumbnailColors:
+    """Colors for ThumbnailButton paintEvent overlay."""
+
+    LABEL_TEXT = "#ffffff"
+    LABEL_TEXT_SELECTED = "#4fc3f7"
+    LABEL_BACKGROUND_RGBA = (0, 0, 0, 140)
+
+
 class TooltipStyle:
     """Shared QToolTip stylesheet snippets.
 

--- a/src/le_beta_vis/frontend/viewmodels/ClusterAnalysisViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/ClusterAnalysisViewModel.py
@@ -1,139 +1,462 @@
-"""Facade ViewModel for cluster extraction controls.
+"""ViewModel for cluster extraction controls and results.
 
-Delegates all state, methods, and callbacks to the parent
-``RawDataViewModel``, keeping ClusterAnalysisView decoupled
-from the full raw-data surface area.
+Owns all ROI and clustering lifecycle state.
+Pure Python — no Qt dependencies.
 """
-from __future__ import annotations
+import logging
+import threading
+from enum import Enum
+from typing import Callable, List, Optional
 
-from typing import TYPE_CHECKING, Callable, List, Optional
+import numpy as np
 
-if TYPE_CHECKING:
-    from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
-    from le_beta_vis.frontend.fitsconverters import Colormap
-    from .RawDataViewModel import ClusteringState, RawDataViewModel
+from le_beta_vis.common.BoundingBox import BoundingBox
+from le_beta_vis.common.ClusterExtractor import (
+    ClusteredEventInfo,
+    ClusterExtractor,
+)
+from le_beta_vis.common.ConfigurationService import ConfigurationService
+from le_beta_vis.common.PhysicsConversionManager import (
+    PhysicsConversionManager,
+)
+from le_beta_vis.common.RoiRect import RoiRect
+from le_beta_vis.frontend.fitsconverters import Colormap
+
+logger = logging.getLogger(__name__)
+
+
+class ClusteringState(str, Enum):
+    """State of the cluster extraction lifecycle."""
+
+    IDLE = "idle"
+    RUNNING = "running"
 
 
 class ClusterAnalysisViewModel:
-    """Pure-Python facade that forwards clustering state to RawDataViewModel."""
+    """ViewModel owning ROI and cluster extraction state.
 
-    def __init__(self, parent: RawDataViewModel) -> None:
-        self._parent = parent
+    Constructed by RawDataViewModel and exposed as
+    ``raw_data_vm.clusterAnalysisViewModel``.
+    """
 
-    # --- Delegated properties ---
+    def __init__(
+        self,
+        config: ConfigurationService,
+        physics_manager: PhysicsConversionManager,
+        active_raw_data: Callable[[], Optional[np.ndarray]],
+        colormap_provider: Optional[Callable[[], Colormap]] = None,
+    ) -> None:
+        self._config = config
+        self._physics_manager = physics_manager
+        self._active_raw_data = active_raw_data
+        self._colormap_provider = colormap_provider
+        self._init_roi_state()
+        self._init_clustering_state()
+        self._init_callbacks()
+
+    def _init_roi_state(self) -> None:
+        """Initializes the ROI list."""
+        self._rois: List[RoiRect] = []
+
+    def _init_clustering_state(self) -> None:
+        """Initializes all clustering lifecycle state."""
+        self._clusterExtractor: Optional[ClusterExtractor] = None
+        self._clusteringState: ClusteringState = ClusteringState.IDLE
+        self._clusteringResults: List[ClusteredEventInfo] = []
+        self._clusteringError: Optional[str] = None
+        self._clusteringProgress: float = 0.0
+        self._clustering_timeout_timer: Optional[threading.Timer] = None
+        self._selectedClusterIndex: int = -1
+        self._single_cluster_export_handler: Optional[Callable] = None
+
+    def _init_callbacks(self) -> None:
+        """Initializes all observer callback registries to empty lists."""
+        self._on_active_tool_changed_callbacks: List[Callable] = []
+        self._on_roi_changed_callbacks: List[Callable] = []
+        self._on_box_selection_completed_callbacks: List[Callable] = []
+        self._on_clustering_state_changed_callbacks: List[Callable] = []
+        self._on_clustering_completed_callbacks: List[Callable] = []
+        self._on_clustering_error_callbacks: List[Callable] = []
+        self._on_clustering_progress_callbacks: List[Callable] = []
+        self._on_selected_cluster_changed_callbacks: List[Callable] = []
+
+    # --- ROI ---
+
+    @property
+    def rois(self) -> List[RoiRect]:
+        """Returns a shallow copy of the ROI list."""
+        return list(self._rois)
+
+    @property
+    def boxSelectColor(self) -> str:
+        """Returns the configured box selection color."""
+        return self._config.get("gui:raw_analysis:box_select_color", "#00BFFF")
+
+    @property
+    def boxSelectBorderWidth(self) -> int:
+        """Returns the configured box selection border width."""
+        return self._config.get("gui:raw_analysis:box_select_border_width", 2)
+
+    @property
+    def selectedRoiRawData(self) -> Optional[np.ndarray]:
+        """Returns the raw data cropped to the current ROI, or None."""
+        raw = self._active_raw_data()
+        if not self._rois or raw is None:
+            return None
+        return self._rois[-1].extract_raw_data(raw)
+
+    @property
+    def selectedRoiBoundingBox(self) -> Optional[BoundingBox]:
+        """Returns the bounding box of the current ROI, or None."""
+        if not self._rois:
+            return None
+        return self._rois[-1].geometry()
+
+    def addRoi(self, top: int, left: int, bottom: int, right: int) -> RoiRect:
+        """Creates and appends a new rectangular ROI.
+
+        Coordinates are normalized so top <= bottom and left <= right.
+        Notifies both roi_changed and box_selection_completed callbacks.
+        """
+        norm_top = min(top, bottom)
+        norm_left = min(left, right)
+        norm_bottom = max(top, bottom)
+        norm_right = max(left, right)
+        roi = RoiRect(norm_top, norm_left, norm_bottom, norm_right)
+        self._rois.append(roi)
+        self._notify_roi_changed()
+        self._notify_box_selection_completed()
+        return roi
+
+    def clearRois(self) -> None:
+        """Clears all ROIs and clustering results.
+
+        Notifies listeners if the list was non-empty.
+        """
+        if self._rois:
+            self._rois.clear()
+            self._notify_roi_changed()
+        self.clearClusteringResults()
+
+    def removeRoi(self, index: int) -> None:
+        """Removes an ROI by index. Notifies listeners on success."""
+        if 0 <= index < len(self._rois):
+            self._rois.pop(index)
+            self._notify_roi_changed()
+
+    # --- Clustering config ---
 
     @property
     def clusteringThreshold(self) -> float:
         """Returns the configured sigma threshold for clustering."""
-        return self._parent.clusteringThreshold
+        return self._config.get("gui:raw_analysis:clustering_threshold", 4.0)
 
     @property
-    def isClusteringAvailable(self) -> bool:
-        """Returns True when extraction can be triggered."""
-        return self._parent.isClusteringAvailable
-
-    @property
-    def clusteringState(self) -> ClusteringState:
-        """Returns the current clustering lifecycle state."""
-        return self._parent.clusteringState
-
-    @property
-    def clusteringResults(self) -> List[ClusteredEventInfo]:
-        """Returns the most recent extraction results."""
-        return self._parent.clusteringResults
-
-    @property
-    def clusteringProgress(self) -> float:
-        """Returns the current extraction progress in [0.0, 1.0]."""
-        return self._parent.clusteringProgress
-
-    @property
-    def clusteringError(self) -> Optional[str]:
-        """Returns the most recent clustering error message, if any."""
-        return self._parent.clusteringError
+    def clusteringTimeoutSeconds(self) -> int:
+        """Returns the configured clustering timeout in seconds."""
+        return self._config.get(
+            "gui:raw_analysis:clustering_timeout_seconds", 300
+        )
 
     @property
     def clusterThumbnailColormap(self) -> Optional[Colormap]:
-        """Returns the active colormap for thumbnails, or None."""
-        return self._parent.clusterThumbnailColormap
+        """Returns the active colormap if thumbnail coloring is enabled.
+
+        Reads ``gui:raw_analysis:cluster_thumbnail_use_colormap``.
+        When enabled, returns the current colormap for false-color
+        cluster thumbnails. When disabled, returns None (grayscale).
+        """
+        use_colormap: bool = self._config.get(
+            "gui:raw_analysis:cluster_thumbnail_use_colormap", True
+        )
+        if use_colormap and self._colormap_provider is not None:
+            return self._colormap_provider()
+        return None
 
     @property
     def displayEnergyInKev(self) -> bool:
         """Whether cluster energy should be displayed in keV."""
-        return self._parent.displayEnergyInKev
+        return bool(
+            self._config.get("gui:raw_analysis:display_energy_in_kev", True)
+        )
 
     @property
     def kevConversion(self) -> float:
-        """ADU-to-keV conversion factor."""
-        return self._parent.kevConversion
+        """ADU-to-keV conversion factor from configuration."""
+        return self._physics_manager.kev_conversion_factor
+
+    # --- Clustering lifecycle ---
+
+    def setClusterExtractor(self, extractor: ClusterExtractor) -> None:
+        """Sets the cluster extractor implementation to use."""
+        self._clusterExtractor = extractor
+
+    @property
+    def isClusteringAvailable(self) -> bool:
+        """Returns True when extraction can be triggered.
+
+        Requires: extractor set, at least one ROI, state IDLE,
+        and raw data loaded.
+        """
+        raw = self._active_raw_data()
+        return (
+            self._clusterExtractor is not None
+            and len(self._rois) > 0
+            and self._clusteringState == ClusteringState.IDLE
+            and raw is not None
+        )
+
+    @property
+    def clusteringState(self) -> ClusteringState:
+        """Returns the current clustering lifecycle state."""
+        return self._clusteringState
+
+    @property
+    def clusteringResults(self) -> List[ClusteredEventInfo]:
+        """Returns the most recent extraction results."""
+        return list(self._clusteringResults)
+
+    @property
+    def clusteringError(self) -> Optional[str]:
+        """Returns the most recent clustering error message, if any."""
+        return self._clusteringError
+
+    @property
+    def clusteringProgress(self) -> float:
+        """Returns the current extraction progress in [0.0, 1.0]."""
+        return self._clusteringProgress
 
     @property
     def selectedClusterIndex(self) -> int:
-        """Returns the index of the currently selected cluster."""
-        return self._parent.selectedClusterIndex
+        """Returns the index of the currently selected cluster, or -1."""
+        return self._selectedClusterIndex
 
-    # --- Delegated methods ---
+    @property
+    def selectedCluster(self) -> Optional[ClusteredEventInfo]:
+        """Returns the currently selected cluster, or None."""
+        if 0 <= self._selectedClusterIndex < len(self._clusteringResults):
+            return self._clusteringResults[self._selectedClusterIndex]
+        return None
+
+    def selectCluster(self, index: int) -> None:
+        """Selects a cluster by index. Pass -1 to deselect.
+
+        Notifies listeners only if the selection changed.
+        """
+        if index == self._selectedClusterIndex:
+            return
+        if index < -1 or index >= len(self._clusteringResults):
+            return
+        self._selectedClusterIndex = index
+        self._notify_selected_cluster_changed()
+
+    def clearClusteringResults(self) -> None:
+        """Clears results and resets selection. Notifies listeners."""
+        if self._clusteringResults or self._selectedClusterIndex != -1:
+            self._clusteringResults = []
+            self._selectedClusterIndex = -1
+            self._notify_clustering_completed()
+            self._notify_selected_cluster_changed()
+
+    def setSingleClusterExportHandler(
+        self,
+        handler: Optional[Callable[["ClusteredEventInfo"], None]],
+    ) -> None:
+        """Injects the per-cluster export callback.
+
+        Kept as an injection seam so this pure-Python VM stays free of
+        direct knowledge of the storage/PNG services and of the Qt
+        file-dialog used to pick the destination path.
+        """
+        self._single_cluster_export_handler = handler
+
+    def classifySelectedCluster(self) -> None:
+        """Placeholder for cluster classification (issue #54).
+
+        Logs the request; no-op until classification pipeline is wired.
+        """
+        cluster = self.selectedCluster
+        if cluster is None:
+            logger.info("classifySelectedCluster: no cluster selected")
+            return
+        logger.info(
+            "classifySelectedCluster: placeholder for cluster at "
+            "(%d, %d) with energy %.2f ADU",
+            cluster.centerX,
+            cluster.centerY,
+            cluster.energy,
+        )
+
+    def exportSelectedCluster(self) -> None:
+        """Requests a single-cluster export for the currently selected cluster.
+
+        No-op when no handler is wired or no cluster is selected.
+        """
+        cluster = self.selectedCluster
+        if cluster is None:
+            logger.info("exportSelectedCluster: no cluster selected")
+            return
+        if self._single_cluster_export_handler is None:
+            logger.info(
+                "exportSelectedCluster: no handler wired for cluster at "
+                "(%d, %d) with %d pixels",
+                cluster.centerX,
+                cluster.centerY,
+                cluster.pixelCount,
+            )
+            return
+        self._single_cluster_export_handler(cluster)
 
     def triggerClustering(self) -> None:
-        """Starts cluster extraction on the current ROI."""
-        self._parent.triggerClustering()
+        """Starts cluster extraction on the current ROI.
+
+        No-op when isClusteringAvailable is False.
+        Starts a timeout watchdog that aborts the extraction
+        if it does not complete within the configured limit.
+        """
+        if not self.isClusteringAvailable:
+            return
+
+        roi = self._rois[-1]
+        raw = self._active_raw_data()
+        data = roi.extract_raw_data(raw)
+        if data is None:
+            return
+
+        self._clusteringResults = []
+        self._selectedClusterIndex = -1
+        self._clusteringError = None
+        self._clusteringProgress = 0.0
+        self._clusteringState = ClusteringState.RUNNING
+        self._notify_clustering_state_changed()
+
+        timeout = self.clusteringTimeoutSeconds
+        self._clustering_timeout_timer = threading.Timer(
+            timeout, self._on_clustering_timeout
+        )
+        self._clustering_timeout_timer.daemon = True
+        self._clustering_timeout_timer.start()
+
+        bbox = roi.geometry()
+        self._clusterExtractor.extract(
+            data,
+            bbox,
+            self._on_clustering_success,
+            progress_callback=self._on_clustering_progress,
+        )
 
     def cancelClustering(self) -> None:
         """Cancels any in-progress cluster extraction."""
-        self._parent.cancelClustering()
+        self._cancel_timeout_timer()
+        if self._clusterExtractor is not None:
+            self._clusterExtractor.cancel()
+        self._clusteringState = ClusteringState.IDLE
+        self._notify_clustering_state_changed()
 
-    def selectCluster(self, index: int) -> None:
-        """Selects a cluster by index."""
-        self._parent.selectCluster(index)
+    def _on_clustering_success(
+        self, results: List[ClusteredEventInfo]
+    ) -> None:
+        """Callback from extractor thread on completion."""
+        self._cancel_timeout_timer()
+        if self._clusteringState != ClusteringState.RUNNING:
+            return
+        self._clusteringResults = results
+        self._clusteringState = ClusteringState.IDLE
+        self._notify_clustering_state_changed()
+        self._notify_clustering_completed()
 
-    def classifySelectedCluster(self) -> None:
-        """Placeholder for cluster classification."""
-        self._parent.classifySelectedCluster()
+    def _on_clustering_timeout(self) -> None:
+        """Called by the watchdog timer when extraction takes too long."""
+        if self._clusteringState != ClusteringState.RUNNING:
+            return
+        logger.warning("Cluster extraction timed out")
+        if self._clusterExtractor is not None:
+            self._clusterExtractor.cancel()
+        self._clusteringError = (
+            "Cluster extraction timed out after "
+            f"{self.clusteringTimeoutSeconds} seconds."
+        )
+        self._clusteringState = ClusteringState.IDLE
+        self._notify_clustering_state_changed()
+        self._notify_clustering_error()
 
-    def exportSelectedCluster(self) -> None:
-        """Placeholder for training data export."""
-        self._parent.exportSelectedCluster()
+    def _on_clustering_progress(self, value: float) -> None:
+        """Called from the extractor thread with progress updates."""
+        self._clusteringProgress = value
+        self._notify_clustering_progress()
 
-    # --- Delegated callback registration ---
+    def _cancel_timeout_timer(self) -> None:
+        """Cancels the timeout watchdog if active."""
+        if self._clustering_timeout_timer is not None:
+            self._clustering_timeout_timer.cancel()
+            self._clustering_timeout_timer = None
+
+    # --- Observer Pattern ---
+
+    def add_active_tool_changed_callback(self, callback: Callable) -> None:
+        """Register callback for active-tool changes (forwarded by RDVM)."""
+        self._on_active_tool_changed_callbacks.append(callback)
+
+    def _notify_active_tool_changed(self) -> None:
+        for callback in self._on_active_tool_changed_callbacks:
+            callback()
+
+    def add_roi_changed_callback(self, callback: Callable) -> None:
+        """Register callback for ROI list changes."""
+        self._on_roi_changed_callbacks.append(callback)
+
+    def add_box_selection_completed_callback(self, callback: Callable) -> None:
+        """Register callback fired when a box selection is finalized."""
+        self._on_box_selection_completed_callbacks.append(callback)
+
+    def _notify_roi_changed(self) -> None:
+        for callback in self._on_roi_changed_callbacks:
+            callback()
+
+    def _notify_box_selection_completed(self) -> None:
+        for callback in self._on_box_selection_completed_callbacks:
+            callback()
 
     def add_clustering_state_changed_callback(
-        self, callback: Callable,
+        self, callback: Callable
     ) -> None:
-        """Register callback for clustering state changes."""
-        self._parent.add_clustering_state_changed_callback(callback)
+        """Register callback for clustering state transitions."""
+        self._on_clustering_state_changed_callbacks.append(callback)
 
-    def add_clustering_completed_callback(
-        self, callback: Callable,
-    ) -> None:
-        """Register callback for clustering completion."""
-        self._parent.add_clustering_completed_callback(callback)
+    def add_clustering_completed_callback(self, callback: Callable) -> None:
+        """Register callback for extraction completion."""
+        self._on_clustering_completed_callbacks.append(callback)
 
-    def add_clustering_error_callback(
-        self, callback: Callable,
-    ) -> None:
+    def add_clustering_error_callback(self, callback: Callable) -> None:
         """Register callback for clustering errors."""
-        self._parent.add_clustering_error_callback(callback)
+        self._on_clustering_error_callbacks.append(callback)
 
-    def add_clustering_progress_callback(
-        self, callback: Callable,
-    ) -> None:
-        """Register callback for clustering progress updates."""
-        self._parent.add_clustering_progress_callback(callback)
+    def add_clustering_progress_callback(self, callback: Callable) -> None:
+        """Register callback for extraction progress updates."""
+        self._on_clustering_progress_callbacks.append(callback)
 
     def add_selected_cluster_changed_callback(
-        self, callback: Callable,
+        self, callback: Callable
     ) -> None:
         """Register callback for cluster selection changes."""
-        self._parent.add_selected_cluster_changed_callback(callback)
+        self._on_selected_cluster_changed_callbacks.append(callback)
 
-    def add_active_tool_changed_callback(
-        self, callback: Callable,
-    ) -> None:
-        """Register callback for active tool changes."""
-        self._parent.add_active_tool_changed_callback(callback)
+    def _notify_clustering_state_changed(self) -> None:
+        for callback in self._on_clustering_state_changed_callbacks:
+            callback()
 
-    def add_roi_changed_callback(
-        self, callback: Callable,
-    ) -> None:
-        """Register callback for ROI changes."""
-        self._parent.add_roi_changed_callback(callback)
+    def _notify_clustering_completed(self) -> None:
+        for callback in self._on_clustering_completed_callbacks:
+            callback()
+
+    def _notify_clustering_error(self) -> None:
+        for callback in self._on_clustering_error_callbacks:
+            callback()
+
+    def _notify_clustering_progress(self) -> None:
+        for callback in self._on_clustering_progress_callbacks:
+            callback()
+
+    def _notify_selected_cluster_changed(self) -> None:
+        for callback in self._on_selected_cluster_changed_callbacks:
+            callback()

--- a/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
@@ -8,19 +8,17 @@ from typing import Callable, List, Optional, Tuple
 import numpy as np
 
 from le_beta_vis.common.CCDCaptureModel import CCDCaptureModel
-from le_beta_vis.common.ClusterExtractor import (
-    ClusteredEventInfo,
-    ClusterExtractor,
-)
 from le_beta_vis.common.ConfigurationService import ConfigurationService
-from le_beta_vis.common.PhysicsConversionManager import PhysicsConversionManager
-from le_beta_vis.common.BoundingBox import BoundingBox
-from le_beta_vis.common.RoiRect import RoiRect
+from le_beta_vis.common.PhysicsConversionManager import (
+    PhysicsConversionManager,
+)
 from le_beta_vis.frontend.fitsconverters import (
     Colormap,
     OpenCVBasedConverter,
     ScalingFunction,
 )
+from .ClusterAnalysisViewModel import ClusterAnalysisViewModel
+from .MosaicViewModel import MosaicViewModel
 
 logger = logging.getLogger(__name__)
 
@@ -30,13 +28,6 @@ class ActiveTool(str, Enum):
 
     MAGNIFIER = "magnifier"
     BOX_SELECT = "box_select"
-
-
-class ClusteringState(str, Enum):
-    """State of the cluster extraction lifecycle."""
-
-    IDLE = "idle"
-    RUNNING = "running"
 
 
 class RawDataViewModel:
@@ -57,21 +48,27 @@ class RawDataViewModel:
         self._converter = OpenCVBasedConverter()
         self._captures: List[CCDCaptureModel] = []
         self._activeIndex: int = -1
+        self._init_callbacks()
         self._init_sub_viewmodels()
         self._init_visualization_state()
-        self._init_clustering_state()
         self._init_render_pipeline()
-        self._init_callbacks()
 
     def _init_sub_viewmodels(self) -> None:
-        """Constructs sub-ViewModels. Lazy imports break the circular
-        import between RawDataViewModel and ClusterAnalysisViewModel."""
-        from .MosaicViewModel import MosaicViewModel
-        from .ClusterAnalysisViewModel import ClusterAnalysisViewModel
-
-        self.mosaicViewModel = MosaicViewModel(self._config, self._physics_manager)
+        """Constructs sub-ViewModels and wires cross-VM notifications."""
+        self.mosaicViewModel = MosaicViewModel(
+            self._config, self._physics_manager
+        )
         self.mosaicViewModel.add_selection_changed_callback(self.setActiveHDU)
-        self.clusterAnalysisViewModel = ClusterAnalysisViewModel(self)
+
+        self.clusterAnalysisViewModel = ClusterAnalysisViewModel(
+            self._config,
+            self._physics_manager,
+            lambda: self.activeRawData,
+            lambda: self._colormap,
+        )
+        self.add_active_tool_changed_callback(
+            self.clusterAnalysisViewModel._notify_active_tool_changed
+        )
 
     def _init_visualization_state(self) -> None:
         """Initializes colormap, value range, scaling, zoom, tool,
@@ -100,24 +97,15 @@ class RawDataViewModel:
         self._image_bounds: Tuple[int, int] = (0, 0)
         self._pointer_hover_pos: Optional[Tuple[int, int]] = None
 
-    def _init_clustering_state(self) -> None:
-        """Initializes ROI list and all clustering lifecycle state."""
-        self._rois: List[RoiRect] = []
-        self._clusterExtractor: Optional[ClusterExtractor] = None
-        self._clusteringState: ClusteringState = ClusteringState.IDLE
-        self._clusteringResults: List[ClusteredEventInfo] = []
-        self._clusteringError: Optional[str] = None
-        self._clusteringProgress: float = 0.0
-        self._clustering_timeout_timer: Optional[threading.Timer] = None
-        self._selectedClusterIndex: int = -1
-
     def _init_render_pipeline(self) -> None:
         """Creates the render queue and buffer lock, then starts the
         background render worker daemon thread."""
         self._buffer_lock = threading.Lock()
         self._current_buffer: Optional[np.ndarray] = None
         self._render_queue: queue.Queue = queue.Queue(maxsize=1)
-        self._render_thread = threading.Thread(target=self._render_worker, daemon=True)
+        self._render_thread = threading.Thread(
+            target=self._render_worker, daemon=True
+        )
         self._render_thread.start()
 
     def _init_callbacks(self) -> None:
@@ -129,13 +117,6 @@ class RawDataViewModel:
         self._on_magnifier_state_changed_callbacks: List[Callable] = []
         self._on_magnifier_position_changed_callbacks: List[Callable] = []
         self._on_pointer_hover_changed_callbacks: List[Callable] = []
-        self._on_roi_changed_callbacks: List[Callable] = []
-        self._on_box_selection_completed_callbacks: List[Callable] = []
-        self._on_clustering_state_changed_callbacks: List[Callable] = []
-        self._on_clustering_completed_callbacks: List[Callable] = []
-        self._on_clustering_error_callbacks: List[Callable] = []
-        self._on_clustering_progress_callbacks: List[Callable] = []
-        self._on_selected_cluster_changed_callbacks: List[Callable] = []
         self._on_active_hdu_changed_callbacks: List[Callable] = []
 
     def loadFile(self, filePath: str):
@@ -241,8 +222,12 @@ class RawDataViewModel:
         Notifies magnifier state listeners on change.
         """
         step = self._config.get("gui:raw_analysis:magnifier_factor_step", 0.5)
-        min_factor = self._config.get("gui:raw_analysis:magnifier_min_factor", 1.0)
-        max_factor = self._config.get("gui:raw_analysis:magnifier_max_factor", 100.0)
+        min_factor = self._config.get(
+            "gui:raw_analysis:magnifier_min_factor", 1.0
+        )
+        max_factor = self._config.get(
+            "gui:raw_analysis:magnifier_max_factor", 100.0
+        )
         new_factor = self._magnificationFactor + delta * step
         new_factor = max(min_factor, min(new_factor, max_factor))
         if new_factor != self._magnificationFactor:
@@ -297,279 +282,12 @@ class RawDataViewModel:
             self._pointer_hover_pos = None
             self._notify_pointer_hover_changed()
 
-    # --- Box Selection / ROI ---
+    # --- Box Selection active-state ---
 
     @property
     def isBoxSelectActive(self) -> bool:
         """Returns True if the box selection tool is active."""
         return self._activeTool == ActiveTool.BOX_SELECT
-
-    @property
-    def rois(self) -> List[RoiRect]:
-        """Returns a shallow copy of the ROI list."""
-        return list(self._rois)
-
-    @property
-    def boxSelectColor(self) -> str:
-        """Returns the configured box selection color."""
-        return self._config.get("gui:raw_analysis:box_select_color", "#00BFFF")
-
-    @property
-    def boxSelectBorderWidth(self) -> int:
-        """Returns the configured box selection border width."""
-        return self._config.get("gui:raw_analysis:box_select_border_width", 2)
-
-    @property
-    def clusteringThreshold(self) -> float:
-        """Returns the configured sigma threshold for clustering."""
-        return self._config.get("gui:raw_analysis:clustering_threshold", 4.0)
-
-    def addRoi(self, top: int, left: int, bottom: int, right: int) -> RoiRect:
-        """
-        Creates and appends a new rectangular ROI.
-        Coordinates are normalized so top <= bottom and left <= right.
-        Notifies both roi_changed and box_selection_completed callbacks.
-        """
-        norm_top = min(top, bottom)
-        norm_left = min(left, right)
-        norm_bottom = max(top, bottom)
-        norm_right = max(left, right)
-        roi = RoiRect(norm_top, norm_left, norm_bottom, norm_right)
-        self._rois.append(roi)
-        self._notify_roi_changed()
-        self._notify_box_selection_completed()
-        return roi
-
-    def clearRois(self) -> None:
-        """Clears all ROIs and clustering results.
-
-        Notifies listeners if the list was non-empty.
-        """
-        if self._rois:
-            self._rois.clear()
-            self._notify_roi_changed()
-        self.clearClusteringResults()
-
-    def removeRoi(self, index: int) -> None:
-        """Removes an ROI by index. Notifies listeners on success."""
-        if 0 <= index < len(self._rois):
-            self._rois.pop(index)
-            self._notify_roi_changed()
-
-    # --- Cluster Extraction ---
-
-    def setClusterExtractor(self, extractor: ClusterExtractor) -> None:
-        """Sets the cluster extractor implementation to use."""
-        self._clusterExtractor = extractor
-
-    @property
-    def isClusteringAvailable(self) -> bool:
-        """Returns True when extraction can be triggered.
-
-        Requires: extractor set, at least one ROI, state IDLE,
-        and raw data loaded.
-        """
-        return (
-            self._clusterExtractor is not None
-            and len(self._rois) > 0
-            and self._clusteringState == ClusteringState.IDLE
-            and self.activeRawData is not None
-        )
-
-    @property
-    def clusteringState(self) -> ClusteringState:
-        """Returns the current clustering lifecycle state."""
-        return self._clusteringState
-
-    @property
-    def clusteringResults(self) -> List[ClusteredEventInfo]:
-        """Returns the most recent extraction results."""
-        return list(self._clusteringResults)
-
-    @property
-    def clusteringTimeoutSeconds(self) -> int:
-        """Returns the configured clustering timeout in seconds."""
-        return self._config.get("gui:raw_analysis:clustering_timeout_seconds", 300)
-
-    @property
-    def clusteringError(self) -> Optional[str]:
-        """Returns the most recent clustering error message, if any."""
-        return self._clusteringError
-
-    @property
-    def clusteringProgress(self) -> float:
-        """Returns the current extraction progress in [0.0, 1.0]."""
-        return self._clusteringProgress
-
-    @property
-    def selectedClusterIndex(self) -> int:
-        """Returns the index of the currently selected cluster, or -1."""
-        return self._selectedClusterIndex
-
-    @property
-    def selectedCluster(self) -> Optional[ClusteredEventInfo]:
-        """Returns the currently selected cluster, or None."""
-        if 0 <= self._selectedClusterIndex < len(self._clusteringResults):
-            return self._clusteringResults[self._selectedClusterIndex]
-        return None
-
-    def selectCluster(self, index: int) -> None:
-        """Selects a cluster by index. Pass -1 to deselect.
-
-        Notifies listeners only if the selection changed.
-        """
-        if index == self._selectedClusterIndex:
-            return
-        if index < -1 or index >= len(self._clusteringResults):
-            return
-        self._selectedClusterIndex = index
-        self._notify_selected_cluster_changed()
-
-    def clearClusteringResults(self) -> None:
-        """Clears results and resets selection. Notifies listeners."""
-        if self._clusteringResults or self._selectedClusterIndex != -1:
-            self._clusteringResults = []
-            self._selectedClusterIndex = -1
-            self._notify_clustering_completed()
-            self._notify_selected_cluster_changed()
-
-    def classifySelectedCluster(self) -> None:
-        """Placeholder for cluster classification (issue #54).
-
-        Logs the request; no-op until classification pipeline is wired.
-        """
-        cluster = self.selectedCluster
-        if cluster is None:
-            logger.info("classifySelectedCluster: no cluster selected")
-            return
-        logger.info(
-            "classifySelectedCluster: placeholder for cluster at "
-            "(%d, %d) with energy %.2f ADU",
-            cluster.centerX,
-            cluster.centerY,
-            cluster.energy,
-        )
-
-    def setSingleClusterExportHandler(
-        self,
-        handler: Optional[Callable[["ClusteredEventInfo"], None]],
-    ) -> None:
-        """Injects the per-cluster export callback.
-
-        Kept as an injection seam so this pure-Python VM stays free of
-        direct knowledge of the storage/PNG services and of the Qt
-        file-dialog used to pick the destination path. MainWindow (or
-        RawDataView) supplies a handler that drives the ExportStorage +
-        ClusterExport services off the main thread.
-        """
-        self._single_cluster_export_handler = handler
-
-    def exportSelectedCluster(self) -> None:
-        """Requests a single-cluster export for the currently selected cluster.
-
-        Delegates to the handler registered via
-        :meth:`setSingleClusterExportHandler`. When no handler is wired
-        (headless tests, early bring-up), logs and no-ops so nothing
-        crashes — the real behavior lands once RawDataView wires the
-        handler to the shared export services introduced in #56.
-        """
-        cluster = self.selectedCluster
-        if cluster is None:
-            logger.info("exportSelectedCluster: no cluster selected")
-            return
-        handler = getattr(self, "_single_cluster_export_handler", None)
-        if handler is None:
-            logger.info(
-                "exportSelectedCluster: no handler wired for cluster at "
-                "(%d, %d) with %d pixels",
-                cluster.centerX,
-                cluster.centerY,
-                cluster.pixelCount,
-            )
-            return
-        handler(cluster)
-
-    def triggerClustering(self) -> None:
-        """Starts cluster extraction on the current ROI.
-
-        No-op when isClusteringAvailable is False.
-        Starts a timeout watchdog that aborts the extraction
-        if it does not complete within the configured limit.
-        """
-        if not self.isClusteringAvailable:
-            return
-
-        roi = self._rois[-1]
-        raw = self.activeRawData
-        data = roi.extract_raw_data(raw)
-        if data is None:
-            return
-
-        self._clusteringResults = []
-        self._selectedClusterIndex = -1
-        self._clusteringError = None
-        self._clusteringProgress = 0.0
-        self._clusteringState = ClusteringState.RUNNING
-        self._notify_clustering_state_changed()
-
-        timeout = self.clusteringTimeoutSeconds
-        self._clustering_timeout_timer = threading.Timer(
-            timeout, self._on_clustering_timeout
-        )
-        self._clustering_timeout_timer.daemon = True
-        self._clustering_timeout_timer.start()
-
-        bbox = roi.geometry()
-        self._clusterExtractor.extract(
-            data,
-            bbox,
-            self._on_clustering_success,
-            progress_callback=self._on_clustering_progress,
-        )
-
-    def cancelClustering(self) -> None:
-        """Cancels any in-progress cluster extraction."""
-        self._cancel_timeout_timer()
-        if self._clusterExtractor is not None:
-            self._clusterExtractor.cancel()
-        self._clusteringState = ClusteringState.IDLE
-        self._notify_clustering_state_changed()
-
-    def _on_clustering_success(self, results: List[ClusteredEventInfo]) -> None:
-        """Callback from extractor thread on completion."""
-        self._cancel_timeout_timer()
-        if self._clusteringState != ClusteringState.RUNNING:
-            return
-        self._clusteringResults = results
-        self._clusteringState = ClusteringState.IDLE
-        self._notify_clustering_state_changed()
-        self._notify_clustering_completed()
-
-    def _on_clustering_timeout(self) -> None:
-        """Called by the watchdog timer when extraction takes too long."""
-        if self._clusteringState != ClusteringState.RUNNING:
-            return
-        logger.warning("Cluster extraction timed out")
-        if self._clusterExtractor is not None:
-            self._clusterExtractor.cancel()
-        self._clusteringError = (
-            "Cluster extraction timed out after "
-            f"{self.clusteringTimeoutSeconds} seconds."
-        )
-        self._clusteringState = ClusteringState.IDLE
-        self._notify_clustering_state_changed()
-        self._notify_clustering_error()
-
-    def _on_clustering_progress(self, value: float) -> None:
-        """Called from the extractor thread with progress updates."""
-        self._clusteringProgress = value
-        self._notify_clustering_progress()
-
-    def _cancel_timeout_timer(self) -> None:
-        """Cancels the timeout watchdog if active."""
-        if self._clustering_timeout_timer is not None:
-            self._clustering_timeout_timer.cancel()
-            self._clustering_timeout_timer = None
 
     def _request_render(self):
         """Queues a render request, coalescing rapid calls into one."""
@@ -642,31 +360,6 @@ class RawDataViewModel:
         return self._scalingFunction.value
 
     @property
-    def clusterThumbnailColormap(self) -> Optional[Colormap]:
-        """Returns the active colormap if thumbnail coloring is enabled.
-
-        Reads ``gui:raw_analysis:cluster_thumbnail_use_colormap``.
-        When enabled, returns the current colormap for false-color
-        cluster thumbnails.  When disabled, returns None (grayscale).
-        """
-        use_colormap: bool = self._config.get(
-            "gui:raw_analysis:cluster_thumbnail_use_colormap", True
-        )
-        if use_colormap:
-            return self._colormap
-        return None
-
-    @property
-    def displayEnergyInKev(self) -> bool:
-        """Whether cluster energy should be displayed in keV."""
-        return bool(self._config.get("gui:raw_analysis:display_energy_in_kev", True))
-
-    @property
-    def kevConversion(self) -> float:
-        """ADU-to-keV conversion factor from configuration."""
-        return self._physics_manager.kev_conversion_factor
-
-    @property
     def activeIndex(self) -> int:
         return self._activeIndex
 
@@ -709,20 +402,6 @@ class RawDataViewModel:
         return self._captures[self._activeIndex].rawData()
 
     @property
-    def selectedRoiRawData(self) -> Optional[np.ndarray]:
-        """Returns the raw data cropped to the current ROI, or None."""
-        if not self._rois or self.activeRawData is None:
-            return None
-        return self._rois[-1].extract_raw_data(self.activeRawData)
-
-    @property
-    def selectedRoiBoundingBox(self) -> Optional[BoundingBox]:
-        """Returns the bounding box of the current ROI, or None."""
-        if not self._rois:
-            return None
-        return self._rois[-1].geometry()
-
-    @property
     def pointerHoverInfo(
         self,
     ) -> Optional[Tuple[int, int, float]]:
@@ -750,7 +429,7 @@ class RawDataViewModel:
 
     @property
     def autoRangeOnLoad(self) -> bool:
-        """Whether to auto-set the visualization range to the full data extent on load."""
+        """Whether to auto-set the visualization range on load."""
         return self._config.get("gui:raw_analysis:auto_range_on_load", False)
 
     # --- Observer Pattern Helpers ---
@@ -810,55 +489,4 @@ class RawDataViewModel:
 
     def _notify_pointer_hover_changed(self):
         for callback in self._on_pointer_hover_changed_callbacks:
-            callback()
-
-    def add_roi_changed_callback(self, callback: Callable):
-        self._on_roi_changed_callbacks.append(callback)
-
-    def add_box_selection_completed_callback(self, callback: Callable):
-        self._on_box_selection_completed_callbacks.append(callback)
-
-    def _notify_roi_changed(self):
-        for callback in self._on_roi_changed_callbacks:
-            callback()
-
-    def _notify_box_selection_completed(self):
-        for callback in self._on_box_selection_completed_callbacks:
-            callback()
-
-    def add_clustering_state_changed_callback(self, callback: Callable):
-        self._on_clustering_state_changed_callbacks.append(callback)
-
-    def add_clustering_completed_callback(self, callback: Callable):
-        self._on_clustering_completed_callbacks.append(callback)
-
-    def _notify_clustering_state_changed(self):
-        for callback in self._on_clustering_state_changed_callbacks:
-            callback()
-
-    def _notify_clustering_completed(self):
-        for callback in self._on_clustering_completed_callbacks:
-            callback()
-
-    def add_clustering_error_callback(self, callback: Callable):
-        self._on_clustering_error_callbacks.append(callback)
-
-    def _notify_clustering_error(self):
-        for callback in self._on_clustering_error_callbacks:
-            callback()
-
-    def add_clustering_progress_callback(self, callback: Callable):
-        """Register a callback for extraction progress updates."""
-        self._on_clustering_progress_callbacks.append(callback)
-
-    def _notify_clustering_progress(self) -> None:
-        for callback in self._on_clustering_progress_callbacks:
-            callback()
-
-    def add_selected_cluster_changed_callback(self, callback: Callable) -> None:
-        """Register a callback for cluster selection changes."""
-        self._on_selected_cluster_changed_callbacks.append(callback)
-
-    def _notify_selected_cluster_changed(self) -> None:
-        for callback in self._on_selected_cluster_changed_callbacks:
             callback()

--- a/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
@@ -136,6 +136,7 @@ class RawDataViewModel:
         self._on_clustering_error_callbacks: List[Callable] = []
         self._on_clustering_progress_callbacks: List[Callable] = []
         self._on_selected_cluster_changed_callbacks: List[Callable] = []
+        self._on_active_hdu_changed_callbacks: List[Callable] = []
 
     def loadFile(self, filePath: str):
         path = Path(filePath)
@@ -154,6 +155,7 @@ class RawDataViewModel:
             if self._activeIndex == index:
                 return
             self._activeIndex = index
+            self._notify_active_hdu_changed()
             self.mosaicViewModel.selectIndex(index)
             self._request_render()
 
@@ -665,15 +667,15 @@ class RawDataViewModel:
         return self._physics_manager.kev_conversion_factor
 
     @property
-    def hduSummaries(self) -> List[str]:
-        return [
-            f"HDU {i}: {c.info().rows}x{c.info().cols}"
-            for i, c in enumerate(self._captures)
-        ]
-
-    @property
     def activeIndex(self) -> int:
         return self._activeIndex
+
+    @property
+    def activeHDULabel(self) -> Optional[str]:
+        """Returns 'HDU <N>' when active, None when no file is loaded."""
+        if self._activeIndex == -1 or not self._captures:
+            return None
+        return f"HDU {self._activeIndex}"
 
     @property
     def scale(self) -> float:
@@ -758,6 +760,14 @@ class RawDataViewModel:
 
     def add_file_loaded_callback(self, callback: Callable):
         self._on_file_loaded_callbacks.append(callback)
+
+    def add_active_hdu_changed_callback(self, callback: Callable) -> None:
+        """Register a callback fired whenever the active HDU index changes."""
+        self._on_active_hdu_changed_callbacks.append(callback)
+
+    def _notify_active_hdu_changed(self) -> None:
+        for callback in self._on_active_hdu_changed_callbacks:
+            callback()
 
     def add_scale_changed_callback(self, callback: Callable):
         self._on_scale_changed_callbacks.append(callback)

--- a/src/le_beta_vis/frontend/viewmodels/__init__.py
+++ b/src/le_beta_vis/frontend/viewmodels/__init__.py
@@ -2,7 +2,7 @@
 # pylint: disable=unused-import
 # pyright: reportUnusedImport=false
 from .RawDataViewModel import ActiveTool, RawDataViewModel
-from .ClusterAnalysisViewModel import ClusterAnalysisViewModel
+from .ClusterAnalysisViewModel import ClusterAnalysisViewModel, ClusteringState
 from .HistoricalViewModel import HistoricalViewModel
 from .HistoricalEventInspectorViewModel import (
     HistoricalEventInspectorViewModel,

--- a/src/le_beta_vis/frontend/views/MosaicView.py
+++ b/src/le_beta_vis/frontend/views/MosaicView.py
@@ -6,9 +6,44 @@ from PySide6.QtWidgets import (
     QScroller,
     QScrollerProperties,
 )
-from PySide6.QtCore import Qt, QSize
-from PySide6.QtGui import QIcon, QImage, QPixmap
+from PySide6.QtCore import Qt, QRect, QSize
+from PySide6.QtGui import QColor, QFont, QIcon, QImage, QPainter, QPixmap
+from ..theme import MosaicThumbnailColors
 from ..viewmodels.MosaicViewModel import MosaicViewModel
+
+
+class ThumbnailButton(QToolButton):
+    """QToolButton that paints an 'HDU N' label overlay on the icon."""
+
+    def __init__(self, index: int, parent=None) -> None:
+        super().__init__(parent)
+        self._index = index
+
+    def paintEvent(self, event) -> None:
+        super().paintEvent(event)
+        painter = QPainter(self)
+        label = f"HDU {self._index}"
+        font = QFont()
+        font.setPixelSize(10)
+        font.setBold(True)
+        painter.setFont(font)
+        fm = painter.fontMetrics()
+        padding = 2
+        bg_rect = QRect(
+            2, 2,
+            fm.horizontalAdvance(label) + 2 * padding,
+            fm.height() + padding,
+        )
+        r, g, b, a = MosaicThumbnailColors.LABEL_BACKGROUND_RGBA
+        painter.fillRect(bg_rect, QColor(r, g, b, a))
+        color_hex = (
+            MosaicThumbnailColors.LABEL_TEXT_SELECTED
+            if self.isChecked()
+            else MosaicThumbnailColors.LABEL_TEXT
+        )
+        painter.setPen(QColor(color_hex))
+        painter.drawText(bg_rect, Qt.AlignCenter, label)
+        painter.end()
 
 
 class MosaicView(QWidget):
@@ -98,10 +133,10 @@ class MosaicView(QWidget):
         """Calculates and sets the fixed height based on content + scrollbar."""
         thumb_h = self.viewModel.thumbnailHeight
 
-        # Button height = thumb_h + 10 (padding) + 20 (text) = thumb_h + 30
+        # Button height = thumb_h + 10 (padding; label is overlaid on icon)
         # Container margins = 5 top + 5 bottom = 10
         # Scrollbar height = 12
-        total_h = (thumb_h + 30) + 10 + 12
+        total_h = (thumb_h + 10) + 10 + 12
         total_h = max(total_h, self.MIN_HEIGHT)
 
         self.setFixedHeight(total_h)
@@ -130,10 +165,9 @@ class MosaicView(QWidget):
             q_img = QImage(buffer.data, width, height, width, QImage.Format_Grayscale8)
             pixmap = QPixmap.fromImage(q_img.copy())
 
-            btn = QToolButton()
+            btn = ThumbnailButton(i)
             btn.setIcon(QIcon(pixmap))
-            btn.setText(f"HDU {i}")
-            btn.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
+            btn.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
             # Calculate aspect ratio
             if height > 0:
@@ -146,9 +180,7 @@ class MosaicView(QWidget):
             # Set Icon Size (Actual Image)
             btn.setIconSize(QSize(target_w, target_h))
 
-            # Set Button Size (Image + Text/Padding)
-            # TextUnderIcon adds height, we adjust button size
-            btn.setFixedSize(target_w + btn_padding, target_h + btn_padding + 20)
+            btn.setFixedSize(target_w + btn_padding, target_h + btn_padding)
 
             btn.setCheckable(True)
             btn.setAutoExclusive(True)  # Only one can be checked

--- a/src/le_beta_vis/frontend/views/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/RawDataView.py
@@ -17,10 +17,8 @@ from PySide6.QtWidgets import (
 )
 
 from ..fitsconverters import Colormap, ScalingFunction
-from ..viewmodels.RawDataViewModel import (
-    ClusteringState,
-    RawDataViewModel,
-)
+from ..viewmodels.ClusterAnalysisViewModel import ClusteringState
+from ..viewmodels.RawDataViewModel import RawDataViewModel
 from ..widgets.CaptureGraphicsView import CaptureGraphicsView
 from ..widgets.RawDataManipulationToolbar import RawDataManipulationToolbar
 from ..widgets.MagnifierGraphicsItem import MagnifierGraphicsItem
@@ -39,6 +37,11 @@ class RawDataView(QWidget):
         self.viewModel = viewModel
         self.initUI()
         self.bindViewModel()
+
+    @property
+    def _cavm(self):
+        """Shorthand accessor for the ClusterAnalysisViewModel sub-VM."""
+        return self.viewModel.clusterAnalysisViewModel
 
     def initUI(self):
         """Initializes the UI components and layout."""
@@ -94,7 +97,9 @@ class RawDataView(QWidget):
         centerLayout.addWidget(self._createStatusBar())
         self._activateDefaultTool()
 
-        self._clusteringOverlay = ClusteringProgressOverlay(self._centerContainer)
+        self._clusteringOverlay = ClusteringProgressOverlay(
+            self._centerContainer
+        )
         self.bodyLayout.addWidget(self._centerContainer)
 
     def _setupGraphicsScene(self, centerLayout: QVBoxLayout) -> None:
@@ -129,8 +134,8 @@ class RawDataView(QWidget):
 
         hud = self._centerContainer.hudWidget
         if hud is not None:
-            hud.setBoxSelectionColor(self.viewModel.boxSelectColor)
-            hud.setBoxSelectionBorderWidth(self.viewModel.boxSelectBorderWidth)
+            hud.setBoxSelectionColor(self._cavm.boxSelectColor)
+            hud.setBoxSelectionBorderWidth(self._cavm.boxSelectBorderWidth)
             hud.bindMagnifier(self._magnifierItem)
 
     def _createStatusBar(self) -> QWidget:
@@ -158,7 +163,9 @@ class RawDataView(QWidget):
         """Sets the box-select cursor mode and shows the initial hint."""
         self.graphicsView.setBoxSelectActive(True)
         if self.viewModel.showToolHints:
-            self._hintLabel.setText(self.tr("\u21e7 Shift + drag to select ROI"))
+            self._hintLabel.setText(
+                self.tr("\u21e7 Shift + drag to select ROI")
+            )
             self._hintLabel.setVisible(True)
 
     def _setupRightSidebar(self):
@@ -176,8 +183,12 @@ class RawDataView(QWidget):
 
     def _setupRightSidebarTabs(self):
         self._rightSidebarTabs = QTabWidget()
-        self._rightSidebarTabs.addTab(self._buildVisualizationTab(), self.tr("Vis"))
-        self._rightSidebarTabs.addTab(self._buildClusteringTab(), self.tr("Clustering"))
+        self._rightSidebarTabs.addTab(
+            self._buildVisualizationTab(), self.tr("Vis")
+        )
+        self._rightSidebarTabs.addTab(
+            self._buildClusteringTab(), self.tr("Clustering")
+        )
         self._roiInfoTabIndex = self._rightSidebarTabs.addTab(
             self._buildRoiInfoTab(), self.tr("ROI Info")
         )
@@ -256,10 +267,14 @@ class RawDataView(QWidget):
         """Wire active tool, magnifier, and pointer hover callbacks."""
 
         def on_active_tool_changed():
-            QMetaObject.invokeMethod(self, "_updateActiveTool", Qt.QueuedConnection)
+            QMetaObject.invokeMethod(
+                self, "_updateActiveTool", Qt.QueuedConnection
+            )
 
         def on_magnifier_state_changed():
-            QMetaObject.invokeMethod(self, "_updateMagnifierState", Qt.QueuedConnection)
+            QMetaObject.invokeMethod(
+                self, "_updateMagnifierState", Qt.QueuedConnection
+            )
 
         def on_magnifier_position_changed():
             QMetaObject.invokeMethod(
@@ -276,11 +291,15 @@ class RawDataView(QWidget):
             )
 
         self.viewModel.add_active_tool_changed_callback(on_active_tool_changed)
-        self.viewModel.add_magnifier_state_changed_callback(on_magnifier_state_changed)
+        self.viewModel.add_magnifier_state_changed_callback(
+            on_magnifier_state_changed
+        )
         self.viewModel.add_magnifier_position_changed_callback(
             on_magnifier_position_changed
         )
-        self.viewModel.add_pointer_hover_changed_callback(on_pointer_hover_changed)
+        self.viewModel.add_pointer_hover_changed_callback(
+            on_pointer_hover_changed
+        )
 
     def _bindGraphicsViewSignals(self):
         """Connect CaptureGraphicsView Qt signals to handlers."""
@@ -290,16 +309,20 @@ class RawDataView(QWidget):
             self.viewModel.adjustMagnification
         )
         self.graphicsView.mouseLeft.connect(self.viewModel.clearPointerHover)
-        self.graphicsView.boxSelectionCompleted.connect(self._onBoxSelectionCompleted)
+        self.graphicsView.boxSelectionCompleted.connect(
+            self._onBoxSelectionCompleted
+        )
         self.graphicsView.boxSelectClicked.connect(self._onBoxSelectClicked)
 
     def _bindRoiCallbacks(self):
         """Wire ROI change callback for the box selection visual."""
 
         def on_roi_changed():
-            QMetaObject.invokeMethod(self, "_updateBoxSelection", Qt.QueuedConnection)
+            QMetaObject.invokeMethod(
+                self, "_updateBoxSelection", Qt.QueuedConnection
+            )
 
-        self.viewModel.add_roi_changed_callback(on_roi_changed)
+        self._cavm.add_roi_changed_callback(on_roi_changed)
 
     def _bindClusteringOverlayCallbacks(self):
         """Wire clustering overlay (progress, state, error, cancel).
@@ -316,7 +339,7 @@ class RawDataView(QWidget):
                 Qt.AutoConnection,
             )
 
-        self.viewModel.add_clustering_state_changed_callback(
+        self._cavm.add_clustering_state_changed_callback(
             on_clustering_state_changed
         )
 
@@ -327,9 +350,11 @@ class RawDataView(QWidget):
                 Qt.AutoConnection,
             )
 
-        self.viewModel.add_clustering_progress_callback(on_clustering_progress)
+        self._cavm.add_clustering_progress_callback(on_clustering_progress)
 
-        self._clusteringOverlay.cancelRequested.connect(self.viewModel.cancelClustering)
+        self._clusteringOverlay.cancelRequested.connect(
+            self._cavm.cancelClustering
+        )
 
         def on_clustering_error():
             QMetaObject.invokeMethod(
@@ -338,7 +363,7 @@ class RawDataView(QWidget):
                 Qt.QueuedConnection,
             )
 
-        self.viewModel.add_clustering_error_callback(on_clustering_error)
+        self._cavm.add_clustering_error_callback(on_clustering_error)
 
     def updateMosaicVisibility(self):
         count = len(self.viewModel.mosaicViewModel.thumbnails)
@@ -413,7 +438,7 @@ class RawDataView(QWidget):
 
     @Slot()
     def _updateActiveTool(self):
-        """Syncs cursor modes, overlays, and hint label with the active tool."""
+        """Syncs cursor modes, overlays, and hint with the active tool."""
         magnifierActive = self.viewModel.isMagnifierActive
         boxSelectActive = self.viewModel.isBoxSelectActive
 
@@ -428,7 +453,9 @@ class RawDataView(QWidget):
             self.viewModel.clearPointerHover()
 
         if boxSelectActive and self.viewModel.showToolHints:
-            self._hintLabel.setText(self.tr("\u21e7 Shift + drag to select ROI"))
+            self._hintLabel.setText(
+                self.tr("\u21e7 Shift + drag to select ROI")
+            )
             self._hintLabel.setVisible(True)
         else:
             self._hintLabel.setVisible(False)
@@ -439,7 +466,9 @@ class RawDataView(QWidget):
     @Slot()
     def _updateMagnifierState(self):
         """Updates the magnifier graphics item's magnification factor."""
-        self._magnifierItem.setMagnificationFactor(self.viewModel.magnificationFactor)
+        self._magnifierItem.setMagnificationFactor(
+            self.viewModel.magnificationFactor
+        )
         hud = self._centerContainer.hudWidget
         if hud is not None:
             hud.refreshMagnifier()
@@ -491,8 +520,12 @@ class RawDataView(QWidget):
         desiredX = col - (self._magnifierItem.displaySize / 2)
         desiredY = row - (magHeight / 2)
 
-        clampedX = max(imageRect.left(), min(desiredX, imageRect.right() - magWidth))
-        clampedY = max(imageRect.top(), min(desiredY, imageRect.bottom() - magHeight))
+        clampedX = max(
+            imageRect.left(), min(desiredX, imageRect.right() - magWidth)
+        )
+        clampedY = max(
+            imageRect.top(), min(desiredY, imageRect.bottom() - magHeight)
+        )
 
         if magWidth > imageRect.width():
             clampedX = imageRect.left()
@@ -502,21 +535,28 @@ class RawDataView(QWidget):
         self._magnifierItem.setPos(clampedX, clampedY)
 
     @Slot(int, int, int, int)
-    def _onBoxSelectionCompleted(self, top: int, left: int, bottom: int, right: int):
+    def _onBoxSelectionCompleted(
+        self, top: int, left: int, bottom: int, right: int
+    ):
         """Handles a completed box selection from the graphics view."""
-        self.viewModel.clearRois()
-        self.viewModel.addRoi(top, left, bottom, right)
+        self._cavm.clearRois()
+        self._cavm.addRoi(top, left, bottom, right)
         self._rightSidebarTabs.setCurrentIndex(self._roiInfoTabIndex)
 
     @Slot(int, int)
     def _onBoxSelectClicked(self, row: int, col: int) -> None:
         """Dismisses the ROI if the click is outside the selection."""
-        rois = self.viewModel.rois
+        rois = self._cavm.rois
         if not rois:
             return
         bbox = rois[-1].geometry()
-        if row < bbox.top or row >= bbox.bottom or col < bbox.left or col >= bbox.right:
-            self.viewModel.clearRois()
+        if (
+            row < bbox.top
+            or row >= bbox.bottom
+            or col < bbox.left
+            or col >= bbox.right
+        ):
+            self._cavm.clearRois()
 
     @Slot()
     def _updateBoxSelection(self):
@@ -524,7 +564,7 @@ class RawDataView(QWidget):
         hud = self._centerContainer.hudWidget
         if hud is None:
             return
-        rois = self.viewModel.rois
+        rois = self._cavm.rois
         if rois:
             bbox = rois[-1].geometry()
             sceneRect = QRectF(
@@ -540,7 +580,7 @@ class RawDataView(QWidget):
     @Slot()
     def _updateClusteringState(self):
         """Shows/hides overlay and enables/disables UI for clustering."""
-        running = self.viewModel.clusteringState == ClusteringState.RUNNING
+        running = self._cavm.clusteringState == ClusteringState.RUNNING
         if running:
             self._clusteringOverlay.showOverlay()
         else:
@@ -550,12 +590,12 @@ class RawDataView(QWidget):
     @Slot()
     def _updateClusteringProgress(self):
         """Updates the overlay progress bar from ViewModel state."""
-        self._clusteringOverlay.setProgress(self.viewModel.clusteringProgress)
+        self._clusteringOverlay.setProgress(self._cavm.clusteringProgress)
 
     @Slot()
     def _showClusteringError(self):
         """Displays a warning dialog with the clustering error message."""
-        message = self.viewModel.clusteringError or self.tr(
+        message = self._cavm.clusteringError or self.tr(
             "An unknown error occurred during cluster extraction."
         )
         QMessageBox.warning(

--- a/src/le_beta_vis/frontend/views/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/RawDataView.py
@@ -1,17 +1,7 @@
-from PySide6.QtCore import QMetaObject, QRectF, QSize, Qt, Slot
-from PySide6.QtGui import (
-    QColor,
-    QFont,
-    QIcon,
-    QImage,
-    QPainter,
-    QPen,
-    QPixmap,
-    QTransform,
-)
+from PySide6.QtCore import QMetaObject, QRectF, Qt, Slot
+from PySide6.QtGui import QImage, QPixmap, QTransform
 from PySide6.QtWidgets import (
     QApplication,
-    QButtonGroup,
     QComboBox,
     QFrame,
     QGraphicsPixmapItem,
@@ -22,18 +12,17 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QStyleFactory,
     QTabWidget,
-    QToolButton,
     QVBoxLayout,
     QWidget,
 )
 
 from ..fitsconverters import Colormap, ScalingFunction
 from ..viewmodels.RawDataViewModel import (
-    ActiveTool,
     ClusteringState,
     RawDataViewModel,
 )
 from ..widgets.CaptureGraphicsView import CaptureGraphicsView
+from ..widgets.RawDataManipulationToolbar import RawDataManipulationToolbar
 from ..widgets.MagnifierGraphicsItem import MagnifierGraphicsItem
 from ..widgets.ClusteringProgressOverlay import ClusteringProgressOverlay
 from ..widgets.HDUVisualizationWidget import HDUVisualizationWidget
@@ -91,144 +80,14 @@ class RawDataView(QWidget):
 
         self.bodyLayout.addWidget(self.leftToolbar)
 
-    def _setupTopToolbar(self) -> None:
-        """Creates the horizontal top toolbar with tool and zoom buttons."""
-        self.topToolbar = QFrame()
-        self.topToolbar.setFixedHeight(46)
-        self.topToolbar.setStyleSheet(_Style.TOP_TOOLBAR)
-        layout = QHBoxLayout(self.topToolbar)
-        layout.setContentsMargins(8, 3, 8, 3)
-        layout.setSpacing(4)
-
-        self._createToolButtons(layout)
-        self._createZoomButtons(layout)
-
-    def _createToolButtons(self, layout: QHBoxLayout) -> None:
-        """Creates the exclusive tool button group (ROI + Magnifier)
-        and adds them to the given toolbar layout."""
-        btn_size = QSize(36, 36)
-        style = _Style.LEFT_TOOLBAR_BUTTON
-
-        self._toolButtonGroup = QButtonGroup(self)
-        self._toolButtonGroup.setExclusive(True)
-
-        self.btnBoxSelect = QToolButton()
-        self.btnBoxSelect.setIcon(self._createBoxSelectIcon())
-        self.btnBoxSelect.setToolTip(self.tr("Region Of Interest"))
-        self.btnBoxSelect.setCheckable(True)
-        self.btnBoxSelect.setChecked(True)
-        self.btnBoxSelect.setFixedSize(btn_size)
-        self.btnBoxSelect.setStyleSheet(style)
-        self.btnBoxSelect.clicked.connect(
-            lambda: self.viewModel.setActiveTool(ActiveTool.BOX_SELECT)
-        )
-        self._toolButtonGroup.addButton(self.btnBoxSelect)
-        layout.addWidget(self.btnBoxSelect)
-
-        self.btnMagnifier = QToolButton()
-        self.btnMagnifier.setIcon(self._createMagnifierIcon())
-        self.btnMagnifier.setToolTip(self.tr("Magnifier: Inspect pixels in detail"))
-        self.btnMagnifier.setCheckable(True)
-        self.btnMagnifier.setFixedSize(btn_size)
-        self.btnMagnifier.setStyleSheet(style)
-        self.btnMagnifier.clicked.connect(
-            lambda: self.viewModel.setActiveTool(ActiveTool.MAGNIFIER)
-        )
-        self._toolButtonGroup.addButton(self.btnMagnifier)
-        layout.addWidget(self.btnMagnifier)
-
-    def _createZoomButtons(self, layout: QHBoxLayout) -> None:
-        """Adds a vertical separator and the three zoom buttons
-        (Zoom In, Reset, Zoom Out) plus a trailing stretch."""
-        btn_size = QSize(36, 36)
-        style = _Style.LEFT_TOOLBAR_BUTTON
-
-        sep = QFrame()
-        sep.setFrameShape(QFrame.VLine)
-        sep.setFrameShadow(QFrame.Sunken)
-        sep.setStyleSheet(_Style.LEFT_TOOLBAR_DIVIDER)
-        sep.setFixedHeight(28)
-        layout.addWidget(sep)
-
-        self.btnZoomIn = QToolButton()
-        self.btnZoomIn.setText("+")
-        self.btnZoomIn.setToolTip(self.tr("Zoom In"))
-        self.btnZoomIn.setFixedSize(btn_size)
-        self.btnZoomIn.setStyleSheet(_Style.ZOOM_IN)
-        self.btnZoomIn.clicked.connect(self.viewModel.zoomIn)
-        layout.addWidget(self.btnZoomIn)
-
-        self.btnZoomReset = QToolButton()
-        self.btnZoomReset.setText("1x")
-        self.btnZoomReset.setToolTip(self.tr("Reset Zoom (1:1)"))
-        self.btnZoomReset.setFixedSize(btn_size)
-        self.btnZoomReset.setStyleSheet(style)
-        self.btnZoomReset.clicked.connect(self.viewModel.resetZoom)
-        layout.addWidget(self.btnZoomReset)
-
-        self.btnZoomOut = QToolButton()
-        self.btnZoomOut.setText("-")
-        self.btnZoomOut.setToolTip(self.tr("Zoom Out"))
-        self.btnZoomOut.setFixedSize(btn_size)
-        self.btnZoomOut.setStyleSheet(_Style.ZOOM_OUT)
-        self.btnZoomOut.clicked.connect(self.viewModel.zoomOut)
-        layout.addWidget(self.btnZoomOut)
-
-        layout.addStretch()
-
-    def _createMagnifierIcon(self) -> QIcon:
-        """Creates a magnifier icon from theme or painted fallback."""
-        icon = QIcon.fromTheme("edit-find")
-        if not icon.isNull():
-            return icon
-
-        pixmap = QPixmap(40, 40)
-        pixmap.fill(Qt.transparent)
-        painter = QPainter(pixmap)
-        painter.setPen(QColor("#ffffff"))
-        font = QFont()
-        font.setPixelSize(24)
-        painter.setFont(font)
-        painter.drawText(pixmap.rect(), Qt.AlignCenter, "\U0001f50d")
-        painter.end()
-        return QIcon(pixmap)
-
-    def _createBoxSelectIcon(self) -> QIcon:
-        """Creates a dashed rectangle icon for the Box Select tool."""
-        size = 40
-        pixmap = QPixmap(size, size)
-        pixmap.fill(Qt.transparent)
-        painter = QPainter(pixmap)
-        painter.setRenderHint(QPainter.Antialiasing)
-        pen = QPen(QColor("#ffffff"))
-        pen.setWidth(2)
-        pen.setStyle(Qt.DashLine)
-        painter.setPen(pen)
-        margin = 8
-        painter.drawRect(margin, margin, size - 2 * margin, size - 2 * margin)
-        # Corner handles
-        handle = 4
-        corners = [
-            (margin, margin),
-            (size - margin, margin),
-            (margin, size - margin),
-            (size - margin, size - margin),
-        ]
-        painter.setPen(Qt.NoPen)
-        painter.setBrush(QColor("#ffffff"))
-        for cx, cy in corners:
-            painter.drawRect(cx - handle // 2, cy - handle // 2, handle, handle)
-        painter.end()
-        return QIcon(pixmap)
-
     def _setupCenterImageArea(self) -> None:
         """Assembles the center image area: toolbar, graphics scene,
         overlays, status bar, and clustering overlay."""
         self._centerContainer = HDUVisualizationWidget()
         centerLayout = self._centerContainer.contentLayout
 
-        self._setupTopToolbar()
-        centerLayout.addWidget(self.topToolbar)
+        self._toolbar = RawDataManipulationToolbar(self.viewModel)
+        centerLayout.addWidget(self._toolbar)
 
         self._setupGraphicsScene(centerLayout)
         self._setupSceneOverlays()
@@ -541,31 +400,20 @@ class RawDataView(QWidget):
     @Slot()
     def updateZoom(self):
         """Updates the graphics view transform based on scale."""
-        # UX Feedback: Busy Cursor & Disable Buttons
         QApplication.setOverrideCursor(Qt.WaitCursor)
-        self.btnZoomIn.setEnabled(False)
-        self.btnZoomOut.setEnabled(False)
-        self.btnZoomReset.setEnabled(False)
-
+        self._toolbar.setZoomControlsEnabled(False)
         try:
             scale = self.viewModel.scale
             transform = QTransform()
             transform.scale(scale, scale)
             self.graphicsView.setTransform(transform)
         finally:
-            # Restore UX
-            self.btnZoomIn.setEnabled(True)
-            self.btnZoomOut.setEnabled(True)
-            self.btnZoomReset.setEnabled(True)
+            self._toolbar.setZoomControlsEnabled(True)
             QApplication.restoreOverrideCursor()
 
     @Slot()
     def _updateActiveTool(self):
-        """Syncs toolbar button states, cursor modes, and overlays."""
-        tool = self.viewModel.activeTool
-        self.btnMagnifier.setChecked(tool == ActiveTool.MAGNIFIER)
-        self.btnBoxSelect.setChecked(tool == ActiveTool.BOX_SELECT)
-
+        """Syncs cursor modes, overlays, and hint label with the active tool."""
         magnifierActive = self.viewModel.isMagnifierActive
         boxSelectActive = self.viewModel.isBoxSelectActive
 
@@ -718,7 +566,7 @@ class RawDataView(QWidget):
 
     def _setInteractionEnabled(self, enabled: bool) -> None:
         """Enables or disables interactive controls."""
-        self.topToolbar.setEnabled(enabled)
+        self._toolbar.setEnabled(enabled)
         self.leftToolbar.setEnabled(enabled)
         self.rightSidebar.setEnabled(enabled)
 

--- a/src/le_beta_vis/frontend/views/_RawDataViewStyle.py
+++ b/src/le_beta_vis/frontend/views/_RawDataViewStyle.py
@@ -1,22 +1,5 @@
-from le_beta_vis.frontend.theme import TooltipStyle
-
-
 class _Style:
     LEFT_TOOLBAR = "background-color: #2d2d2d; border-right: 1px solid #3d3d3d;"
-    TOP_TOOLBAR = "background-color: #2d2d2d; border-bottom: 1px solid #3d3d3d;"
-    LEFT_TOOLBAR_BUTTON = (
-        "QToolButton { font-weight: bold; color: #ffffff; }"
-        f"{TooltipStyle.QSS}"
-    )
-    LEFT_TOOLBAR_DIVIDER = "background-color: #555555;"
-    ZOOM_IN = (
-        "QToolButton { font-size: 20px; font-weight: bold; color: #ffffff; }"
-        f"{TooltipStyle.QSS}"
-    )
-    ZOOM_OUT = (
-        "QToolButton { font-size: 20px; font-weight: bold; color: #ffffff; }"
-        f"{TooltipStyle.QSS}"
-    )
     GRAPHICS_VIEW = """
         QGraphicsView {
             background-color: #000;

--- a/src/le_beta_vis/frontend/widgets/ROIInfoWidget.py
+++ b/src/le_beta_vis/frontend/widgets/ROIInfoWidget.py
@@ -25,6 +25,9 @@ from le_beta_vis.frontend.widgets.InteractiveHistogramWidget import (
 )
 
 if TYPE_CHECKING:
+    from le_beta_vis.frontend.viewmodels.ClusterAnalysisViewModel import (
+        ClusterAnalysisViewModel,
+    )
     from le_beta_vis.frontend.viewmodels.RawDataViewModel import (
         RawDataViewModel,
     )
@@ -36,7 +39,9 @@ _HISTOGRAM_BINS = 50
 
 class _Style:
     HEADER = "font-weight: bold; font-size: 13px; color: #333333;"
-    STAT_LABEL = "font-weight: bold; font-size: 11px; color: #555555; border: none;"
+    STAT_LABEL = (
+        "font-weight: bold; font-size: 11px; color: #555555; border: none;"
+    )
     STAT_VALUE = "font-size: 11px; color: #222222; border: none;"
 
 
@@ -50,6 +55,9 @@ class ROIInfoWidget(QWidget):
     ) -> None:
         super().__init__(parent)
         self._vm = viewModel
+        self._cavm: ClusterAnalysisViewModel = (
+            viewModel.clusterAnalysisViewModel
+        )
         self._stat_labels: Dict[str, QLabel] = {}
         self._roi_coord_labels: Dict[str, QLabel] = {}
         self._initUI()
@@ -137,7 +145,7 @@ class ROIInfoWidget(QWidget):
 
     def _bindViewModel(self) -> None:
         """Connects ViewModel callbacks to the render slot."""
-        self._vm.add_roi_changed_callback(self._onRoiChanged)
+        self._cavm.add_roi_changed_callback(self._onRoiChanged)
         self._vm.add_image_changed_callback(self._onImageChanged)
 
     def _onRoiChanged(self) -> None:
@@ -161,7 +169,7 @@ class ROIInfoWidget(QWidget):
     @Slot()
     def _scheduleRender(self) -> None:
         """Builds all display sections from current ROI data."""
-        roi_data = self._vm.selectedRoiRawData
+        roi_data = self._cavm.selectedRoiRawData
         if roi_data is None:
             self._clearAll()
             return
@@ -173,7 +181,7 @@ class ROIInfoWidget(QWidget):
 
     def _updateCoords(self) -> None:
         """Populates ROI origin and dimensions from the bounding box."""
-        bbox = self._vm.selectedRoiBoundingBox
+        bbox = self._cavm.selectedRoiBoundingBox
         if bbox is None:
             return
         width = bbox.right - bbox.left
@@ -187,7 +195,7 @@ class ROIInfoWidget(QWidget):
 
     def _updateStatistics(self, data: np.ndarray) -> None:
         """Computes and displays ROI statistics."""
-        bbox = self._vm.selectedRoiBoundingBox
+        bbox = self._cavm.selectedRoiBoundingBox
         if bbox is None:
             return
         stats = ROIStatistics.from_roi_data(
@@ -199,10 +207,10 @@ class ROIInfoWidget(QWidget):
 
     def _updateHistogram(self, data: np.ndarray) -> None:
         """Builds a histogram model and pushes it to the widget."""
-        cmap_enum = self._vm.clusterThumbnailColormap
+        cmap_enum = self._cavm.clusterThumbnailColormap
         colormap_str = cmap_enum.value if cmap_enum is not None else None
 
-        if self._vm.displayEnergyInKev:
+        if self._cavm.displayEnergyInKev:
             data = self._vm.physics_manager.adu_to_kev(data)
             x_label = "Energy (keV)"
             x_unit = "keV"

--- a/src/le_beta_vis/frontend/widgets/RawDataManipulationToolbar.py
+++ b/src/le_beta_vis/frontend/widgets/RawDataManipulationToolbar.py
@@ -1,0 +1,202 @@
+"""Horizontal toolbar for the Raw Data Analysis view.
+
+Owns the tool-selection buttons (ROI box-select, magnifier), zoom controls,
+and the active-HDU indicator label.  Binds ViewModel callbacks directly so
+RawDataView only needs to call setZoomControlsEnabled() during a zoom
+transform and setEnabled() during clustering.
+"""
+
+from PySide6.QtCore import QMetaObject, QSize, Qt, Slot
+from PySide6.QtGui import QColor, QFont, QIcon, QPainter, QPen, QPixmap
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QToolButton,
+)
+
+from ..theme import RawDataManipulationToolbarColors, TooltipStyle
+from ..viewmodels.RawDataViewModel import ActiveTool, RawDataViewModel
+
+
+class _Style:
+    TOOLBAR = "background-color: #2d2d2d; border-bottom: 1px solid #3d3d3d;"
+    BUTTON = "QToolButton { font-weight: bold; color: #ffffff; }" f"{TooltipStyle.QSS}"
+    DIVIDER = "background-color: #555555;"
+    ZOOM_IN = (
+        "QToolButton { font-size: 20px; font-weight: bold; color: #ffffff; }"
+        f"{TooltipStyle.QSS}"
+    )
+    ZOOM_OUT = (
+        "QToolButton { font-size: 20px; font-weight: bold; color: #ffffff; }"
+        f"{TooltipStyle.QSS}"
+    )
+    HDU_LABEL = (
+        f"color: {RawDataManipulationToolbarColors.HDU_LABEL};"
+        " font-size: 11px; padding-left: 8px; font-weight: bold;"
+    )
+
+
+class RawDataManipulationToolbar(QFrame):
+    """Horizontal toolbar strip for the Raw Data Analysis view."""
+
+    def __init__(self, viewModel: RawDataViewModel) -> None:
+        super().__init__()
+        self._viewModel = viewModel
+        self._setupUI()
+        self._bindViewModel()
+
+    def _setupUI(self) -> None:
+        self.setFixedHeight(46)
+        self.setStyleSheet(_Style.TOOLBAR)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 3, 8, 3)
+        layout.setSpacing(4)
+        self._createToolButtons(layout)
+        self._createZoomButtons(layout)
+        self._createHDULabel(layout)
+
+    def _createToolButtons(self, layout: QHBoxLayout) -> None:
+        """Creates the exclusive tool button group (ROI + Magnifier)."""
+        btn_size = QSize(36, 36)
+
+        self._toolButtonGroup = QButtonGroup(self)
+        self._toolButtonGroup.setExclusive(True)
+
+        self.btnBoxSelect = QToolButton()
+        self.btnBoxSelect.setIcon(self._createBoxSelectIcon())
+        self.btnBoxSelect.setToolTip(self.tr("Region Of Interest"))
+        self.btnBoxSelect.setCheckable(True)
+        self.btnBoxSelect.setChecked(True)
+        self.btnBoxSelect.setFixedSize(btn_size)
+        self.btnBoxSelect.setStyleSheet(_Style.BUTTON)
+        self.btnBoxSelect.clicked.connect(
+            lambda: self._viewModel.setActiveTool(ActiveTool.BOX_SELECT)
+        )
+        self._toolButtonGroup.addButton(self.btnBoxSelect)
+        layout.addWidget(self.btnBoxSelect)
+
+        self.btnMagnifier = QToolButton()
+        self.btnMagnifier.setIcon(self._createMagnifierIcon())
+        self.btnMagnifier.setToolTip(self.tr("Magnifier: Inspect pixels in detail"))
+        self.btnMagnifier.setCheckable(True)
+        self.btnMagnifier.setFixedSize(btn_size)
+        self.btnMagnifier.setStyleSheet(_Style.BUTTON)
+        self.btnMagnifier.clicked.connect(
+            lambda: self._viewModel.setActiveTool(ActiveTool.MAGNIFIER)
+        )
+        self._toolButtonGroup.addButton(self.btnMagnifier)
+        layout.addWidget(self.btnMagnifier)
+
+    def _createZoomButtons(self, layout: QHBoxLayout) -> None:
+        """Adds a vertical separator and the three zoom buttons."""
+        btn_size = QSize(36, 36)
+
+        sep = QFrame()
+        sep.setFrameShape(QFrame.VLine)
+        sep.setFrameShadow(QFrame.Sunken)
+        sep.setStyleSheet(_Style.DIVIDER)
+        sep.setFixedHeight(28)
+        layout.addWidget(sep)
+
+        self.btnZoomIn = QToolButton()
+        self.btnZoomIn.setText("+")
+        self.btnZoomIn.setToolTip(self.tr("Zoom In"))
+        self.btnZoomIn.setFixedSize(btn_size)
+        self.btnZoomIn.setStyleSheet(_Style.ZOOM_IN)
+        self.btnZoomIn.clicked.connect(self._viewModel.zoomIn)
+        layout.addWidget(self.btnZoomIn)
+
+        self.btnZoomReset = QToolButton()
+        self.btnZoomReset.setText("1x")
+        self.btnZoomReset.setToolTip(self.tr("Reset Zoom (1:1)"))
+        self.btnZoomReset.setFixedSize(btn_size)
+        self.btnZoomReset.setStyleSheet(_Style.BUTTON)
+        self.btnZoomReset.clicked.connect(self._viewModel.resetZoom)
+        layout.addWidget(self.btnZoomReset)
+
+        self.btnZoomOut = QToolButton()
+        self.btnZoomOut.setText("-")
+        self.btnZoomOut.setToolTip(self.tr("Zoom Out"))
+        self.btnZoomOut.setFixedSize(btn_size)
+        self.btnZoomOut.setStyleSheet(_Style.ZOOM_OUT)
+        self.btnZoomOut.clicked.connect(self._viewModel.zoomOut)
+        layout.addWidget(self.btnZoomOut)
+
+    def _createHDULabel(self, layout: QHBoxLayout) -> None:
+        layout.addStretch()
+        self.selectedHDULabel = QLabel()
+        self.selectedHDULabel.setStyleSheet(_Style.HDU_LABEL)
+        layout.addWidget(self.selectedHDULabel)
+
+    def _createMagnifierIcon(self) -> QIcon:
+        """Creates a magnifier icon from theme or painted fallback."""
+        icon = QIcon.fromTheme("edit-find")
+        if not icon.isNull():
+            return icon
+
+        pixmap = QPixmap(40, 40)
+        pixmap.fill(Qt.transparent)
+        painter = QPainter(pixmap)
+        painter.setPen(QColor("#ffffff"))
+        font = QFont()
+        font.setPixelSize(24)
+        painter.setFont(font)
+        painter.drawText(pixmap.rect(), Qt.AlignCenter, "\U0001f50d")
+        painter.end()
+        return QIcon(pixmap)
+
+    def _createBoxSelectIcon(self) -> QIcon:
+        """Creates a dashed rectangle icon for the Box Select tool."""
+        size = 40
+        pixmap = QPixmap(size, size)
+        pixmap.fill(Qt.transparent)
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.Antialiasing)
+        pen = QPen(QColor("#ffffff"))
+        pen.setWidth(2)
+        pen.setStyle(Qt.DashLine)
+        painter.setPen(pen)
+        margin = 8
+        painter.drawRect(margin, margin, size - 2 * margin, size - 2 * margin)
+        handle = 4
+        corners = [
+            (margin, margin),
+            (size - margin, margin),
+            (margin, size - margin),
+            (size - margin, size - margin),
+        ]
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(QColor("#ffffff"))
+        for cx, cy in corners:
+            painter.drawRect(cx - handle // 2, cy - handle // 2, handle, handle)
+        painter.end()
+        return QIcon(pixmap)
+
+    def setZoomControlsEnabled(self, enabled: bool) -> None:
+        """Enables or disables zoom buttons during a zoom transform."""
+        self.btnZoomIn.setEnabled(enabled)
+        self.btnZoomReset.setEnabled(enabled)
+        self.btnZoomOut.setEnabled(enabled)
+
+    def _bindViewModel(self) -> None:
+        def on_active_tool_changed():
+            QMetaObject.invokeMethod(self, "_updateToolButtons", Qt.AutoConnection)
+
+        def on_active_hdu_changed():
+            QMetaObject.invokeMethod(self, "_updateHDULabel", Qt.AutoConnection)
+
+        self._viewModel.add_active_tool_changed_callback(on_active_tool_changed)
+        self._viewModel.add_active_hdu_changed_callback(on_active_hdu_changed)
+
+    @Slot()
+    def _updateToolButtons(self) -> None:
+        tool = self._viewModel.activeTool
+        self.btnMagnifier.setChecked(tool == ActiveTool.MAGNIFIER)
+        self.btnBoxSelect.setChecked(tool == ActiveTool.BOX_SELECT)
+
+    @Slot()
+    def _updateHDULabel(self) -> None:
+        label = self._viewModel.activeHDULabel
+        self.selectedHDULabel.setText(self.tr(label) if label else "")

--- a/src/le_beta_vis/frontend/widgets/__init__.py
+++ b/src/le_beta_vis/frontend/widgets/__init__.py
@@ -12,6 +12,7 @@ from .ClusteredEventWidget import ClusteredEventWidget
 from .EnergyClusterWidget import EnergyClusterWidget
 from .InteractiveHistogramWidget import InteractiveHistogramWidget
 from .HistoricalFilterBar import HistoricalFilterBar
+from .RawDataManipulationToolbar import RawDataManipulationToolbar
 from .HistoricalAdvancedFilterDialog import (
     HistoricalAdvancedFilterDialog,
 )

--- a/tests/test_BoxSelectViewModel.py
+++ b/tests/test_BoxSelectViewModel.py
@@ -4,67 +4,73 @@ import numpy as np
 import pytest
 
 from le_beta_vis.common.BoundingBox import BoundingBox
-from mock_configuration_service import MockConfigurationService
 from le_beta_vis.common.RoiRect import RoiRect
+from mock_configuration_service import MockConfigurationService
+from le_beta_vis.common.PhysicsConversionManager import (
+    PhysicsConversionManagerImpl,
+)
+from le_beta_vis.frontend.viewmodels.ClusterAnalysisViewModel import (
+    ClusterAnalysisViewModel,
+)
 from le_beta_vis.frontend.viewmodels.RawDataViewModel import (
     ActiveTool,
     RawDataViewModel,
 )
-from le_beta_vis.common.PhysicsConversionManager import PhysicsConversionManagerImpl
+
+_RAW = np.zeros((10, 10), dtype=float)
 
 
 @pytest.fixture
-def view_model():
+def cavm():
     config = MockConfigurationService()
-    physics_manager = PhysicsConversionManagerImpl(config)
-    vm = RawDataViewModel(config, physics_manager)
+    physics = PhysicsConversionManagerImpl(config)
+    return ClusterAnalysisViewModel(config, physics, lambda: _RAW.copy())
+
+
+@pytest.fixture
+def rdvm():
+    config = MockConfigurationService()
+    physics = PhysicsConversionManagerImpl(config)
+    vm = RawDataViewModel(config, physics)
     vm._converter = MagicMock()
-    vm._converter.convert.return_value = np.zeros(
-        (10, 10, 3), dtype=np.uint8
-    )
-
-    def mock_request():
-        vm._render_worker_logic()
-
-    vm._request_render = mock_request
+    vm._converter.convert.return_value = np.zeros((10, 10, 3), dtype=np.uint8)
     return vm
 
 
-# --- isBoxSelectActive ---
+# --- isBoxSelectActive (RDVM tool state) ---
 
 
-def test_is_box_select_active_initial(view_model):
-    """Test that box select is active by default."""
-    assert view_model.isBoxSelectActive is True
+def test_is_box_select_active_initial(rdvm):
+    """Box select is active by default."""
+    assert rdvm.isBoxSelectActive is True
 
 
-def test_is_box_select_active_after_switch(view_model):
-    """Test isBoxSelectActive is True after switching to BOX_SELECT."""
-    view_model.setActiveTool(ActiveTool.BOX_SELECT)
-    assert view_model.isBoxSelectActive is True
+def test_is_box_select_active_after_switch(rdvm):
+    """isBoxSelectActive remains True after explicit BOX_SELECT set."""
+    rdvm.setActiveTool(ActiveTool.BOX_SELECT)
+    assert rdvm.isBoxSelectActive is True
 
 
-def test_is_box_select_active_after_switch_away(view_model):
-    """Test isBoxSelectActive returns False after switching away."""
-    view_model.setActiveTool(ActiveTool.BOX_SELECT)
-    view_model.setActiveTool(ActiveTool.MAGNIFIER)
-    assert view_model.isBoxSelectActive is False
+def test_is_box_select_active_after_switch_away(rdvm):
+    """isBoxSelectActive is False after switching to MAGNIFIER."""
+    rdvm.setActiveTool(ActiveTool.MAGNIFIER)
+    assert rdvm.isBoxSelectActive is False
 
 
 # --- addRoi ---
 
 
-def test_add_roi_stores_roi(view_model):
-    """Test that addRoi creates and stores the ROI."""
-    roi = view_model.addRoi(10, 20, 50, 80)
+def test_add_roi_stores_roi(cavm):
+    """addRoi creates and stores the ROI."""
+    roi = cavm.addRoi(10, 20, 50, 80)
     assert isinstance(roi, RoiRect)
     assert roi.geometry() == BoundingBox(10, 20, 50, 80)
-    assert len(view_model.rois) == 1
+    assert len(cavm.rois) == 1
 
 
-def test_add_roi_normalizes_coords(view_model):
-    """Test that addRoi normalizes inverted coordinates."""
-    roi = view_model.addRoi(50, 80, 10, 20)
+def test_add_roi_normalizes_coords(cavm):
+    """addRoi normalizes inverted coordinates."""
+    roi = cavm.addRoi(50, 80, 10, 20)
     bbox = roi.geometry()
     assert bbox.top == 10
     assert bbox.left == 20
@@ -72,117 +78,117 @@ def test_add_roi_normalizes_coords(view_model):
     assert bbox.right == 80
 
 
-def test_add_roi_fires_callbacks(view_model):
-    """Test that addRoi fires both roi_changed and selection_completed."""
+def test_add_roi_fires_callbacks(cavm):
+    """addRoi fires both roi_changed and box_selection_completed."""
     roi_cb = MagicMock()
     sel_cb = MagicMock()
-    view_model.add_roi_changed_callback(roi_cb)
-    view_model.add_box_selection_completed_callback(sel_cb)
-    view_model.addRoi(0, 0, 10, 10)
+    cavm.add_roi_changed_callback(roi_cb)
+    cavm.add_box_selection_completed_callback(sel_cb)
+    cavm.addRoi(0, 0, 10, 10)
     roi_cb.assert_called_once()
     sel_cb.assert_called_once()
 
 
-def test_multiple_rois(view_model):
-    """Test adding multiple ROIs."""
-    view_model.addRoi(0, 0, 10, 10)
-    view_model.addRoi(20, 20, 30, 30)
-    assert len(view_model.rois) == 2
+def test_multiple_rois(cavm):
+    """Multiple ROIs can be added."""
+    cavm.addRoi(0, 0, 10, 10)
+    cavm.addRoi(20, 20, 30, 30)
+    assert len(cavm.rois) == 2
 
 
 # --- clearRois ---
 
 
-def test_clear_rois(view_model):
-    """Test that clearRois removes all ROIs and fires callback."""
-    view_model.addRoi(0, 0, 10, 10)
+def test_clear_rois(cavm):
+    """clearRois removes all ROIs and fires callback."""
+    cavm.addRoi(0, 0, 10, 10)
     cb = MagicMock()
-    view_model.add_roi_changed_callback(cb)
-    view_model.clearRois()
-    assert len(view_model.rois) == 0
+    cavm.add_roi_changed_callback(cb)
+    cavm.clearRois()
+    assert len(cavm.rois) == 0
     cb.assert_called_once()
 
 
-def test_clear_rois_when_empty(view_model):
-    """Test that clearRois does not fire if already empty."""
+def test_clear_rois_when_empty(cavm):
+    """clearRois does not fire if already empty."""
     cb = MagicMock()
-    view_model.add_roi_changed_callback(cb)
-    view_model.clearRois()
+    cavm.add_roi_changed_callback(cb)
+    cavm.clearRois()
     cb.assert_not_called()
 
 
 # --- removeRoi ---
 
 
-def test_remove_roi(view_model):
-    """Test removing an ROI by index."""
-    view_model.addRoi(0, 0, 10, 10)
-    view_model.addRoi(20, 20, 30, 30)
+def test_remove_roi(cavm):
+    """Removing ROI by index works."""
+    cavm.addRoi(0, 0, 10, 10)
+    cavm.addRoi(20, 20, 30, 30)
     cb = MagicMock()
-    view_model.add_roi_changed_callback(cb)
-    view_model.removeRoi(0)
-    assert len(view_model.rois) == 1
-    assert view_model.rois[0].geometry() == BoundingBox(20, 20, 30, 30)
+    cavm.add_roi_changed_callback(cb)
+    cavm.removeRoi(0)
+    assert len(cavm.rois) == 1
+    assert cavm.rois[0].geometry() == BoundingBox(20, 20, 30, 30)
     cb.assert_called_once()
 
 
-def test_remove_roi_invalid_index(view_model):
-    """Test that removing an invalid index does nothing."""
-    view_model.addRoi(0, 0, 10, 10)
+def test_remove_roi_invalid_index(cavm):
+    """Removing out-of-bounds index does nothing."""
+    cavm.addRoi(0, 0, 10, 10)
     cb = MagicMock()
-    view_model.add_roi_changed_callback(cb)
-    view_model.removeRoi(5)
-    assert len(view_model.rois) == 1
+    cavm.add_roi_changed_callback(cb)
+    cavm.removeRoi(5)
+    assert len(cavm.rois) == 1
     cb.assert_not_called()
 
 
-def test_remove_roi_negative_index(view_model):
-    """Test that removing a negative index does nothing."""
-    view_model.addRoi(0, 0, 10, 10)
+def test_remove_roi_negative_index(cavm):
+    """Removing negative index does nothing."""
+    cavm.addRoi(0, 0, 10, 10)
     cb = MagicMock()
-    view_model.add_roi_changed_callback(cb)
-    view_model.removeRoi(-1)
-    assert len(view_model.rois) == 1
+    cavm.add_roi_changed_callback(cb)
+    cavm.removeRoi(-1)
+    assert len(cavm.rois) == 1
     cb.assert_not_called()
 
 
 # --- rois returns copy ---
 
 
-def test_rois_returns_copy(view_model):
-    """Test that rois property returns a copy, not the internal list."""
-    view_model.addRoi(0, 0, 10, 10)
-    rois_copy = view_model.rois
+def test_rois_returns_copy(cavm):
+    """rois property returns a copy, not the internal list."""
+    cavm.addRoi(0, 0, 10, 10)
+    rois_copy = cavm.rois
     rois_copy.clear()
-    assert len(view_model.rois) == 1
+    assert len(cavm.rois) == 1
 
 
 # --- Config properties ---
 
 
-def test_box_select_color(view_model):
-    """Test boxSelectColor returns config value."""
-    assert view_model.boxSelectColor == "#00BFFF"
+def test_box_select_color(cavm):
+    """boxSelectColor returns config default."""
+    assert cavm.boxSelectColor == "#00BFFF"
 
 
-def test_box_select_border_width(view_model):
-    """Test boxSelectBorderWidth returns config value."""
-    assert view_model.boxSelectBorderWidth == 2
+def test_box_select_border_width(cavm):
+    """boxSelectBorderWidth returns config default."""
+    assert cavm.boxSelectBorderWidth == 2
 
 
 # --- clear + re-add cycle ---
 
 
-def test_clear_then_readd_roi(view_model):
-    """Test that clearing ROIs then adding a new one works correctly."""
-    view_model.addRoi(0, 0, 10, 10)
-    assert len(view_model.rois) == 1
+def test_clear_then_readd_roi(cavm):
+    """Clearing then adding a new ROI works correctly."""
+    cavm.addRoi(0, 0, 10, 10)
+    assert len(cavm.rois) == 1
 
-    view_model.clearRois()
-    assert len(view_model.rois) == 0
+    cavm.clearRois()
+    assert len(cavm.rois) == 0
 
-    roi = view_model.addRoi(20, 30, 40, 50)
-    assert len(view_model.rois) == 1
+    roi = cavm.addRoi(20, 30, 40, 50)
+    assert len(cavm.rois) == 1
     bbox = roi.geometry()
     assert bbox.top == 20
     assert bbox.left == 30

--- a/tests/test_ClusterAnalysisViewModel.py
+++ b/tests/test_ClusterAnalysisViewModel.py
@@ -1,182 +1,285 @@
-# Citation for Unit Tests: Verifies ClusterAnalysisViewModel delegation to parent RawDataViewModel.
-# Date: 28/02/2026
-# Adapted from Claude Code:
-# Write headless PyTest unit tests for ClusterAnalysisViewModel verifying properties and callbacks
-# are correctly forwarded to its parent RawDataViewModel.
+"""Tests for ClusterAnalysisViewModel.
 
-"""Tests for ClusterAnalysisViewModel delegation.
-
-Verifies that ClusterAnalysisViewModel correctly forwards
-all properties, methods, and callback registrations to the
-parent RawDataViewModel.
+Verifies state initialization, property defaults, ROI integration,
+clustering integration, and callback forwarding.
 
 Pure Python tests — no QApplication instantiation.
 """
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 from mock_configuration_service import MockConfigurationService
+from le_beta_vis.common.MockClusterExtractor import MockClusterExtractor
 from le_beta_vis.common.PhysicsConversionManager import (
     PhysicsConversionManagerImpl,
 )
-from le_beta_vis.frontend.viewmodels.RawDataViewModel import (
-    RawDataViewModel,
+from le_beta_vis.frontend.viewmodels.ClusterAnalysisViewModel import (
+    ClusterAnalysisViewModel,
+    ClusteringState,
 )
+from le_beta_vis.frontend.fitsconverters import Colormap
+
+_DEFAULT_RAW = np.arange(100, dtype=float).reshape(10, 10)
 
 
 @pytest.fixture
-def parent_vm():
+def config():
+    return MockConfigurationService()
+
+
+@pytest.fixture
+def physics(config):
+    return PhysicsConversionManagerImpl(config)
+
+
+@pytest.fixture
+def vm(config, physics):
+    return ClusterAnalysisViewModel(
+        config, physics, lambda: _DEFAULT_RAW.copy()
+    )
+
+
+@pytest.fixture
+def vm_no_data(config, physics):
+    return ClusterAnalysisViewModel(config, physics, lambda: None)
+
+
+# --- Initial state ---
+
+
+def test_initial_clustering_state(vm):
+    """State starts IDLE."""
+    assert vm.clusteringState == ClusteringState.IDLE
+
+
+def test_initial_selected_cluster_index(vm):
+    """Selected cluster starts at -1."""
+    assert vm.selectedClusterIndex == -1
+
+
+def test_initial_clustering_results_empty(vm):
+    """No results until extraction runs."""
+    assert vm.clusteringResults == []
+
+
+def test_initial_clustering_error_none(vm):
+    """No error on construction."""
+    assert vm.clusteringError is None
+
+
+def test_initial_clustering_progress_zero(vm):
+    """Progress starts at 0.0."""
+    assert vm.clusteringProgress == 0.0
+
+
+def test_initial_rois_empty(vm):
+    """ROI list starts empty."""
+    assert vm.rois == []
+
+
+# --- Config-driven properties ---
+
+
+def test_clustering_threshold_default(vm):
+    """Default threshold is 4.0 σ."""
+    assert vm.clusteringThreshold == 4.0
+
+
+def test_display_energy_in_kev_default(vm):
+    """displayEnergyInKev defaults to True."""
+    assert vm.displayEnergyInKev is True
+
+
+def test_kev_conversion_from_physics(vm, physics):
+    """kevConversion reads from physics manager."""
+    assert vm.kevConversion == physics.kev_conversion_factor
+
+
+def test_box_select_color_default(vm):
+    """boxSelectColor returns the default config value."""
+    assert vm.boxSelectColor == "#00BFFF"
+
+
+def test_box_select_border_width_default(vm):
+    """boxSelectBorderWidth returns the default config value."""
+    assert vm.boxSelectBorderWidth == 2
+
+
+def test_cluster_thumbnail_colormap_no_provider(vm):
+    """Returns None when no colormap_provider is wired."""
+    assert vm.clusterThumbnailColormap is None
+
+
+def test_cluster_thumbnail_colormap_with_provider(config, physics):
+    """Returns colormap when provider is wired and config enabled."""
+    vm = ClusterAnalysisViewModel(
+        config, physics,
+        lambda: None,
+        colormap_provider=lambda: Colormap.VIRIDIS,
+    )
+    assert vm.clusterThumbnailColormap == Colormap.VIRIDIS
+
+
+def test_cluster_thumbnail_colormap_disabled(config, physics):
+    """Returns None when feature is disabled in config."""
+    config.set("gui:raw_analysis:cluster_thumbnail_use_colormap", False)
+    vm = ClusterAnalysisViewModel(
+        config, physics,
+        lambda: None,
+        colormap_provider=lambda: Colormap.VIRIDIS,
+    )
+    assert vm.clusterThumbnailColormap is None
+
+
+# --- isClusteringAvailable ---
+
+
+def test_clustering_available_all_conditions(vm):
+    """True when extractor, ROI, idle state, and data are present."""
+    vm.setClusterExtractor(MockClusterExtractor(delay_seconds=0.0))
+    vm.addRoi(0, 0, 5, 5)
+    assert vm.isClusteringAvailable is True
+
+
+def test_clustering_unavailable_no_extractor(vm):
+    """False without an extractor."""
+    vm.addRoi(0, 0, 5, 5)
+    assert vm.isClusteringAvailable is False
+
+
+def test_clustering_unavailable_no_roi(vm):
+    """False without an ROI."""
+    vm.setClusterExtractor(MockClusterExtractor(delay_seconds=0.0))
+    assert vm.isClusteringAvailable is False
+
+
+def test_clustering_unavailable_no_data(vm_no_data):
+    """False when no raw data is available."""
+    vm_no_data.setClusterExtractor(MockClusterExtractor(delay_seconds=0.0))
+    vm_no_data.addRoi(0, 0, 5, 5)
+    assert vm_no_data.isClusteringAvailable is False
+
+
+# --- selectedRoiRawData / selectedRoiBoundingBox ---
+
+
+def test_selected_roi_raw_data_no_roi(vm):
+    """None when no ROI exists."""
+    assert vm.selectedRoiRawData is None
+
+
+def test_selected_roi_raw_data_with_roi(vm):
+    """Crops data to ROI bounding box."""
+    vm.addRoi(0, 0, 5, 5)
+    result = vm.selectedRoiRawData
+    assert result is not None
+    assert result.shape == (5, 5)
+
+
+def test_selected_roi_raw_data_no_raw_data(vm_no_data):
+    """None when raw data callable returns None."""
+    vm_no_data.addRoi(0, 0, 5, 5)
+    assert vm_no_data.selectedRoiRawData is None
+
+
+def test_selected_roi_bounding_box_no_roi(vm):
+    """None when no ROI exists."""
+    assert vm.selectedRoiBoundingBox is None
+
+
+def test_selected_roi_bounding_box_with_roi(vm):
+    """Returns the correct bounding box after addRoi."""
+    from le_beta_vis.common.BoundingBox import BoundingBox
+    vm.addRoi(2, 3, 8, 9)
+    bbox = vm.selectedRoiBoundingBox
+    assert bbox == BoundingBox(2, 3, 8, 9)
+
+
+# --- Callback forwarding ---
+
+
+def test_roi_changed_callback_on_add(vm):
+    """add_roi_changed_callback fires when ROI is added."""
+    called = []
+    vm.add_roi_changed_callback(lambda: called.append(True))
+    vm.addRoi(0, 0, 5, 5)
+    assert called
+
+
+def test_box_selection_completed_callback_on_add(vm):
+    """add_box_selection_completed_callback fires when ROI is added."""
+    called = []
+    vm.add_box_selection_completed_callback(lambda: called.append(True))
+    vm.addRoi(0, 0, 5, 5)
+    assert called
+
+
+def test_clustering_state_callback_fires(vm):
+    """add_clustering_state_changed_callback fires on state change."""
+    called = []
+    vm.add_clustering_state_changed_callback(lambda: called.append(True))
+    vm._notify_clustering_state_changed()
+    assert called
+
+
+def test_clustering_completed_callback_fires(vm):
+    """add_clustering_completed_callback fires on completion."""
+    called = []
+    vm.add_clustering_completed_callback(lambda: called.append(True))
+    vm._notify_clustering_completed()
+    assert called
+
+
+def test_clustering_error_callback_fires(vm):
+    """add_clustering_error_callback fires on error."""
+    called = []
+    vm.add_clustering_error_callback(lambda: called.append(True))
+    vm._notify_clustering_error()
+    assert called
+
+
+def test_clustering_progress_callback_fires(vm):
+    """add_clustering_progress_callback fires on progress update."""
+    called = []
+    vm.add_clustering_progress_callback(lambda: called.append(True))
+    vm._notify_clustering_progress()
+    assert called
+
+
+def test_selected_cluster_callback_fires(vm):
+    """add_selected_cluster_changed_callback fires on selection change."""
+    called = []
+    vm.add_selected_cluster_changed_callback(lambda: called.append(True))
+    vm._notify_selected_cluster_changed()
+    assert called
+
+
+def test_active_tool_callback_fires(vm):
+    """add_active_tool_changed_callback fires when notified."""
+    called = []
+    vm.add_active_tool_changed_callback(lambda: called.append(True))
+    vm._notify_active_tool_changed()
+    assert called
+
+
+# --- active_tool forwarding from RawDataViewModel ---
+
+
+def test_rdvm_tool_change_reaches_cavm():
+    """Tool-change from RDVM propagates to CAVM listeners."""
+    from le_beta_vis.frontend.viewmodels.RawDataViewModel import (
+        RawDataViewModel,
+    )
     config = MockConfigurationService()
     physics = PhysicsConversionManagerImpl(config)
-    vm = RawDataViewModel(config, physics)
-    vm._converter = MagicMock()
-    vm._request_render = lambda: vm._render_worker_logic()
-    return vm
+    rdvm = RawDataViewModel(config, physics)
+    rdvm._converter = MagicMock()
 
-
-@pytest.fixture
-def facade(parent_vm):
-    return parent_vm.clusterAnalysisViewModel
-
-
-# --- Property delegation ---
-
-
-def test_clustering_threshold(facade, parent_vm):
-    """clusteringThreshold delegates to parent."""
-    assert facade.clusteringThreshold == parent_vm.clusteringThreshold
-
-
-def test_is_clustering_available(facade, parent_vm):
-    """isClusteringAvailable delegates to parent."""
-    assert facade.isClusteringAvailable == parent_vm.isClusteringAvailable
-
-
-def test_clustering_state(facade, parent_vm):
-    """clusteringState delegates to parent."""
-    assert facade.clusteringState == parent_vm.clusteringState
-
-
-def test_clustering_results(facade, parent_vm):
-    """clusteringResults delegates to parent."""
-    assert facade.clusteringResults == parent_vm.clusteringResults
-
-
-def test_clustering_progress(facade, parent_vm):
-    """clusteringProgress delegates to parent."""
-    assert facade.clusteringProgress == parent_vm.clusteringProgress
-
-
-def test_clustering_error(facade, parent_vm):
-    """clusteringError delegates to parent."""
-    assert facade.clusteringError == parent_vm.clusteringError
-
-
-def test_cluster_thumbnail_colormap(facade, parent_vm):
-    """clusterThumbnailColormap delegates to parent."""
-    assert facade.clusterThumbnailColormap == parent_vm.clusterThumbnailColormap
-
-
-def test_display_energy_in_kev(facade, parent_vm):
-    """displayEnergyInKev delegates to parent."""
-    assert facade.displayEnergyInKev == parent_vm.displayEnergyInKev
-
-
-def test_kev_conversion(facade, parent_vm):
-    """kevConversion delegates to parent."""
-    assert facade.kevConversion == parent_vm.kevConversion
-
-
-def test_selected_cluster_index(facade, parent_vm):
-    """selectedClusterIndex delegates to parent."""
-    assert facade.selectedClusterIndex == parent_vm.selectedClusterIndex
-
-
-# --- Method delegation ---
-
-
-def test_trigger_clustering(facade, parent_vm):
-    """triggerClustering delegates to parent (no-op when unavailable)."""
-    facade.triggerClustering()
-    # No error — clustering not available so it's a safe no-op
-
-
-def test_cancel_clustering(facade, parent_vm):
-    """cancelClustering delegates to parent."""
-    facade.cancelClustering()
-
-
-def test_select_cluster(facade, parent_vm):
-    """selectCluster delegates to parent."""
-    facade.selectCluster(-1)
-    assert parent_vm.selectedClusterIndex == -1
-
-
-def test_classify_selected_cluster(facade):
-    """classifySelectedCluster delegates without error."""
-    facade.classifySelectedCluster()
-
-
-def test_export_selected_cluster(facade):
-    """exportSelectedCluster delegates without error."""
-    facade.exportSelectedCluster()
-
-
-# --- Callback delegation ---
-
-
-def test_add_clustering_state_changed_callback(facade, parent_vm):
-    """Callback registered via facade fires on parent state change."""
     called = []
-    facade.add_clustering_state_changed_callback(lambda: called.append(True))
-    parent_vm._notify_clustering_state_changed()
-    assert called
-
-
-def test_add_clustering_completed_callback(facade, parent_vm):
-    """Callback registered via facade fires on parent completion."""
-    called = []
-    facade.add_clustering_completed_callback(lambda: called.append(True))
-    parent_vm._notify_clustering_completed()
-    assert called
-
-
-def test_add_clustering_error_callback(facade, parent_vm):
-    """Callback registered via facade fires on parent error."""
-    called = []
-    facade.add_clustering_error_callback(lambda: called.append(True))
-    parent_vm._notify_clustering_error()
-    assert called
-
-
-def test_add_clustering_progress_callback(facade, parent_vm):
-    """Callback registered via facade fires on parent progress."""
-    called = []
-    facade.add_clustering_progress_callback(lambda: called.append(True))
-    parent_vm._notify_clustering_progress()
-    assert called
-
-
-def test_add_selected_cluster_changed_callback(facade, parent_vm):
-    """Callback registered via facade fires on selection change."""
-    called = []
-    facade.add_selected_cluster_changed_callback(lambda: called.append(True))
-    parent_vm._notify_selected_cluster_changed()
-    assert called
-
-
-def test_add_active_tool_changed_callback(facade, parent_vm):
-    """Callback registered via facade fires on tool change."""
-    called = []
-    facade.add_active_tool_changed_callback(lambda: called.append(True))
-    parent_vm._notify_active_tool_changed()
-    assert called
-
-
-def test_add_roi_changed_callback(facade, parent_vm):
-    """Callback registered via facade fires on ROI change."""
-    called = []
-    facade.add_roi_changed_callback(lambda: called.append(True))
-    parent_vm._notify_roi_changed()
+    rdvm.clusterAnalysisViewModel.add_active_tool_changed_callback(
+        lambda: called.append(True)
+    )
+    rdvm._notify_active_tool_changed()
     assert called

--- a/tests/test_ClusteredEventSelection.py
+++ b/tests/test_ClusteredEventSelection.py
@@ -1,9 +1,5 @@
-# Citation for Unit Tests: Verifies RawDataViewModel cluster selection logic, results management,
-# and clustering tool state.
-# Date: 28/02/2026
-# Adapted from Claude Code:
-# Write headless PyTest unit tests for RawDataViewModel covering cluster selection state changes,
-# clearing results on ROI clearing, and cluster thumbnail configuration without Qt dependencies.
+"""Tests for cluster selection state, result management,
+and thumbnail config properties on ClusterAnalysisViewModel."""
 
 from unittest.mock import MagicMock
 
@@ -14,40 +10,44 @@ from le_beta_vis.common.BoundingBox import BoundingBox
 from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
 from mock_configuration_service import MockConfigurationService
 from le_beta_vis.common.MockClusterExtractor import MockClusterExtractor
-from le_beta_vis.common.PhysicsConversionManager import PhysicsConversionManagerImpl
-from le_beta_vis.frontend.viewmodels.RawDataViewModel import (
-    ActiveTool,
-    RawDataViewModel,
+from le_beta_vis.common.PhysicsConversionManager import (
+    PhysicsConversionManagerImpl,
 )
+from le_beta_vis.frontend.viewmodels.RawDataViewModel import RawDataViewModel
 
 
 @pytest.fixture
-def view_model():
+def rdvm():
     config = MockConfigurationService()
-    physics_manager = PhysicsConversionManagerImpl(config)
-    vm = RawDataViewModel(config, physics_manager)
+    physics = PhysicsConversionManagerImpl(config)
+    vm = RawDataViewModel(config, physics)
     vm._converter = MagicMock()
     vm._converter.convert.return_value = np.zeros((10, 10, 3), dtype=np.uint8)
-
-    def mock_request():
-        vm._render_worker_logic()
-
-    vm._request_render = mock_request
+    vm._request_render = lambda: vm._render_worker_logic()
     return vm
 
 
-def _setup_for_clustering(vm):
-    """Helper: load mock data, set tool, add ROI, set extractor."""
-    mock_capture = MagicMock()
-    mock_capture.rawData.return_value = np.arange(100, dtype=float).reshape(10, 10)
-    mock_capture.info.return_value = MagicMock(rows=10, cols=10, min=0, max=99)
-    vm._captures = [mock_capture]
-    vm._activeIndex = 0
-    vm._image_bounds = (10, 10)
+@pytest.fixture
+def cavm(rdvm):
+    return rdvm.clusterAnalysisViewModel
 
-    vm.setClusterExtractor(MockClusterExtractor(delay_seconds=0.01))
-    vm.setActiveTool(ActiveTool.BOX_SELECT)
-    vm.addRoi(0, 0, 5, 5)
+
+def _setup_for_clustering(rdvm: RawDataViewModel) -> None:
+    """Load mock data into RDVM and configure CAVM for clustering."""
+    mock_capture = MagicMock()
+    mock_capture.rawData.return_value = (
+        np.arange(100, dtype=float).reshape(10, 10)
+    )
+    mock_capture.info.return_value = MagicMock(
+        rows=10, cols=10, min=0, max=99
+    )
+    rdvm._captures = [mock_capture]
+    rdvm._activeIndex = 0
+    rdvm._image_bounds = (10, 10)
+
+    cavm = rdvm.clusterAnalysisViewModel
+    cavm.setClusterExtractor(MockClusterExtractor(delay_seconds=0.01))
+    cavm.addRoi(0, 0, 5, 5)
 
 
 def _make_cluster(
@@ -70,199 +70,200 @@ def _make_cluster(
 # --- Initial state ---
 
 
-def test_initial_selection_is_negative_one(view_model):
+def test_initial_selection_is_negative_one(cavm):
     """selectedClusterIndex starts at -1."""
-    assert view_model.selectedClusterIndex == -1
+    assert cavm.selectedClusterIndex == -1
 
 
-def test_selected_cluster_returns_none_when_empty(view_model):
+def test_selected_cluster_returns_none_when_empty(cavm):
     """selectedCluster returns None when no results exist."""
-    assert view_model.selectedCluster is None
+    assert cavm.selectedCluster is None
 
 
 # --- selectCluster ---
 
 
-def test_select_cluster_valid_index(view_model):
+def test_select_cluster_valid_index(cavm):
     """selectCluster with a valid index updates selectedClusterIndex."""
-    view_model._clusteringResults = [_make_cluster(), _make_cluster()]
-    view_model.selectCluster(1)
-    assert view_model.selectedClusterIndex == 1
+    cavm._clusteringResults = [_make_cluster(), _make_cluster()]
+    cavm.selectCluster(1)
+    assert cavm.selectedClusterIndex == 1
 
 
-def test_select_cluster_fires_callback(view_model):
+def test_select_cluster_fires_callback(cavm):
     """selectCluster fires selected_cluster_changed callback."""
-    view_model._clusteringResults = [_make_cluster()]
+    cavm._clusteringResults = [_make_cluster()]
     cb = MagicMock()
-    view_model.add_selected_cluster_changed_callback(cb)
-    view_model.selectCluster(0)
+    cavm.add_selected_cluster_changed_callback(cb)
+    cavm.selectCluster(0)
     cb.assert_called_once()
 
 
-def test_select_cluster_no_double_fire(view_model):
+def test_select_cluster_no_double_fire(cavm):
     """selectCluster with same index does not fire callback."""
-    view_model._clusteringResults = [_make_cluster()]
-    view_model.selectCluster(0)
+    cavm._clusteringResults = [_make_cluster()]
+    cavm.selectCluster(0)
     cb = MagicMock()
-    view_model.add_selected_cluster_changed_callback(cb)
-    view_model.selectCluster(0)
+    cavm.add_selected_cluster_changed_callback(cb)
+    cavm.selectCluster(0)
     cb.assert_not_called()
 
 
-def test_select_cluster_invalid_index_ignored(view_model):
+def test_select_cluster_invalid_index_ignored(cavm):
     """selectCluster with out-of-range index is a no-op."""
-    view_model._clusteringResults = [_make_cluster()]
+    cavm._clusteringResults = [_make_cluster()]
     cb = MagicMock()
-    view_model.add_selected_cluster_changed_callback(cb)
-    view_model.selectCluster(5)
-    assert view_model.selectedClusterIndex == -1
+    cavm.add_selected_cluster_changed_callback(cb)
+    cavm.selectCluster(5)
+    assert cavm.selectedClusterIndex == -1
     cb.assert_not_called()
 
 
-def test_select_cluster_negative_below_minus_one_ignored(view_model):
+def test_select_cluster_negative_below_minus_one_ignored(cavm):
     """selectCluster with index < -1 is a no-op."""
-    view_model._clusteringResults = [_make_cluster()]
-    view_model.selectCluster(-2)
-    assert view_model.selectedClusterIndex == -1
+    cavm._clusteringResults = [_make_cluster()]
+    cavm.selectCluster(-2)
+    assert cavm.selectedClusterIndex == -1
 
 
-def test_select_cluster_deselect(view_model):
+def test_select_cluster_deselect(cavm):
     """selectCluster(-1) deselects."""
-    view_model._clusteringResults = [_make_cluster()]
-    view_model.selectCluster(0)
-    view_model.selectCluster(-1)
-    assert view_model.selectedClusterIndex == -1
+    cavm._clusteringResults = [_make_cluster()]
+    cavm.selectCluster(0)
+    cavm.selectCluster(-1)
+    assert cavm.selectedClusterIndex == -1
 
 
 # --- selectedCluster property ---
 
 
-def test_selected_cluster_returns_correct_info(view_model):
+def test_selected_cluster_returns_correct_info(cavm):
     """selectedCluster returns the correct ClusteredEventInfo."""
     c1 = _make_cluster(cx=1, cy=2, energy=50.0)
     c2 = _make_cluster(cx=3, cy=4, energy=200.0)
-    view_model._clusteringResults = [c1, c2]
-    view_model.selectCluster(1)
-    assert view_model.selectedCluster is c2
+    cavm._clusteringResults = [c1, c2]
+    cavm.selectCluster(1)
+    assert cavm.selectedCluster is c2
 
 
 # --- clearClusteringResults ---
 
 
-def test_clear_clustering_results(view_model):
+def test_clear_clustering_results(cavm):
     """clearClusteringResults empties results and resets selection."""
-    view_model._clusteringResults = [_make_cluster()]
-    view_model.selectCluster(0)
-    view_model.clearClusteringResults()
-    assert view_model.clusteringResults == []
-    assert view_model.selectedClusterIndex == -1
+    cavm._clusteringResults = [_make_cluster()]
+    cavm.selectCluster(0)
+    cavm.clearClusteringResults()
+    assert cavm.clusteringResults == []
+    assert cavm.selectedClusterIndex == -1
 
 
-def test_clear_clustering_results_fires_callbacks(view_model):
+def test_clear_clustering_results_fires_callbacks(cavm):
     """clearClusteringResults fires completed and selection callbacks."""
-    view_model._clusteringResults = [_make_cluster()]
+    cavm._clusteringResults = [_make_cluster()]
     completed_cb = MagicMock()
     selection_cb = MagicMock()
-    view_model.add_clustering_completed_callback(completed_cb)
-    view_model.add_selected_cluster_changed_callback(selection_cb)
+    cavm.add_clustering_completed_callback(completed_cb)
+    cavm.add_selected_cluster_changed_callback(selection_cb)
 
-    view_model.clearClusteringResults()
+    cavm.clearClusteringResults()
     completed_cb.assert_called_once()
     selection_cb.assert_called_once()
 
 
-def test_clear_clustering_noop_when_already_empty(view_model):
+def test_clear_clustering_noop_when_already_empty(cavm):
     """clearClusteringResults is a no-op when already empty."""
     cb = MagicMock()
-    view_model.add_clustering_completed_callback(cb)
-    view_model.clearClusteringResults()
+    cavm.add_clustering_completed_callback(cb)
+    cavm.clearClusteringResults()
     cb.assert_not_called()
 
 
 # --- clearRois clears clustering ---
 
 
-def test_clear_rois_clears_clustering_results(view_model):
+def test_clear_rois_clears_clustering_results(rdvm, cavm):
     """clearRois also clears clustering results."""
-    _setup_for_clustering(view_model)
-    view_model._clusteringResults = [_make_cluster()]
-    view_model.selectCluster(0)
-    view_model.clearRois()
-    assert view_model.clusteringResults == []
-    assert view_model.selectedClusterIndex == -1
+    _setup_for_clustering(rdvm)
+    cavm._clusteringResults = [_make_cluster()]
+    cavm.selectCluster(0)
+    cavm.clearRois()
+    assert cavm.clusteringResults == []
+    assert cavm.selectedClusterIndex == -1
 
 
 # --- triggerClustering clears previous results ---
 
 
-def test_trigger_clustering_clears_previous_results(view_model):
+def test_trigger_clustering_clears_previous_results(rdvm, cavm):
     """New triggerClustering clears old results and selection."""
-    _setup_for_clustering(view_model)
-    view_model._clusteringResults = [_make_cluster()]
-    view_model._selectedClusterIndex = 0
+    _setup_for_clustering(rdvm)
+    cavm._clusteringResults = [_make_cluster()]
+    cavm._selectedClusterIndex = 0
 
-    view_model.triggerClustering()
-    assert view_model._clusteringResults == []
-    assert view_model._selectedClusterIndex == -1
+    cavm.triggerClustering()
+    assert cavm._clusteringResults == []
+    assert cavm._selectedClusterIndex == -1
 
-    # Clean up: cancel so the background thread doesn't fire
-    view_model.cancelClustering()
+    cavm.cancelClustering()
 
 
 # --- Placeholder methods ---
 
 
-def test_classify_selected_cluster_no_error(view_model):
+def test_classify_selected_cluster_no_error(cavm):
     """classifySelectedCluster runs without error when cluster selected."""
-    view_model._clusteringResults = [_make_cluster()]
-    view_model.selectCluster(0)
-    view_model.classifySelectedCluster()
+    cavm._clusteringResults = [_make_cluster()]
+    cavm.selectCluster(0)
+    cavm.classifySelectedCluster()
 
 
-def test_classify_no_selection_no_error(view_model):
+def test_classify_no_selection_no_error(cavm):
     """classifySelectedCluster is safe when nothing selected."""
-    view_model.classifySelectedCluster()
+    cavm.classifySelectedCluster()
 
 
-def test_export_selected_cluster_no_error(view_model):
+def test_export_selected_cluster_no_error(cavm):
     """exportSelectedCluster runs without error when cluster selected."""
-    view_model._clusteringResults = [_make_cluster()]
-    view_model.selectCluster(0)
-    view_model.exportSelectedCluster()
+    cavm._clusteringResults = [_make_cluster()]
+    cavm.selectCluster(0)
+    cavm.exportSelectedCluster()
 
 
-def test_export_no_selection_no_error(view_model):
+def test_export_no_selection_no_error(cavm):
     """exportSelectedCluster is safe when nothing selected."""
-    view_model.exportSelectedCluster()
+    cavm.exportSelectedCluster()
 
 
 # --- Cluster display properties ---
 
 
-def test_cluster_thumbnail_colormap_enabled_by_default(view_model):
-    """clusterThumbnailColormap returns active colormap with default config."""
-    assert view_model.clusterThumbnailColormap is not None
+def test_cluster_thumbnail_colormap_enabled_by_default(cavm):
+    """clusterThumbnailColormap returns colormap with default config."""
+    assert cavm.clusterThumbnailColormap is not None
 
 
-def test_cluster_thumbnail_colormap_enabled(view_model):
+def test_cluster_thumbnail_colormap_enabled(rdvm, cavm):
     """clusterThumbnailColormap returns active colormap when enabled."""
-    view_model._config.set("gui:raw_analysis:cluster_thumbnail_use_colormap", True)
-    result = view_model.clusterThumbnailColormap
+    rdvm._config.set(
+        "gui:raw_analysis:cluster_thumbnail_use_colormap", True
+    )
+    result = cavm.clusterThumbnailColormap
     assert result is not None
     assert result.value == "viridis"
 
 
-def test_display_energy_in_kev_default_true(view_model):
+def test_display_energy_in_kev_default_true(cavm):
     """displayEnergyInKev defaults to True."""
-    assert view_model.displayEnergyInKev is True
+    assert cavm.displayEnergyInKev is True
 
 
-def test_display_energy_in_kev_disabled(view_model):
+def test_display_energy_in_kev_disabled(rdvm, cavm):
     """displayEnergyInKev returns False when config is set."""
-    view_model._config.set("gui:raw_analysis:display_energy_in_kev", False)
-    assert view_model.displayEnergyInKev is False
+    rdvm._config.set("gui:raw_analysis:display_energy_in_kev", False)
+    assert cavm.displayEnergyInKev is False
 
 
-def test_kev_conversion_from_config(view_model):
-    """kevConversion reads from config."""
-    assert view_model.kevConversion == pytest.approx(1.02857e-5)
+def test_kev_conversion_from_config(cavm):
+    """kevConversion reads from physics manager."""
+    assert cavm.kevConversion == pytest.approx(1.02857e-5)

--- a/tests/test_ClusteringViewModel.py
+++ b/tests/test_ClusteringViewModel.py
@@ -11,11 +11,12 @@ from le_beta_vis.common.PhysicsConversionManager import (
     PhysicsConversionManager,
     PhysicsConversionManagerImpl,
 )
-from le_beta_vis.frontend.viewmodels.RawDataViewModel import (
-    ActiveTool,
+from le_beta_vis.frontend.viewmodels.ClusterAnalysisViewModel import (
+    ClusterAnalysisViewModel,
     ClusteringState,
-    RawDataViewModel,
 )
+
+_DEFAULT_RAW = np.arange(100, dtype=float).reshape(10, 10)
 
 
 class MockPhysicsManager(PhysicsConversionManager):
@@ -34,34 +35,36 @@ class MockPhysicsManager(PhysicsConversionManager):
     def calculate_threshold(self, sigma: float) -> float:
         return sigma * self._ped_width
 
-    def adu_to_kev(self, value: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+    def adu_to_kev(
+        self, value: Union[float, np.ndarray]
+    ) -> Union[float, np.ndarray]:
         return value * self._factor
 
 
 @pytest.fixture
-def view_model():
+def raw_holder():
+    """Mutable container so tests can swap the raw data array."""
+    return [_DEFAULT_RAW.copy()]
+
+
+@pytest.fixture
+def vm(raw_holder):
     config = MockConfigurationService()
-    physics_manager = PhysicsConversionManagerImpl(config)
-    vm = RawDataViewModel(config, physics_manager)
-    vm._converter = MagicMock()
-    vm._converter.convert.return_value = np.zeros((10, 10, 3), dtype=np.uint8)
-
-    def mock_request():
-        vm._render_worker_logic()
-
-    vm._request_render = mock_request
-    return vm
+    physics = PhysicsConversionManagerImpl(config)
+    return ClusterAnalysisViewModel(
+        config, physics, lambda: raw_holder[0]
+    )
 
 
-def _setup_for_clustering(vm):
-    """Helper: load mock data, set tool, add ROI, set extractor."""
-    mock_capture = MagicMock()
-    mock_capture.rawData.return_value = np.arange(100, dtype=float).reshape(10, 10)
-    mock_capture.info.return_value = MagicMock(rows=10, cols=10, min=0, max=99)
-    vm._captures = [mock_capture]
-    vm._activeIndex = 0
-    vm._image_bounds = (10, 10)
+@pytest.fixture
+def vm_no_data():
+    config = MockConfigurationService()
+    physics = PhysicsConversionManagerImpl(config)
+    return ClusterAnalysisViewModel(config, physics, lambda: None)
 
+
+def _setup_for_clustering(vm: ClusterAnalysisViewModel) -> None:
+    """Inject extractor and add ROI so clustering is available."""
     vm.setClusterExtractor(MockClusterExtractor(delay_seconds=0.01))
     vm.addRoi(0, 0, 5, 5)
 
@@ -69,117 +72,112 @@ def _setup_for_clustering(vm):
 # --- isClusteringAvailable ---
 
 
-def test_clustering_unavailable_no_extractor(view_model):
+def test_clustering_unavailable_no_extractor(vm):
     """False when no extractor is set."""
-    assert view_model.isClusteringAvailable is False
+    assert vm.isClusteringAvailable is False
 
 
-def test_clustering_unavailable_no_roi(view_model):
+def test_clustering_unavailable_no_roi(vm):
     """False when no ROI exists."""
-    _setup_for_clustering(view_model)
-    view_model.clearRois()
-    assert view_model.isClusteringAvailable is False
+    _setup_for_clustering(vm)
+    vm.clearRois()
+    assert vm.isClusteringAvailable is False
 
 
-def test_clustering_unavailable_no_data(view_model):
-    """False when no raw data is loaded."""
-    view_model.setClusterExtractor(MockClusterExtractor(delay_seconds=0.01))
-    view_model.setActiveTool(ActiveTool.BOX_SELECT)
-    view_model.addRoi(0, 0, 5, 5)
-    assert view_model.isClusteringAvailable is False
+def test_clustering_unavailable_no_data(vm_no_data):
+    """False when no raw data is available."""
+    vm_no_data.setClusterExtractor(MockClusterExtractor(delay_seconds=0.01))
+    vm_no_data.addRoi(0, 0, 5, 5)
+    assert vm_no_data.isClusteringAvailable is False
 
 
-def test_clustering_available(view_model):
+def test_clustering_available(vm):
     """True when all conditions are met."""
-    _setup_for_clustering(view_model)
-    assert view_model.isClusteringAvailable is True
+    _setup_for_clustering(vm)
+    assert vm.isClusteringAvailable is True
 
 
 # --- triggerClustering ---
 
 
-def test_trigger_sets_running(view_model):
+def test_trigger_sets_running(vm):
     """triggerClustering sets state to RUNNING."""
-    _setup_for_clustering(view_model)
-    view_model.triggerClustering()
-    assert view_model.clusteringState == ClusteringState.RUNNING
+    _setup_for_clustering(vm)
+    vm.triggerClustering()
+    assert vm.clusteringState == ClusteringState.RUNNING
 
 
-def test_trigger_fires_state_callback(view_model):
+def test_trigger_fires_state_callback(vm):
     """triggerClustering fires the state changed callback."""
-    _setup_for_clustering(view_model)
+    _setup_for_clustering(vm)
     cb = MagicMock()
-    view_model.add_clustering_state_changed_callback(cb)
-    view_model.triggerClustering()
+    vm.add_clustering_state_changed_callback(cb)
+    vm.triggerClustering()
     cb.assert_called()
 
 
-def test_trigger_noop_when_unavailable(view_model):
+def test_trigger_noop_when_unavailable(vm):
     """triggerClustering does nothing when conditions not met."""
     cb = MagicMock()
-    view_model.add_clustering_state_changed_callback(cb)
-    view_model.triggerClustering()
-    assert view_model.clusteringState == ClusteringState.IDLE
+    vm.add_clustering_state_changed_callback(cb)
+    vm.triggerClustering()
+    assert vm.clusteringState == ClusteringState.IDLE
     cb.assert_not_called()
 
 
 # --- cancelClustering ---
 
 
-def test_cancel_resets_idle(view_model):
+def test_cancel_resets_idle(vm):
     """cancelClustering sets state back to IDLE."""
-    _setup_for_clustering(view_model)
-    view_model.triggerClustering()
-    view_model.cancelClustering()
-    assert view_model.clusteringState == ClusteringState.IDLE
+    _setup_for_clustering(vm)
+    vm.triggerClustering()
+    vm.cancelClustering()
+    assert vm.clusteringState == ClusteringState.IDLE
 
 
 # --- Extraction completion ---
 
 
-def test_success_stores_results(view_model):
+def test_success_stores_results(vm):
     """Results are populated after extraction completes."""
-    _setup_for_clustering(view_model)
+    _setup_for_clustering(vm)
     done = threading.Event()
 
-    def on_completed():
-        done.set()
-
-    view_model.add_clustering_completed_callback(on_completed)
-    view_model.triggerClustering()
+    vm.add_clustering_completed_callback(lambda: done.set())
+    vm.triggerClustering()
     done.wait(timeout=2.0)
 
-    results = view_model.clusteringResults
+    results = vm.clusteringResults
     assert len(results) == 1
-    assert view_model.clusteringState == ClusteringState.IDLE
+    assert vm.clusteringState == ClusteringState.IDLE
 
 
-def test_success_fires_completed_callback(view_model):
+def test_success_fires_completed_callback(vm):
     """Completed callback fires on success."""
-    _setup_for_clustering(view_model)
+    _setup_for_clustering(vm)
     done = threading.Event()
     cb = MagicMock(side_effect=lambda: done.set())
 
-    view_model.add_clustering_completed_callback(cb)
-    view_model.triggerClustering()
+    vm.add_clustering_completed_callback(cb)
+    vm.triggerClustering()
     done.wait(timeout=2.0)
 
     cb.assert_called_once()
 
 
-def test_cancel_prevents_completed_callback(view_model):
+def test_cancel_prevents_completed_callback(vm):
     """Cancelling during extraction suppresses completed callback."""
     extractor = MockClusterExtractor(delay_seconds=1.0)
-    _setup_for_clustering(view_model)
-    view_model.setClusterExtractor(extractor)
+    vm.setClusterExtractor(extractor)
+    vm.addRoi(0, 0, 5, 5)
 
     cb = MagicMock()
-    view_model.add_clustering_completed_callback(cb)
-    view_model.triggerClustering()
-    view_model.cancelClustering()
+    vm.add_clustering_completed_callback(cb)
+    vm.triggerClustering()
+    vm.cancelClustering()
 
     import time
-
     time.sleep(0.1)
     cb.assert_not_called()
 
@@ -187,133 +185,125 @@ def test_cancel_prevents_completed_callback(view_model):
 # --- Timeout ---
 
 
-def test_timeout_fires_error_callback(view_model):
+def test_timeout_fires_error_callback(vm):
     """Error callback fires when extraction times out."""
-    # Use a slow extractor and a very short timeout
     slow = MockClusterExtractor(delay_seconds=5.0)
-    _setup_for_clustering(view_model)
-    view_model.setClusterExtractor(slow)
-    view_model._config.set("gui:raw_analysis:clustering_timeout_seconds", 0.1)
+    vm.setClusterExtractor(slow)
+    vm.addRoi(0, 0, 5, 5)
+    vm._config.set("gui:raw_analysis:clustering_timeout_seconds", 0.1)
 
     error_fired = threading.Event()
-    view_model.add_clustering_error_callback(lambda: error_fired.set())
+    vm.add_clustering_error_callback(lambda: error_fired.set())
 
-    view_model.triggerClustering()
+    vm.triggerClustering()
     assert error_fired.wait(timeout=2.0), "Error callback not fired"
-    assert view_model.clusteringState == ClusteringState.IDLE
-    assert view_model.clusteringError is not None
-    assert "timed out" in view_model.clusteringError.lower()
+    assert vm.clusteringState == ClusteringState.IDLE
+    assert vm.clusteringError is not None
+    assert "timed out" in vm.clusteringError.lower()
 
 
-def test_timeout_cancels_extractor(view_model):
+def test_timeout_cancels_extractor(vm):
     """Timeout calls cancel() on the extractor."""
     slow = MockClusterExtractor(delay_seconds=5.0)
-    _setup_for_clustering(view_model)
-    view_model.setClusterExtractor(slow)
-    view_model._config.set("gui:raw_analysis:clustering_timeout_seconds", 0.1)
+    vm.setClusterExtractor(slow)
+    vm.addRoi(0, 0, 5, 5)
+    vm._config.set("gui:raw_analysis:clustering_timeout_seconds", 0.1)
 
     done = threading.Event()
-    view_model.add_clustering_error_callback(lambda: done.set())
+    vm.add_clustering_error_callback(lambda: done.set())
 
-    view_model.triggerClustering()
+    vm.triggerClustering()
     done.wait(timeout=2.0)
-    # MockClusterExtractor sets _cancelled = True on cancel()
     assert slow._cancelled is True
 
 
-def test_successful_completion_cancels_timer(view_model):
+def test_successful_completion_cancels_timer(vm):
     """Successful extraction cancels the timeout timer."""
-    _setup_for_clustering(view_model)
-    view_model._config.set("gui:raw_analysis:clustering_timeout_seconds", 60)
+    _setup_for_clustering(vm)
+    vm._config.set("gui:raw_analysis:clustering_timeout_seconds", 60)
 
     done = threading.Event()
-    view_model.add_clustering_completed_callback(lambda: done.set())
+    vm.add_clustering_completed_callback(lambda: done.set())
 
-    view_model.triggerClustering()
+    vm.triggerClustering()
     assert done.wait(timeout=2.0), "Completion callback not fired"
-    assert view_model._clustering_timeout_timer is None
-    assert view_model.clusteringError is None
+    assert vm._clustering_timeout_timer is None
+    assert vm.clusteringError is None
 
 
-def test_clustering_error_cleared_on_new_trigger(view_model):
+def test_clustering_error_cleared_on_new_trigger(vm):
     """A new triggerClustering clears any previous error."""
-    _setup_for_clustering(view_model)
-    view_model._clusteringError = "previous error"
+    _setup_for_clustering(vm)
+    vm._clusteringError = "previous error"
 
     done = threading.Event()
-    view_model.add_clustering_completed_callback(lambda: done.set())
-    view_model.triggerClustering()
+    vm.add_clustering_completed_callback(lambda: done.set())
+    vm.triggerClustering()
     done.wait(timeout=2.0)
-    assert view_model.clusteringError is None
+    assert vm.clusteringError is None
 
 
 # --- Progress tracking ---
 
 
-def test_trigger_resets_progress(view_model):
+def test_trigger_resets_progress(vm):
     """triggerClustering resets clusteringProgress to 0.0."""
-    _setup_for_clustering(view_model)
-    view_model._clusteringProgress = 0.5
-    view_model.triggerClustering()
-    # Progress is reset before extraction starts
-    assert view_model.clusteringProgress == 0.0
+    _setup_for_clustering(vm)
+    vm._clusteringProgress = 0.5
+    vm.triggerClustering()
+    assert vm.clusteringProgress == 0.0
 
 
-def test_progress_callback_fires(view_model):
+def test_progress_callback_fires(raw_holder):
     """Progress callback is registered and fires on extractor call."""
     from le_beta_vis.common.GeneralClusterExtractor import (
         GeneralClusterExtractor,
     )
 
-    # Use GeneralClusterExtractor since it actually reports progress
     physics = MockPhysicsManager(factor=0.01, ped_width=100)
+    config = MockConfigurationService()
     extractor = GeneralClusterExtractor(
         sigma_multiplier=4.0,
         physics_manager=physics,
     )
-    _setup_for_clustering(view_model)
 
-    # Give it data with a cluster above threshold (4*100=400)
     data = np.zeros((20, 20), dtype=float)
     for i in range(5):
         data[10, 10 + i] = 500
-    mock_capture = MagicMock()
-    mock_capture.rawData.return_value = data
-    mock_capture.info.return_value = MagicMock(rows=20, cols=20, min=0, max=500)
-    view_model._captures = [mock_capture]
-    view_model._image_bounds = (20, 20)
-    view_model.clearRois()
-    view_model.addRoi(0, 0, 20, 20)
-    view_model.setClusterExtractor(extractor)
+    raw_holder[0] = data
+
+    vm = ClusterAnalysisViewModel(config, physics, lambda: raw_holder[0])
+    vm.addRoi(0, 0, 20, 20)
+    vm.setClusterExtractor(extractor)
 
     progress_fired = threading.Event()
-    view_model.add_clustering_progress_callback(lambda: progress_fired.set())
+    vm.add_clustering_progress_callback(lambda: progress_fired.set())
 
     done = threading.Event()
-    view_model.add_clustering_completed_callback(lambda: done.set())
-    view_model.triggerClustering()
+    vm.add_clustering_completed_callback(lambda: done.set())
+    vm.triggerClustering()
     done.wait(timeout=5.0)
 
     assert progress_fired.is_set()
-    assert view_model.clusteringProgress > 0.0
+    assert vm.clusteringProgress > 0.0
 
 
-def test_progress_passes_callback_to_extractor(view_model):
+def test_progress_passes_callback_to_extractor(vm):
     """triggerClustering passes progress_callback to the extractor."""
-    _setup_for_clustering(view_model)
+    _setup_for_clustering(vm)
 
     extract_kwargs = {}
-    original_extract = view_model._clusterExtractor.extract
+    original_extract = vm._clusterExtractor.extract
 
     def spy_extract(*args, **kwargs):
         extract_kwargs.update(kwargs)
         return original_extract(*args, **kwargs)
 
-    view_model._clusterExtractor.extract = spy_extract
+    vm._clusterExtractor.extract = spy_extract
 
     done = threading.Event()
-    view_model.add_clustering_completed_callback(lambda: done.set())
-    view_model.triggerClustering()
+    vm.add_clustering_completed_callback(lambda: done.set())
+    vm.triggerClustering()
     done.wait(timeout=2.0)
 
     assert "progress_callback" in extract_kwargs

--- a/tests/test_RawDataViewModel.py
+++ b/tests/test_RawDataViewModel.py
@@ -122,34 +122,6 @@ def test_set_active_hdu(view_model):
     assert isinstance(view_model.currentBuffer, np.ndarray)
 
 
-def test_selected_roi_raw_data_none_without_roi(view_model):
-    """selectedRoiRawData returns None when no ROI is set."""
-    assert view_model.selectedRoiRawData is None
-
-
-def test_selected_roi_raw_data_none_without_capture(view_model):
-    """selectedRoiRawData returns None when no capture is loaded."""
-    view_model.addRoi(0, 0, 5, 5)
-    assert view_model.selectedRoiRawData is None
-
-
-def test_selected_roi_raw_data_returns_cropped_data(view_model):
-    """selectedRoiRawData returns the cropped sub-array."""
-    raw = np.arange(100).reshape(10, 10)
-    mock_capture = MagicMock(spec=CCDCaptureModel)
-    mock_capture.rawData.return_value = raw
-    view_model._captures = [mock_capture]
-    view_model._activeIndex = 0
-
-    view_model.addRoi(2, 3, 5, 7)
-    result = view_model.selectedRoiRawData
-    assert result is not None
-    expected = raw[2:5, 3:7]
-    assert np.array_equal(result, expected)
-    # Verify it's a copy, not a reference
-    assert result is not raw[2:5, 3:7]
-
-
 def test_set_colormap(view_model):
     """Test updating parameters triggers render."""
     mock_capture = MagicMock()
@@ -225,23 +197,6 @@ def test_toggle_magnifier_notifies(view_model):
 
     view_model.toggleMagnifier()
     assert cb.call_count == 2
-
-
-def test_clustering_available_with_magnifier_active(view_model):
-    """isClusteringAvailable should be True regardless of active tool."""
-    mock_capture = MagicMock(spec=CCDCaptureModel)
-    mock_capture.rawData.return_value = np.zeros((10, 10))
-    view_model._captures = [mock_capture]
-    view_model._activeIndex = 0
-    view_model._clusterExtractor = MagicMock()
-    view_model.addRoi(0, 0, 5, 5)
-
-    # Available with default BOX_SELECT
-    assert view_model.isClusteringAvailable is True
-
-    # Still available with MAGNIFIER
-    view_model.setActiveTool(ActiveTool.MAGNIFIER)
-    assert view_model.isClusteringAvailable is True
 
 
 def test_pointer_hover_position(view_model):

--- a/tests/test_RawDataViewModel.py
+++ b/tests/test_RawDataViewModel.py
@@ -52,7 +52,6 @@ def test_initial_colormap_from_config():
 def test_initial_state(view_model):
     """Test the initial state of the ViewModel."""
     assert view_model.activeIndex == -1
-    assert view_model.hduSummaries == []
 
 
 def test_load_file_success(view_model):
@@ -79,7 +78,6 @@ def test_load_file_success(view_model):
             mock_load.assert_called_once()
             mock_file_loaded_cb.assert_called_once()
             assert view_model.activeIndex == 0
-            assert "100x100" in view_model.hduSummaries[0]
 
 
 def test_load_file_renders_first_hdu(view_model):


### PR DESCRIPTION
- Overlays HDU ids on top of each HDU thumbnail so that MosaicView uses less vertical space
- Extracts the RawDataView's top toolbar to a separate widget named: `RawDataManipulation` to simplify the view code
- Adds a `selectedHDULabel` to the toolbar so the user can identify the exposure being inspected more easily
- Moves clustering logic to `ClusterAnalysisViewModel` to make `RawDataViewModel` more readable

## User Interface

<img width="2092" height="1520" alt="Screenshot From 2026-04-30 21-41-04" src="https://github.com/user-attachments/assets/d57b578b-25b4-460e-872b-864aa153277e" />


Resolves #40 

