### PR TITLE
feat: Implement export for re-training UX flow

### DIFF
--- a/database-docker/init-scripts/eventPersistence.sql
+++ b/database-docker/init-scripts/eventPersistence.sql
@@ -106,17 +106,20 @@ DELIMITER //
 
 CREATE PROCEDURE insert_classifications(
     IN in_classification VARCHAR(255),
-    IN in_clusterID INT
+    IN in_clusterID INT,
+    OUT out_rows_updated INT
 )
 BEGIN
     DECLARE EXIT HANDLER FOR SQLEXCEPTION
     BEGIN
         ROLLBACK;
+        SET out_rows_updated = -1;
     END;
     START TRANSACTION;
     UPDATE clusters
     SET classification = in_classification
     WHERE clusterID = in_clusterID;
+    SET out_rows_updated = ROW_COUNT();
     COMMIT;
 END //
 

--- a/src/le_beta_vis/app.py
+++ b/src/le_beta_vis/app.py
@@ -93,6 +93,11 @@ def _install_linux_desktop_integration() -> None:
 
 def main() -> None:
     """Launch the LE Beta Particle Visualization application."""
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+        datefmt="%H:%M:%S",
+    )
     current_platform = platform.system()
 
     if current_platform == "Windows":

--- a/src/le_beta_vis/common/EventRepository.py
+++ b/src/le_beta_vis/common/EventRepository.py
@@ -8,6 +8,8 @@ from .EPSDataClasses import (
     ClusterStoreRequest,
     EPSFitsRecord,
     FitsClusterQueryFilter,
+    FitsQueryFilter,
+    FitsStoreRequest,
 )
 
 onCluster = Callable[[List[Cluster]], None]
@@ -142,4 +144,19 @@ class EventRepository(ABC):
             Matching ``Cluster`` objects, enriched with FITS
             filename and date from the backend response.
         """
+        raise NotImplementedError
+
+    def query_fits_sync(
+        self,
+        query_filter: Optional[FitsQueryFilter] = None,
+    ) -> List[EPSFitsRecord]:
+        """Returns FITS records matching *query_filter*, or all records if None.
+
+        Callers already on a background thread may call this directly to
+        avoid an async callback round-trip.
+        """
+        raise NotImplementedError
+
+    def store_fits_sync(self, request: FitsStoreRequest) -> Optional[int]:
+        """Registers a FITS file in EPS; returns its database ID or None on failure."""
         raise NotImplementedError

--- a/src/le_beta_vis/common/MockEventRepository.py
+++ b/src/le_beta_vis/common/MockEventRepository.py
@@ -1,11 +1,15 @@
-from typing import List, Optional, Callable
+from typing import List, Optional
 
 import numpy as np
 
 from .BoundingBox import BoundingBox
 from .Cluster import Cluster
-from .EPSDataClasses import ClusterQueryFilter
-from .EventRepository import EventRepository, onCluster, onError
+from .EPSDataClasses import (
+    ClassificationUpdateRequest,
+    ClusterQueryFilter,
+    ClusterStoreRequest,
+)
+from .EventRepository import EventRepository, onCluster, onError, onUpdate
 
 
 def _gaussian_blob(
@@ -152,3 +156,16 @@ class MockEventRepository(EventRepository):
         if qf.classification is not None:
             return False
         return True
+
+    def store_cluster(self, request: ClusterStoreRequest) -> Optional[int]:
+        """Returns a deterministic fake cluster_id derived from the bounding box."""
+        return abs(hash(frozenset(request.bounding_box.items()))) % 100_000
+
+    def update_classification(
+        self,
+        request: ClassificationUpdateRequest,
+        callback: onUpdate,
+        on_error: onError,
+    ) -> None:
+        """No-op success — no ZMQ in mock mode."""
+        callback(True)

--- a/src/le_beta_vis/common/ZMQBasedEventRepository.py
+++ b/src/le_beta_vis/common/ZMQBasedEventRepository.py
@@ -26,8 +26,9 @@ from .EPSDataClasses import (
     ClusterStoreRequest,
     EPSClusterRecord,
     EPSFitsRecord,
-    FitsQueryFilter,
     FitsClusterQueryFilter,
+    FitsQueryFilter,
+    FitsStoreRequest,
 )
 from .EventRepository import EventRepository, onCluster, onError, onFits, onUpdate
 
@@ -218,6 +219,19 @@ class ZMQBasedEventRepository(EventRepository):
             )
             return None
         return response.get("cluster_id")
+
+    def store_fits_sync(self, request: FitsStoreRequest) -> Optional[int]:
+        """Registers a FITS file in EPS; returns its database ID or None on failure."""
+        response = self._send_fits(request.to_eps_dict())
+        if response is None:
+            return None
+        if response.get("result") != "success":
+            logger.warning(
+                "EPS store_fits returned failure: %s",
+                response.get("result"),
+            )
+            return None
+        return response.get("fits_id")
 
     def update_classification(
             self,

--- a/src/le_beta_vis/frontend/MainWindow.py
+++ b/src/le_beta_vis/frontend/MainWindow.py
@@ -216,7 +216,10 @@ class MainWindow(QMainWindow):
         return row
 
     def _setupViews(self) -> None:
-        self.rawDataView = RawDataView(self.rawDataViewModel)
+        self.rawDataView = RawDataView(
+            self.rawDataViewModel,
+            repository=self.viewModel.eventRepository,
+        )
         self.historicalView = HistoricalView(
             self.historicalViewModel,
             statusViewModel=self.statusViewModel,

--- a/src/le_beta_vis/frontend/theme.py
+++ b/src/le_beta_vis/frontend/theme.py
@@ -110,6 +110,21 @@ class MosaicThumbnailColors:
     LABEL_BACKGROUND_RGBA = (0, 0, 0, 140)
 
 
+class RawClusterLabelingDialogColors:
+    """Colors for the raw-data cluster labeling / training export dialog."""
+
+    CALLOUT_BACKGROUND = "#1a3a1a"
+    CALLOUT_BORDER = "#2e7d32"
+    CALLOUT_TEXT = "#c8e6c9"
+    SUBMIT_BUTTON_BACKGROUND = "#0078d7"
+    SUBMIT_BUTTON_FOREGROUND = "#ffffff"
+    SUBMIT_BUTTON_HOVER = "#005fa3"
+    CANCEL_BUTTON_BACKGROUND = "#3d3d3d"
+    CANCEL_BUTTON_FOREGROUND = "#cccccc"
+    CANCEL_BUTTON_BORDER = "#555555"
+    RESULT_TEXT = "#c8e6c9"
+
+
 class TooltipStyle:
     """Shared QToolTip stylesheet snippets.
 

--- a/src/le_beta_vis/frontend/theme.py
+++ b/src/le_beta_vis/frontend/theme.py
@@ -125,6 +125,10 @@ class RawClusterLabelingDialogColors:
     RESULT_TEXT = "#c8e6c9"
 
 
+class ClusteredEventWidgetColors:
+    BUTTON_DISABLED_TEXT = "#a0a0a0"
+
+
 class TooltipStyle:
     """Shared QToolTip stylesheet snippets.
 

--- a/src/le_beta_vis/frontend/viewmodels/ClusterAnalysisViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/ClusterAnalysisViewModel.py
@@ -336,6 +336,25 @@ class ClusterAnalysisViewModel:
             return
         self._export_handler(clusters)
 
+    def removeClustersByIndices(self, indices: List[int]) -> None:
+        """Removes clusters at the given indices and resets selection.
+
+        Triggers clustering-completed and selection-changed callbacks so
+        ClusterAnalysisView refreshes ClusteredEventWidget automatically.
+        """
+        index_set = frozenset(
+            i for i in indices if 0 <= i < len(self._clusteringResults)
+        )
+        if not index_set:
+            return
+        self._clusteringResults = [
+            c for i, c in enumerate(self._clusteringResults)
+            if i not in index_set
+        ]
+        self._selectedClusterIndices = frozenset()
+        self._notify_clustering_completed()
+        self._notify_selected_cluster_changed()
+
     def triggerClustering(self) -> None:
         """Starts cluster extraction on the current ROI.
 

--- a/src/le_beta_vis/frontend/viewmodels/RawClusterLabelingViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawClusterLabelingViewModel.py
@@ -5,16 +5,18 @@ particle type label to each one, and submit them to EPS via store_cluster.
 The stored records are later harvested for CNN/NRG/BDT retraining.
 """
 
+from le_beta_vis.common.PhysicsConversionManager import PhysicsConversionManager
+from le_beta_vis.common.ParticleType import ParticleType
+from le_beta_vis.common.EventRepository import EventRepository
+from le_beta_vis.common.EPSDataClasses import ClusterStoreRequest
+from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
+from le_beta_vis.common.BoundingBox import BoundingBox
+import logging
 import threading
 from enum import Enum, auto
 from typing import Callable, Dict, List, Optional, Tuple
 
-from le_beta_vis.common.BoundingBox import BoundingBox
-from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
-from le_beta_vis.common.EPSDataClasses import ClusterStoreRequest
-from le_beta_vis.common.EventRepository import EventRepository
-from le_beta_vis.common.ParticleType import ParticleType
-from le_beta_vis.common.PhysicsConversionManager import PhysicsConversionManager
+logger = logging.getLogger(__name__)
 
 
 class Phase(Enum):
@@ -122,6 +124,7 @@ class RawClusterLabelingViewModel:
         threading.Thread(target=self._run_submission, daemon=True).start()
 
     def _run_submission(self) -> None:
+        logger.info("Starting submission of %d cluster(s)", len(self._clusters))
         try:
             fits_id, hdu_id = self._fits_info_provider()
             count = 0
@@ -140,8 +143,12 @@ class RawClusterLabelingViewModel:
                 if result is not None:
                     count += 1
             self._stored_count = count
+            logger.info(
+                "Successfully stored %d/%d cluster(s)", count, len(self._clusters)
+            )
             self._phase = Phase.DONE
         except Exception as exc:
+            logger.exception("store_cluster submission failed: %s", exc)
             self._error_message = str(exc)
             self._phase = Phase.ERROR
         finally:
@@ -159,15 +166,15 @@ class RawClusterLabelingViewModel:
             data=cluster.data.tolist(),
             hdu_id=hdu_id,
             bounding_box={
-                "top": bb.top,
-                "left": bb.left,
-                "bottom": bb.bottom,
-                "right": bb.right,
+                "top": int(bb.top),
+                "left": int(bb.left),
+                "bottom": int(bb.bottom),
+                "right": int(bb.right),
             },
-            sigma_x=cluster.sigmaX,
-            sigma_y=cluster.sigmaY,
-            total_energy=cluster.energy,
-            total_pixels=cluster.pixelCount,
+            sigma_x=float(cluster.sigmaX),
+            sigma_y=float(cluster.sigmaY),
+            total_energy=float(cluster.energy),
+            total_pixels=int(cluster.pixelCount),
             fits_id=fits_id,
             classification=label.name,
         )

--- a/src/le_beta_vis/frontend/viewmodels/RawClusterLabelingViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawClusterLabelingViewModel.py
@@ -83,6 +83,14 @@ class RawClusterLabelingViewModel:
         """Returns cluster energy converted to keV."""
         return float(self._physics.adu_to_kev(self._clusters[index].energy))
 
+    @property
+    def has_any_label(self) -> bool:
+        """True if at least one cluster has a non-UNCLASSIFIED label."""
+        return any(
+            self._labels.get(i, ParticleType.UNCLASSIFIED) != ParticleType.UNCLASSIFIED
+            for i in range(len(self._clusters))
+        )
+
     def set_label(self, index: int, particle_type: ParticleType) -> None:
         """Sets the particle type label for a single cluster row."""
         self._labels[index] = particle_type
@@ -143,6 +151,21 @@ class RawClusterLabelingViewModel:
                 if result is not None:
                     count += 1
             self._stored_count = count
+            labeled_count = sum(
+                1 for i in range(len(self._clusters))
+                if self.label_for(i) != ParticleType.UNCLASSIFIED
+            )
+            if count == 0 and labeled_count > 0:
+                logger.error(
+                    "0/%d labeled cluster(s) were stored — EPS rejected all submissions",
+                    labeled_count,
+                )
+                self._error_message = (
+                    f"No clusters were stored. "
+                    f"EPS rejected all {labeled_count} submission(s)."
+                )
+                self._phase = Phase.ERROR
+                return
             logger.info(
                 "Successfully stored %d/%d cluster(s)", count, len(self._clusters)
             )
@@ -163,7 +186,7 @@ class RawClusterLabelingViewModel:
     ) -> ClusterStoreRequest:
         bb: BoundingBox = cluster.boundingBox
         return ClusterStoreRequest(
-            data=cluster.data.tolist(),
+            data=None,  # type: ignore[arg-type]
             hdu_id=hdu_id,
             bounding_box={
                 "top": int(bb.top),

--- a/src/le_beta_vis/frontend/viewmodels/RawClusterLabelingViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawClusterLabelingViewModel.py
@@ -1,0 +1,173 @@
+"""ViewModel for the raw-data cluster labeling dialog (issue #195).
+
+Scientists select clusters from a live FITS frame, assign a ground-truth
+particle type label to each one, and submit them to EPS via store_cluster.
+The stored records are later harvested for CNN/NRG/BDT retraining.
+"""
+
+import threading
+from enum import Enum, auto
+from typing import Callable, Dict, List, Optional, Tuple
+
+from le_beta_vis.common.BoundingBox import BoundingBox
+from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
+from le_beta_vis.common.EPSDataClasses import ClusterStoreRequest
+from le_beta_vis.common.EventRepository import EventRepository
+from le_beta_vis.common.ParticleType import ParticleType
+from le_beta_vis.common.PhysicsConversionManager import PhysicsConversionManager
+
+
+class Phase(Enum):
+    IDLE = auto()
+    SUBMITTING = auto()
+    DONE = auto()
+    ERROR = auto()
+
+
+class RawClusterLabelingViewModel:
+    """Manages per-cluster label state and async submission to EPS.
+
+    Pure Python — no Qt imports, no QObject inheritance.  The dialog
+    binds to this VM via add_phase_changed_callback and observes phase
+    transitions to switch between form / spinner / result pages.
+    """
+
+    def __init__(
+        self,
+        clusters: List[ClusteredEventInfo],
+        repository: EventRepository,
+        physics: PhysicsConversionManager,
+        fits_info_provider: Callable[[], Tuple[int, int]],
+    ) -> None:
+        self._clusters = clusters
+        self._repository = repository
+        self._physics = physics
+        self._fits_info_provider = fits_info_provider
+        self._labels: Dict[int, ParticleType] = {}
+        self._phase: Phase = Phase.IDLE
+        self._stored_count: int = 0
+        self._error_message: Optional[str] = None
+        self._phase_changed_callbacks: List[Callable[[], None]] = []
+
+    # ------------------------------------------------------------------ state
+
+    @property
+    def clusters(self) -> List[ClusteredEventInfo]:
+        """The clusters offered for labeling."""
+        return self._clusters
+
+    @property
+    def phase(self) -> Phase:
+        """Current submission phase."""
+        return self._phase
+
+    @property
+    def stored_count(self) -> int:
+        """Number of clusters successfully persisted on last submission."""
+        return self._stored_count
+
+    @property
+    def error_message(self) -> Optional[str]:
+        """Set when phase is ERROR; None otherwise."""
+        return self._error_message
+
+    # ----------------------------------------------------------------- labels
+
+    def label_for(self, index: int) -> ParticleType:
+        """Returns the current label for cluster *index*, defaulting to UNCLASSIFIED."""
+        return self._labels.get(index, ParticleType.UNCLASSIFIED)
+
+    def energy_kev(self, index: int) -> float:
+        """Returns cluster energy converted to keV."""
+        return float(self._physics.adu_to_kev(self._clusters[index].energy))
+
+    def set_label(self, index: int, particle_type: ParticleType) -> None:
+        """Sets the particle type label for a single cluster row."""
+        self._labels[index] = particle_type
+
+    def set_all_labels(self, particle_type: ParticleType) -> None:
+        """Sets the same particle type label for every cluster."""
+        for i in range(len(self._clusters)):
+            self._labels[i] = particle_type
+
+    # --------------------------------------------------------------- callbacks
+
+    def add_phase_changed_callback(self, cb: Callable[[], None]) -> None:
+        """Registers *cb* to be called whenever the submission phase changes."""
+        self._phase_changed_callbacks.append(cb)
+
+    def remove_phase_changed_callback(self, cb: Callable[[], None]) -> None:
+        """Unregisters *cb*."""
+        try:
+            self._phase_changed_callbacks.remove(cb)
+        except ValueError:
+            pass
+
+    def _notify_phase_changed(self) -> None:
+        for cb in list(self._phase_changed_callbacks):
+            cb()
+
+    # ------------------------------------------------------------------ action
+
+    def submit(self) -> None:
+        """Submits all labeled (non-UNCLASSIFIED) clusters to EPS asynchronously.
+
+        Transitions: IDLE → SUBMITTING (on this thread) then DONE or ERROR
+        (on the background thread via _notify_phase_changed).
+        """
+        self._phase = Phase.SUBMITTING
+        self._stored_count = 0
+        self._error_message = None
+        self._notify_phase_changed()
+        threading.Thread(target=self._run_submission, daemon=True).start()
+
+    def _run_submission(self) -> None:
+        try:
+            fits_id, hdu_id = self._fits_info_provider()
+            count = 0
+            for i, cluster in enumerate(self._clusters):
+                if self.label_for(i) == ParticleType.UNCLASSIFIED:
+                    continue
+                request = self._build_request(cluster, hdu_id, fits_id, self.label_for(i))
+                # store_cluster creates a new EPS record with the classification
+                # already set in one round-trip. update_classification is
+                # intentionally NOT called here — it requires a cluster_id and
+                # is for retroactively relabeling clusters that were previously
+                # stored without a label (e.g. from the Historical view).
+                # ClusteredEventInfo objects have no cluster_id; they are
+                # in-memory extraction results that have never been persisted.
+                result = self._repository.store_cluster(request)
+                if result is not None:
+                    count += 1
+            self._stored_count = count
+            self._phase = Phase.DONE
+        except Exception as exc:
+            self._error_message = str(exc)
+            self._phase = Phase.ERROR
+        finally:
+            self._notify_phase_changed()
+
+    @staticmethod
+    def _build_request(
+        cluster: ClusteredEventInfo,
+        hdu_id: int,
+        fits_id: int,
+        label: ParticleType,
+    ) -> ClusterStoreRequest:
+        bb: BoundingBox = cluster.boundingBox
+        return ClusterStoreRequest(
+            data=cluster.data.tolist(),
+            hdu_id=hdu_id,
+            bounding_box={
+                "top": bb.top,
+                "left": bb.left,
+                "bottom": bb.bottom,
+                "right": bb.right,
+            },
+            sigma_x=cluster.sigmaX,
+            sigma_y=cluster.sigmaY,
+            total_energy=cluster.energy,
+            total_pixels=cluster.pixelCount,
+            fits_id=fits_id,
+            classification=label.name,
+        )

--- a/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
@@ -48,6 +48,7 @@ class RawDataViewModel:
         self._converter = OpenCVBasedConverter()
         self._captures: List[CCDCaptureModel] = []
         self._activeIndex: int = -1
+        self._fits_path: Optional[str] = None
         self._init_callbacks()
         self._init_sub_viewmodels()
         self._init_visualization_state()
@@ -126,6 +127,7 @@ class RawDataViewModel:
 
         self._captures = CCDCaptureModel.load(path)
         self._activeIndex = -1
+        self._fits_path = filePath
         self.mosaicViewModel.setCaptures(self._captures)
 
         if self._captures:
@@ -362,6 +364,17 @@ class RawDataViewModel:
     @property
     def activeIndex(self) -> int:
         return self._activeIndex
+
+    @property
+    def fits_path(self) -> Optional[str]:
+        """Path of the currently loaded FITS file; None if no file is loaded."""
+        return self._fits_path
+
+    def active_capture_info(self) -> Optional[CCDCaptureModel.Info]:
+        """Metadata for the currently active HDU; None if nothing is loaded."""
+        if self._activeIndex == -1 or not self._captures:
+            return None
+        return self._captures[self._activeIndex].info()
 
     @property
     def activeHDULabel(self) -> Optional[str]:

--- a/src/le_beta_vis/frontend/views/raw_data_view/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/RawDataView.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from pathlib import Path
 from typing import List, Optional, Tuple
 
 from PySide6.QtCore import (
@@ -13,6 +15,7 @@ from PySide6.QtWidgets import (
 )
 
 from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
+from le_beta_vis.common.EPSDataClasses import FitsQueryFilter, FitsStoreRequest
 from le_beta_vis.common.EventRepository import EventRepository
 from ...viewmodels.ClusterAnalysisViewModel import ClusteringState
 from ...viewmodels.RawDataViewModel import RawDataViewModel
@@ -144,10 +147,36 @@ class RawDataView(QWidget):
         indices_to_remove = list(self._cavm.selectedClusterIndices)
 
         def fits_info() -> Tuple[int, int]:
-            # fits_id: int — the EPS database ID for the loaded FITS file.
-            # Not yet available on RawDataViewModel; returns 0 as a placeholder
-            # until FITS ingestion lookup is implemented (issue #195).
-            return 0, self.viewModel.activeIndex
+            fits_path = self.viewModel.fits_path
+            if not fits_path:
+                raise RuntimeError("No FITS file is currently loaded.")
+            filename = Path(fits_path).name
+            records = self._repository.query_fits_sync(
+                FitsQueryFilter(filename=filename)
+            )
+            if records:
+                return records[0].fits_id, self.viewModel.activeIndex
+            info = self.viewModel.active_capture_info()
+            capture_date = info.captureDate() if info else None
+            date_str = (
+                capture_date.to_datetime().strftime("%Y-%m-%d %H:%M:%S")
+                if capture_date is not None
+                else datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            )
+            exposure = info.exposureDuration() if info else None
+            new_fits_id = self._repository.store_fits_sync(FitsStoreRequest(
+                filename=filename,
+                date=date_str,
+                min=float(info.min) if info else 0.0,
+                max=float(info.max) if info else 0.0,
+                exposure_time=float(exposure.sec) if exposure is not None else 0.0,
+            ))
+            if new_fits_id is None:
+                raise RuntimeError(
+                    f"Failed to register '{filename}' in EPS. "
+                    "Check EPS connectivity."
+                )
+            return new_fits_id, self.viewModel.activeIndex
 
         from ...viewmodels.RawClusterLabelingViewModel import (
             RawClusterLabelingViewModel,

--- a/src/le_beta_vis/frontend/views/raw_data_view/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/RawDataView.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 from PySide6.QtCore import (
     QMetaObject,
@@ -6,11 +6,14 @@ from PySide6.QtCore import (
     Slot,
 )
 from PySide6.QtWidgets import (
+    QDialog,
     QHBoxLayout,
     QVBoxLayout,
     QWidget,
 )
 
+from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
+from le_beta_vis.common.EventRepository import EventRepository
 from ...viewmodels.ClusterAnalysisViewModel import ClusteringState
 from ...viewmodels.RawDataViewModel import RawDataViewModel
 from ..MosaicView import MosaicView
@@ -20,9 +23,14 @@ from ._RightSidebarView import _RightSidebarView
 
 
 class RawDataView(QWidget):
-    def __init__(self, viewModel: RawDataViewModel):
+    def __init__(
+        self,
+        viewModel: RawDataViewModel,
+        repository: Optional[EventRepository] = None,
+    ):
         super().__init__()
         self.viewModel = viewModel
+        self._repository = repository
         self._pendingClusterFocus: Optional[
             Tuple[Optional[int], Tuple[int, int, int, int]]
         ] = None
@@ -75,6 +83,8 @@ class RawDataView(QWidget):
         self._bindRangeAndFocusCallbacks()
         self._bindClusteringStateCallback()
         self._rightSidebar.syncSelectors()
+        if self._repository is not None:
+            self._cavm.setExportHandler(self._onExportRequested)
 
     def _bindMosaicCallbacks(self) -> None:
         self.viewModel.mosaicViewModel.add_thumbnails_changed_callback(
@@ -129,6 +139,30 @@ class RawDataView(QWidget):
         running = self._cavm.clusteringState == ClusteringState.RUNNING
         self._leftToolbar.setEnabled(not running)
         self._rightSidebar.setEnabled(not running)
+
+    def _onExportRequested(self, clusters: List[ClusteredEventInfo]) -> None:
+        indices_to_remove = list(self._cavm.selectedClusterIndices)
+
+        def fits_info() -> Tuple[int, int]:
+            # fits_id: int — the EPS database ID for the loaded FITS file.
+            # Not yet available on RawDataViewModel; returns 0 as a placeholder
+            # until FITS ingestion lookup is implemented (issue #195).
+            return 0, self.viewModel.activeIndex
+
+        from ...viewmodels.RawClusterLabelingViewModel import (
+            RawClusterLabelingViewModel,
+        )
+        from ._RawClusterLabelingDialog import _RawClusterLabelingDialog
+
+        vm = RawClusterLabelingViewModel(
+            clusters=clusters,
+            repository=self._repository,
+            physics=self.viewModel.physics_manager,
+            fits_info_provider=fits_info,
+        )
+        dialog = _RawClusterLabelingDialog(vm, parent=self.window())
+        if dialog.exec() == QDialog.Accepted:
+            self._cavm.removeClustersByIndices(indices_to_remove)
 
     def openClusterForAnalysis(
         self,

--- a/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterLabelingDialog.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterLabelingDialog.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from PySide6.QtCore import QMetaObject, QSize, Qt, Slot
+from PySide6.QtCore import QMetaObject, Qt, Slot
 from PySide6.QtWidgets import (
     QComboBox,
     QDialog,
     QFrame,
     QHBoxLayout,
     QLabel,
+    QMessageBox,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -58,8 +59,9 @@ class _RawClusterLabelingDialog(QDialog):
         self.setWindowTitle(self.tr("Export for Training"))
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setMinimumWidth(480)
+        self.setMaximumHeight(500)
         if parent is not None:
-            self.setMaximumSize(parent.size() - QSize(40, 40))
+            self.setMaximumWidth(parent.width() - 40)
         self._initUI()
         self._bindViewModel()
 
@@ -301,16 +303,8 @@ class _RawClusterLabelingDialog(QDialog):
         elif phase == Phase.ERROR:
             self._spinner.stop()
             msg = self._vm.error_message or self.tr("Unknown error")
-            self._resultLabel.setText(
-                self.tr("Submission failed:\n{msg}").format(msg=msg)
-            )
-            self._resultLabel.setStyleSheet(
-                "color: #ff5a5a; font-size: 14px;"
-            )
-            self._stack.setCurrentIndex(self._PAGE_RESULT)
-            self._cancelBtn.setVisible(False)
-            self._submitBtn.setVisible(False)
-            self._okBtn.setVisible(True)
+            QMessageBox.critical(self, self.tr("Submission Failed"), msg)
+            self.reject()
 
     def _onLabelAllChanged(self, combo_index: int) -> None:
         pt = _PARTICLE_TYPES[combo_index]

--- a/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterLabelingDialog.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterLabelingDialog.py
@@ -1,0 +1,328 @@
+"""Ground-truth labeling dialog for exporting clusters to EPS for retraining.
+
+Private to the raw_data_view package. Binds to RawClusterLabelingViewModel.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from PySide6.QtCore import QMetaObject, QSize, Qt, Slot
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ...fitsconverters import Colormap
+from ...theme import RawClusterLabelingDialogColors as _C
+from ...viewmodels.RawClusterLabelingViewModel import Phase, RawClusterLabelingViewModel
+from ...widgets.ArcSpinner import ArcSpinner
+from ...widgets.EnergyClusterWidget import EnergyClusterWidget
+from le_beta_vis.common.ParticleType import ParticleType
+
+_THUMBNAIL_SIZE = 64
+_PARTICLE_TYPES = list(ParticleType)
+
+
+class _RawClusterLabelingDialog(QDialog):
+    """Shows selected clusters with per-row particle type selectors.
+
+    Three-page flow managed by a QStackedWidget:
+      0 — FORM: callout + label-all + scroll area of cluster rows
+      1 — SPINNER: ArcSpinner while submission is in flight
+      2 — RESULT: summary label + OK button
+
+    Never exceeds the size of the parent window.
+    """
+
+    _PAGE_FORM = 0
+    _PAGE_SPINNER = 1
+    _PAGE_RESULT = 2
+
+    def __init__(
+        self,
+        viewModel: RawClusterLabelingViewModel,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._vm = viewModel
+        self._row_combos: List[QComboBox] = []
+        self.setWindowTitle(self.tr("Export for Training"))
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        self.setMinimumWidth(480)
+        if parent is not None:
+            self.setMaximumSize(parent.size() - QSize(40, 40))
+        self._initUI()
+        self._bindViewModel()
+
+    # ------------------------------------------------------------------- UI
+
+    def _initUI(self) -> None:
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 16)
+        root.setSpacing(0)
+
+        self._stack = QStackedWidget()
+        self._stack.addWidget(self._buildFormPage())
+        self._stack.addWidget(self._buildSpinnerPage())
+        self._stack.addWidget(self._buildResultPage())
+        root.addWidget(self._stack, 1)
+
+        root.addLayout(self._buildButtonRow())
+
+    def _buildFormPage(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(16, 16, 16, 8)
+        layout.setSpacing(10)
+
+        layout.addWidget(self._buildCallout())
+        layout.addWidget(self._buildLabelAllRow())
+        layout.addWidget(self._buildScrollArea(), 1)
+        return page
+
+    def _buildCallout(self) -> QLabel:
+        callout = QLabel(
+            self.tr(
+                "Assign a particle type to each cluster to add it as a ground-truth "
+                "label. Submitted clusters are available for the next CNN, NRG, and "
+                "BDT retraining cycle. Clusters left as ‘?’ are not submitted."
+            )
+        )
+        callout.setWordWrap(True)
+        callout.setStyleSheet(
+            f"background-color: {_C.CALLOUT_BACKGROUND};"
+            f"border: 1px solid {_C.CALLOUT_BORDER};"
+            f"color: {_C.CALLOUT_TEXT};"
+            "border-radius: 4px;"
+            "padding: 8px 10px;"
+            "font-size: 12px;"
+        )
+        return callout
+
+    def _buildLabelAllRow(self) -> QWidget:
+        container = QWidget()
+        row = QHBoxLayout(container)
+        row.setContentsMargins(0, 0, 0, 0)
+        row.addWidget(QLabel(self.tr("Label all:")))
+        self._labelAllCombo = QComboBox()
+        for pt in _PARTICLE_TYPES:
+            self._labelAllCombo.addItem(pt.symbol, pt)
+        self._labelAllCombo.setCurrentIndex(
+            _PARTICLE_TYPES.index(ParticleType.UNCLASSIFIED)
+        )
+        self._labelAllCombo.currentIndexChanged.connect(self._onLabelAllChanged)
+        row.addWidget(self._labelAllCombo)
+        row.addStretch()
+        return container
+
+    def _buildScrollArea(self) -> QScrollArea:
+        area = QScrollArea()
+        area.setWidgetResizable(True)
+        area.setFrameShape(QFrame.NoFrame)
+        area.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        content = QWidget()
+        content_layout = QVBoxLayout(content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(6)
+
+        self._row_combos = []
+        for i, cluster in enumerate(self._vm.clusters):
+            row_widget, combo = self._buildClusterRow(i, cluster)
+            self._row_combos.append(combo)
+            content_layout.addWidget(row_widget)
+
+        content_layout.addStretch()
+        area.setWidget(content)
+        return area
+
+    def _buildClusterRow(self, index: int, cluster) -> tuple:
+        row = QFrame()
+        row.setFrameShape(QFrame.StyledPanel)
+        h = QHBoxLayout(row)
+        h.setContentsMargins(6, 6, 6, 6)
+        h.setSpacing(10)
+
+        thumb = EnergyClusterWidget(size=_THUMBNAIL_SIZE)
+        thumb.setCluster(cluster.data, Colormap.VIRIDIS)
+        h.addWidget(thumb)
+
+        info = QVBoxLayout()
+        info.setSpacing(2)
+
+        sigma_label = QLabel(
+            self.tr(
+                "σx {sx:.1f}  σy {sy:.1f}  {px} px"
+            ).format(
+                sx=cluster.sigmaX,
+                sy=cluster.sigmaY,
+                px=cluster.pixelCount,
+            )
+        )
+        info.addWidget(sigma_label)
+
+        energy_label = QLabel(
+            self.tr("{e:.2f} keV").format(e=self._vm.energy_kev(index))
+        )
+        info.addWidget(energy_label)
+
+        label_row = QHBoxLayout()
+        label_row.addWidget(QLabel(self.tr("Label:")))
+        combo = QComboBox()
+        for pt in _PARTICLE_TYPES:
+            combo.addItem(pt.symbol, pt)
+        combo.setCurrentIndex(_PARTICLE_TYPES.index(ParticleType.UNCLASSIFIED))
+        combo.currentIndexChanged.connect(
+            lambda _, idx=index, c=combo: self._onRowLabelChanged(idx, c)
+        )
+        label_row.addWidget(combo)
+        label_row.addStretch()
+        info.addLayout(label_row)
+
+        h.addLayout(info, 1)
+        return row, combo
+
+    def _buildSpinnerPage(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setSpacing(12)
+
+        self._spinner = ArcSpinner()
+        self._spinner.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        layout.addWidget(self._spinner, 0, Qt.AlignHCenter)
+
+        self._spinnerLabel = QLabel(self.tr("Submitting…"))
+        self._spinnerLabel.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self._spinnerLabel)
+        return page
+
+    def _buildResultPage(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setSpacing(12)
+
+        self._resultLabel = QLabel()
+        self._resultLabel.setAlignment(Qt.AlignCenter)
+        self._resultLabel.setWordWrap(True)
+        self._resultLabel.setStyleSheet(
+            f"color: {_C.RESULT_TEXT}; font-size: 14px;"
+        )
+        layout.addWidget(self._resultLabel)
+        return page
+
+    def _buildButtonRow(self) -> QHBoxLayout:
+        row = QHBoxLayout()
+        row.setContentsMargins(16, 0, 0, 0)
+        row.addStretch()
+
+        self._cancelBtn = QPushButton(self.tr("Cancel"))
+        self._cancelBtn.setStyleSheet(
+            "QPushButton {"
+            f"  background-color: {_C.CANCEL_BUTTON_BACKGROUND};"
+            f"  color: {_C.CANCEL_BUTTON_FOREGROUND};"
+            f"  border: 1px solid {_C.CANCEL_BUTTON_BORDER};"
+            "  border-radius: 4px;"
+            "  padding: 6px 16px;"
+            "}"
+        )
+        self._cancelBtn.clicked.connect(self.reject)
+        row.addWidget(self._cancelBtn)
+
+        self._submitBtn = QPushButton(self.tr("Submit"))
+        self._submitBtn.setStyleSheet(
+            "QPushButton {"
+            f"  background-color: {_C.SUBMIT_BUTTON_BACKGROUND};"
+            f"  color: {_C.SUBMIT_BUTTON_FOREGROUND};"
+            "  border: none;"
+            "  border-radius: 4px;"
+            "  padding: 6px 16px;"
+            "  font-weight: bold;"
+            "}"
+            "QPushButton:hover {"
+            f"  background-color: {_C.SUBMIT_BUTTON_HOVER};"
+            "}"
+            "QPushButton:disabled { background-color: #555555; color: #888888; }"
+        )
+        self._submitBtn.clicked.connect(self._vm.submit)
+        row.addWidget(self._submitBtn)
+
+        self._okBtn = QPushButton(self.tr("OK"))
+        self._okBtn.setStyleSheet(self._submitBtn.styleSheet())
+        self._okBtn.clicked.connect(self.accept)
+        self._okBtn.setVisible(False)
+        row.addWidget(self._okBtn)
+
+        return row
+
+    # ------------------------------------------------------------ ViewModel binding
+
+    def _bindViewModel(self) -> None:
+        self._vm.add_phase_changed_callback(
+            lambda: QMetaObject.invokeMethod(
+                self, "_onPhaseChanged", Qt.AutoConnection
+            )
+        )
+
+    # ------------------------------------------------------------------ slots
+
+    @Slot()
+    def _onPhaseChanged(self) -> None:
+        phase = self._vm.phase
+        if phase == Phase.SUBMITTING:
+            self._stack.setCurrentIndex(self._PAGE_SPINNER)
+            self._spinner.start()
+            self._cancelBtn.setEnabled(False)
+            self._submitBtn.setEnabled(False)
+        elif phase == Phase.DONE:
+            self._spinner.stop()
+            total = len(self._vm.clusters)
+            stored = self._vm.stored_count
+            self._resultLabel.setText(
+                self.tr(
+                    "✓ {stored} of {total} cluster(s) submitted\n"
+                    "for model retraining."
+                ).format(stored=stored, total=total)
+            )
+            self._stack.setCurrentIndex(self._PAGE_RESULT)
+            self._cancelBtn.setVisible(False)
+            self._submitBtn.setVisible(False)
+            self._okBtn.setVisible(True)
+        elif phase == Phase.ERROR:
+            self._spinner.stop()
+            msg = self._vm.error_message or self.tr("Unknown error")
+            self._resultLabel.setText(
+                self.tr("Submission failed:\n{msg}").format(msg=msg)
+            )
+            self._resultLabel.setStyleSheet(
+                "color: #ff5a5a; font-size: 14px;"
+            )
+            self._stack.setCurrentIndex(self._PAGE_RESULT)
+            self._cancelBtn.setVisible(False)
+            self._submitBtn.setVisible(False)
+            self._okBtn.setVisible(True)
+
+    def _onLabelAllChanged(self, combo_index: int) -> None:
+        pt = _PARTICLE_TYPES[combo_index]
+        self._vm.set_all_labels(pt)
+        self._refreshAllRowCombos()
+
+    def _onRowLabelChanged(self, cluster_index: int, combo: QComboBox) -> None:
+        pt = combo.currentData()
+        self._vm.set_label(cluster_index, pt)
+
+    def _refreshAllRowCombos(self) -> None:
+        for i, combo in enumerate(self._row_combos):
+            combo.blockSignals(True)
+            combo.setCurrentIndex(_PARTICLE_TYPES.index(self._vm.label_for(i)))
+            combo.blockSignals(False)

--- a/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterLabelingDialog.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterLabelingDialog.py
@@ -36,17 +36,17 @@ _PARTICLE_TYPES = list(ParticleType)
 class _RawClusterLabelingDialog(QDialog):
     """Shows selected clusters with per-row particle type selectors.
 
-    Three-page flow managed by a QStackedWidget:
+    Two-page flow managed by a QStackedWidget:
       0 — FORM: callout + label-all + scroll area of cluster rows
       1 — SPINNER: ArcSpinner while submission is in flight
-      2 — RESULT: summary label + OK button
 
+    Outcomes (success / error) are surfaced via QMessageBox; the dialog
+    closes immediately after the user dismisses the message box.
     Never exceeds the size of the parent window.
     """
 
     _PAGE_FORM = 0
     _PAGE_SPINNER = 1
-    _PAGE_RESULT = 2
 
     def __init__(
         self,
@@ -69,13 +69,12 @@ class _RawClusterLabelingDialog(QDialog):
 
     def _initUI(self) -> None:
         root = QVBoxLayout(self)
-        root.setContentsMargins(0, 0, 0, 16)
+        root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(0)
 
         self._stack = QStackedWidget()
         self._stack.addWidget(self._buildFormPage())
         self._stack.addWidget(self._buildSpinnerPage())
-        self._stack.addWidget(self._buildResultPage())
         root.addWidget(self._stack, 1)
 
         root.addLayout(self._buildButtonRow())
@@ -208,24 +207,9 @@ class _RawClusterLabelingDialog(QDialog):
         layout.addWidget(self._spinnerLabel)
         return page
 
-    def _buildResultPage(self) -> QWidget:
-        page = QWidget()
-        layout = QVBoxLayout(page)
-        layout.setAlignment(Qt.AlignCenter)
-        layout.setSpacing(12)
-
-        self._resultLabel = QLabel()
-        self._resultLabel.setAlignment(Qt.AlignCenter)
-        self._resultLabel.setWordWrap(True)
-        self._resultLabel.setStyleSheet(
-            f"color: {_C.RESULT_TEXT}; font-size: 14px;"
-        )
-        layout.addWidget(self._resultLabel)
-        return page
-
     def _buildButtonRow(self) -> QHBoxLayout:
         row = QHBoxLayout()
-        row.setContentsMargins(16, 0, 0, 0)
+        row.setContentsMargins(16, 12, 16, 12)
         row.addStretch()
 
         self._cancelBtn = QPushButton(self.tr("Cancel"))
@@ -240,8 +224,9 @@ class _RawClusterLabelingDialog(QDialog):
         )
         self._cancelBtn.clicked.connect(self.reject)
         row.addWidget(self._cancelBtn)
+        row.addSpacing(8)
 
-        self._submitBtn = QPushButton(self.tr("Submit"))
+        self._submitBtn = QPushButton(self.tr("Add to Training Set"))
         self._submitBtn.setStyleSheet(
             "QPushButton {"
             f"  background-color: {_C.SUBMIT_BUTTON_BACKGROUND};"
@@ -256,14 +241,9 @@ class _RawClusterLabelingDialog(QDialog):
             "}"
             "QPushButton:disabled { background-color: #555555; color: #888888; }"
         )
+        self._submitBtn.setEnabled(False)
         self._submitBtn.clicked.connect(self._vm.submit)
         row.addWidget(self._submitBtn)
-
-        self._okBtn = QPushButton(self.tr("OK"))
-        self._okBtn.setStyleSheet(self._submitBtn.styleSheet())
-        self._okBtn.clicked.connect(self.accept)
-        self._okBtn.setVisible(False)
-        row.addWidget(self._okBtn)
 
         return row
 
@@ -290,30 +270,33 @@ class _RawClusterLabelingDialog(QDialog):
             self._spinner.stop()
             total = len(self._vm.clusters)
             stored = self._vm.stored_count
-            self._resultLabel.setText(
+            QMessageBox.information(
+                self,
+                self.tr("Training Set Updated"),
                 self.tr(
-                    "✓ {stored} of {total} cluster(s) submitted\n"
-                    "for model retraining."
-                ).format(stored=stored, total=total)
+                    "{stored} of {total} cluster(s) added to the training set."
+                ).format(stored=stored, total=total),
             )
-            self._stack.setCurrentIndex(self._PAGE_RESULT)
-            self._cancelBtn.setVisible(False)
-            self._submitBtn.setVisible(False)
-            self._okBtn.setVisible(True)
+            self.accept()
         elif phase == Phase.ERROR:
             self._spinner.stop()
             msg = self._vm.error_message or self.tr("Unknown error")
             QMessageBox.critical(self, self.tr("Submission Failed"), msg)
             self.reject()
 
+    def _refreshSubmitButton(self) -> None:
+        self._submitBtn.setEnabled(self._vm.has_any_label)
+
     def _onLabelAllChanged(self, combo_index: int) -> None:
         pt = _PARTICLE_TYPES[combo_index]
         self._vm.set_all_labels(pt)
         self._refreshAllRowCombos()
+        self._refreshSubmitButton()
 
     def _onRowLabelChanged(self, cluster_index: int, combo: QComboBox) -> None:
         pt = combo.currentData()
         self._vm.set_label(cluster_index, pt)
+        self._refreshSubmitButton()
 
     def _refreshAllRowCombos(self) -> None:
         for i, combo in enumerate(self._row_combos):

--- a/src/le_beta_vis/frontend/widgets/ClusteredEventWidget.py
+++ b/src/le_beta_vis/frontend/widgets/ClusteredEventWidget.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
 
 from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
 from le_beta_vis.frontend.fitsconverters.interface import Colormap
+from le_beta_vis.frontend.theme import ClusteredEventWidgetColors as _CEC
 from le_beta_vis.frontend.widgets.EnergyClusterWidget import (
     EnergyClusterWidget,
 )
@@ -71,13 +72,19 @@ class ClusteredEventWidget(QWidget):
         layout.addWidget(self._listWidget)
 
         btnLayout = QHBoxLayout()
+        _disabled_style = (
+            "QPushButton:disabled {" f" color: {_CEC.BUTTON_DISABLED_TEXT};" "}"
+        )
+
         self._btnClassify = QPushButton(self.tr("Classify"))
         self._btnClassify.setEnabled(False)
+        self._btnClassify.setStyleSheet(_disabled_style)
         self._btnClassify.clicked.connect(self.classifyRequested)
         btnLayout.addWidget(self._btnClassify)
 
         self._btnExport = QPushButton(self.tr("Export for Training"))
         self._btnExport.setEnabled(False)
+        self._btnExport.setStyleSheet(_disabled_style)
         self._btnExport.clicked.connect(self.exportRequested)
         btnLayout.addWidget(self._btnExport)
 
@@ -167,9 +174,7 @@ class ClusteredEventWidget(QWidget):
         """
         self.setSelectedIndices([] if index < 0 else [index])
 
-    def _createEntryWidget(
-        self, index: int, event: ClusteredEventInfo
-    ) -> QWidget:
+    def _createEntryWidget(self, index: int, event: ClusteredEventInfo) -> QWidget:
         """Creates a single list entry with thumbnail and metadata."""
         entry = QWidget()
         entry.setStyleSheet(_Style.ENTRY_WIDGET)
@@ -205,8 +210,7 @@ class ClusteredEventWidget(QWidget):
 
         sigma_label = QLabel(
             self.tr(
-                "\u03c3<sub>x</sub> = {sx:.2f},"
-                " \u03c3<sub>y</sub> = {sy:.2f}"
+                "\u03c3<sub>x</sub> = {sx:.2f}," " \u03c3<sub>y</sub> = {sy:.2f}"
             ).format(sx=event.sigmaX, sy=event.sigmaY)
         )
         metaLayout.addWidget(sigma_label)
@@ -233,13 +237,9 @@ class ClusteredEventWidget(QWidget):
             )
         )
 
-    def _createThumbnailLabel(
-        self, event: ClusteredEventInfo
-    ) -> EnergyClusterWidget:
+    def _createThumbnailLabel(self, event: ClusteredEventInfo) -> EnergyClusterWidget:
         """Generates a thumbnail widget from cluster data."""
-        widget = EnergyClusterWidget(
-            size=THUMBNAIL_SIZE, parent=self
-        )
+        widget = EnergyClusterWidget(size=THUMBNAIL_SIZE, parent=self)
         widget.setCluster(event.data, self._colormap)
         return widget
 
@@ -259,8 +259,7 @@ class ClusteredEventWidget(QWidget):
     def _onSelectionChanged(self) -> None:
         """Slot for QListWidget.itemSelectionChanged signal."""
         selected_rows = sorted(
-            self._listWidget.row(item)
-            for item in self._listWidget.selectedItems()
+            self._listWidget.row(item) for item in self._listWidget.selectedItems()
         )
         count = len(selected_rows)
         self._btnClassify.setEnabled(count > 0)

--- a/tests/test_EPSDataClasses.py
+++ b/tests/test_EPSDataClasses.py
@@ -2,8 +2,10 @@
 
 Pure data-mapping tests — no ZMQ dependency.
 """
+import json
 from datetime import datetime
 
+import numpy as np
 import pytest
 
 from le_beta_vis.common.EPSDataClasses import (
@@ -188,11 +190,11 @@ class TestFitsQueryFilter:
             FitsQueryFilter.from_eps_dict(
                 {
                     "date": {
-                "start": datetime("2025-03-01 08:00:00"),
-                "end": datetime("2025-03-31 17:30:00"),
-            }
-        }
-    )
+                        "start": datetime("2025-03-01 08:00:00"),
+                        "end": datetime("2025-03-31 17:30:00"),
+                    }
+                }
+            )
 
 
 # -------------------------------------------------------------------
@@ -223,6 +225,66 @@ class TestClusterStoreRequest:
             total_energy=0.0, total_pixels=0, fits_id=0,
         )
         assert req.classification == ""
+
+    # -- serialization contract tests (issue #196) -------------------------
+
+    _NATIVE_KWARGS = dict(
+        data=[[1, 2], [3, 4]],
+        hdu_id=0,
+        bounding_box={"top": 0, "left": 0, "bottom": 5, "right": 5},
+        sigma_x=1.5,
+        sigma_y=2.0,
+        total_energy=100.0,
+        total_pixels=25,
+        fits_id=1,
+        classification="TRITIUM",
+    )
+
+    def test_json_serializable_with_python_natives(self):
+        req = ClusterStoreRequest(**self._NATIVE_KWARGS)
+        json.dumps(req.to_eps_dict())
+
+    def test_numpy_int64_bounding_box_not_json_serializable(self):
+        kwargs = {**self._NATIVE_KWARGS, "bounding_box": {
+            "top": np.int64(0), "left": np.int64(0),
+            "bottom": np.int64(5), "right": np.int64(5),
+        }}
+        req = ClusterStoreRequest(**kwargs)
+        with pytest.raises(TypeError):
+            json.dumps(req.to_eps_dict())
+
+    def test_numpy_int64_total_pixels_not_json_serializable(self):
+        req = ClusterStoreRequest(**{**self._NATIVE_KWARGS, "total_pixels": np.int64(25)})
+        with pytest.raises(TypeError):
+            json.dumps(req.to_eps_dict())
+
+    def test_numpy_float64_fields_are_json_serializable(self):
+        req = ClusterStoreRequest(**{
+            **self._NATIVE_KWARGS,
+            "sigma_x": np.float64(1.5),
+            "sigma_y": np.float64(2.0),
+            "total_energy": np.float64(100.0),
+        })
+        json.dumps(req.to_eps_dict())
+
+    def test_ndarray_data_not_json_serializable_but_tolist_is(self):
+        array = np.array([[1, 2], [3, 4]])
+        req_raw = ClusterStoreRequest(**{**self._NATIVE_KWARGS, "data": array})
+        with pytest.raises(TypeError):
+            json.dumps(req_raw.to_eps_dict())
+        req_converted = ClusterStoreRequest(**{**self._NATIVE_KWARGS, "data": array.tolist()})
+        json.dumps(req_converted.to_eps_dict())
+
+    def test_output_dict_field_types_are_python_natives(self):
+        d = ClusterStoreRequest(**self._NATIVE_KWARGS).to_eps_dict()
+        assert isinstance(d["hdu_id"], int) and not isinstance(d["hdu_id"], np.integer)
+        assert isinstance(d["fits_id"], int) and not isinstance(d["fits_id"], np.integer)
+        assert isinstance(d["total_pixels"], int) and not isinstance(d["total_pixels"], np.integer)
+        assert isinstance(d["sigmaX"], float) and not isinstance(d["sigmaX"], np.floating)
+        assert isinstance(d["sigmaY"], float) and not isinstance(d["sigmaY"], np.floating)
+        assert isinstance(d["total_energy"], float) and not isinstance(d["total_energy"], np.floating)
+        for val in d["bounding_box"].values():
+            assert isinstance(val, int) and not isinstance(val, np.integer)
 
 
 # -------------------------------------------------------------------

--- a/tests/test_RawClusterLabelingViewModel.py
+++ b/tests/test_RawClusterLabelingViewModel.py
@@ -1,0 +1,208 @@
+"""Unit tests for RawClusterLabelingViewModel (no QApplication required)."""
+
+import threading
+from typing import List, Optional
+from unittest.mock import MagicMock, call, patch
+
+import numpy as np
+import pytest
+
+from le_beta_vis.common.BoundingBox import BoundingBox
+from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
+from le_beta_vis.common.EPSDataClasses import ClusterStoreRequest
+from le_beta_vis.common.ParticleType import ParticleType
+from le_beta_vis.frontend.viewmodels.RawClusterLabelingViewModel import (
+    Phase,
+    RawClusterLabelingViewModel,
+)
+
+
+def _make_cluster(
+    energy: float = 1000.0,
+    sigma_x: float = 1.5,
+    sigma_y: float = 1.2,
+    pixel_count: int = 20,
+    top: int = 0,
+    left: int = 0,
+) -> ClusteredEventInfo:
+    return ClusteredEventInfo(
+        boundingBox=BoundingBox(top=top, left=left, bottom=top + 5, right=left + 5),
+        data=np.ones((5, 5), dtype=float),
+        centerX=left + 2,
+        centerY=top + 2,
+        sigmaX=sigma_x,
+        sigmaY=sigma_y,
+        energy=energy,
+        pixelCount=pixel_count,
+    )
+
+
+def _make_vm(
+    clusters: Optional[List[ClusteredEventInfo]] = None,
+    store_return: Optional[int] = 42,
+) -> RawClusterLabelingViewModel:
+    if clusters is None:
+        clusters = [_make_cluster(), _make_cluster(), _make_cluster()]
+    repo = MagicMock()
+    repo.store_cluster.return_value = store_return
+    physics = MagicMock()
+    physics.adu_to_kev.side_effect = lambda v: v * 0.5
+    def fits_info(): return (7, 2)
+    return RawClusterLabelingViewModel(
+        clusters=clusters,
+        repository=repo,
+        physics=physics,
+        fits_info_provider=fits_info,
+    )
+
+
+# ----------------------------------------------------------------- label state
+
+
+def test_default_labels_are_unclassified():
+    vm = _make_vm()
+    for i in range(len(vm.clusters)):
+        assert vm.label_for(i) == ParticleType.UNCLASSIFIED
+
+
+def test_set_label_updates_single_index():
+    vm = _make_vm()
+    vm.set_label(1, ParticleType.TRITIUM)
+    assert vm.label_for(0) == ParticleType.UNCLASSIFIED
+    assert vm.label_for(1) == ParticleType.TRITIUM
+    assert vm.label_for(2) == ParticleType.UNCLASSIFIED
+
+
+def test_set_all_labels_updates_every_index():
+    vm = _make_vm()
+    vm.set_all_labels(ParticleType.MUON)
+    for i in range(len(vm.clusters)):
+        assert vm.label_for(i) == ParticleType.MUON
+
+
+def test_set_all_then_override_single():
+    vm = _make_vm()
+    vm.set_all_labels(ParticleType.TRITIUM)
+    vm.set_label(1, ParticleType.GAMMA)
+    assert vm.label_for(0) == ParticleType.TRITIUM
+    assert vm.label_for(1) == ParticleType.GAMMA
+    assert vm.label_for(2) == ParticleType.TRITIUM
+
+
+# ---------------------------------------------------------------- energy_kev
+
+
+def test_energy_kev_uses_physics_manager():
+    cluster = _make_cluster(energy=2000.0)
+    vm = _make_vm(clusters=[cluster])
+    assert vm.energy_kev(0) == pytest.approx(1000.0)
+    vm._physics.adu_to_kev.assert_called_once_with(2000.0)
+
+
+# --------------------------------------------------------------- submit logic
+
+
+def _submit_and_wait(vm: RawClusterLabelingViewModel) -> None:
+    done = threading.Event()
+    vm.add_phase_changed_callback(
+        lambda: done.set() if vm.phase in (Phase.DONE, Phase.ERROR) else None
+    )
+    vm.submit()
+    done.wait(timeout=5)
+
+
+def test_submit_skips_unclassified_clusters():
+    clusters = [_make_cluster(top=i * 10) for i in range(3)]
+    vm = _make_vm(clusters=clusters)
+    vm.set_label(0, ParticleType.TRITIUM)
+    vm.set_label(2, ParticleType.MUON)
+    # index 1 stays UNCLASSIFIED → skipped
+
+    _submit_and_wait(vm)
+
+    assert vm._repository.store_cluster.call_count == 2
+
+
+def test_submit_stores_correct_request_fields():
+    cluster = _make_cluster(energy=3000.0, sigma_x=1.8, sigma_y=1.4,
+                            pixel_count=30, top=5, left=10)
+    vm = _make_vm(clusters=[cluster])
+    vm.set_label(0, ParticleType.TRITIUM)
+
+    _submit_and_wait(vm)
+
+    req: ClusterStoreRequest = vm._repository.store_cluster.call_args[0][0]
+    assert req.classification == "TRITIUM"
+    assert req.sigma_x == pytest.approx(1.8)
+    assert req.sigma_y == pytest.approx(1.4)
+    assert req.total_pixels == 30
+    assert req.total_energy == pytest.approx(3000.0)
+    assert req.fits_id == 7
+    assert req.hdu_id == 2
+    assert req.bounding_box == {"top": 5, "left": 10, "bottom": 10, "right": 15}
+
+
+def test_submit_sets_stored_count():
+    clusters = [_make_cluster(top=i * 10) for i in range(4)]
+    vm = _make_vm(clusters=clusters)
+    vm.set_label(0, ParticleType.TRITIUM)
+    vm.set_label(1, ParticleType.MUON)
+    vm.set_label(2, ParticleType.ALPHA)
+    # index 3 stays UNCLASSIFIED
+
+    _submit_and_wait(vm)
+
+    assert vm.stored_count == 3
+    assert vm.phase == Phase.DONE
+
+
+def test_submit_fires_phase_callbacks_in_order():
+    vm = _make_vm()
+    vm.set_label(0, ParticleType.TRITIUM)
+    phases_seen = []
+    done = threading.Event()
+
+    def on_change():
+        phases_seen.append(vm.phase)
+        if vm.phase in (Phase.DONE, Phase.ERROR):
+            done.set()
+
+    vm.add_phase_changed_callback(on_change)
+    vm.submit()
+    done.wait(timeout=5)
+
+    assert phases_seen[0] == Phase.SUBMITTING
+    assert phases_seen[-1] == Phase.DONE
+
+
+def test_submit_handles_repository_exception():
+    vm = _make_vm()
+    vm._repository.store_cluster.side_effect = RuntimeError("EPS down")
+    vm.set_label(0, ParticleType.TRITIUM)
+
+    _submit_and_wait(vm)
+
+    assert vm.phase == Phase.ERROR
+    assert "EPS down" in vm.error_message
+
+
+def test_submit_all_unclassified_stores_nothing():
+    vm = _make_vm()
+    # No labels set — all UNCLASSIFIED
+
+    _submit_and_wait(vm)
+
+    vm._repository.store_cluster.assert_not_called()
+    assert vm.stored_count == 0
+    assert vm.phase == Phase.DONE
+
+
+def test_store_cluster_none_return_not_counted():
+    """store_cluster returning None (EPS failure) is not counted as stored."""
+    vm = _make_vm(store_return=None)
+    vm.set_label(0, ParticleType.TRITIUM)
+
+    _submit_and_wait(vm)
+
+    assert vm.stored_count == 0
+    assert vm.phase == Phase.DONE

--- a/tests/test_RawClusterLabelingViewModel.py
+++ b/tests/test_RawClusterLabelingViewModel.py
@@ -132,6 +132,7 @@ def test_submit_stores_correct_request_fields():
     _submit_and_wait(vm)
 
     req: ClusterStoreRequest = vm._repository.store_cluster.call_args[0][0]
+    assert req.data is None
     assert req.classification == "TRITIUM"
     assert req.sigma_x == pytest.approx(1.8)
     assert req.sigma_y == pytest.approx(1.4)
@@ -198,11 +199,53 @@ def test_submit_all_unclassified_stores_nothing():
 
 
 def test_store_cluster_none_return_not_counted():
-    """store_cluster returning None (EPS failure) is not counted as stored."""
+    """store_cluster returning None for all labeled clusters triggers Phase.ERROR."""
     vm = _make_vm(store_return=None)
     vm.set_label(0, ParticleType.TRITIUM)
 
     _submit_and_wait(vm)
 
     assert vm.stored_count == 0
+    assert vm.phase == Phase.ERROR
+    assert vm.error_message is not None
+
+
+def test_partial_store_failure_is_done_not_error():
+    """Partial success (some stored, some not) ends as DONE."""
+    clusters = [_make_cluster(top=i * 10) for i in range(3)]
+    vm = _make_vm(clusters=clusters)
+    vm._repository.store_cluster.side_effect = [1, None, 3]
+    for i in range(3):
+        vm.set_label(i, ParticleType.TRITIUM)
+
+    _submit_and_wait(vm)
+
     assert vm.phase == Phase.DONE
+    assert vm.stored_count == 2
+
+
+def test_build_request_data_field_is_none():
+    """Pixel data is never sent to EPS — data is always None."""
+    cluster = _make_cluster()
+    req = RawClusterLabelingViewModel._build_request(
+        cluster, hdu_id=0, fits_id=1, label=ParticleType.TRITIUM
+    )
+    assert req.data is None
+
+
+def test_has_any_label_false_when_all_unclassified():
+    vm = _make_vm()
+    assert vm.has_any_label is False
+
+
+def test_has_any_label_true_after_setting_one_label():
+    vm = _make_vm()
+    vm.set_label(0, ParticleType.TRITIUM)
+    assert vm.has_any_label is True
+
+
+def test_has_any_label_false_after_resetting_to_unclassified():
+    vm = _make_vm()
+    vm.set_label(0, ParticleType.TRITIUM)
+    vm.set_label(0, ParticleType.UNCLASSIFIED)
+    assert vm.has_any_label is False


### PR DESCRIPTION
Allows to label and export clusters for model re-training. This enables users to directly classify events within the raw data view and persist these annotations.

- Add `RawClusterLabelingViewModel` to manage the state and logic for cluster classification.
- Wire FITS endpoints in the `EventRepository` to support storing classified clusters.
- Integrate `QMessageBox` dialogues to provide clear user feedback on successful exports and to report errors.
- Ensure strict type handling for serialization across EPSDataClasses to maintain data integrity when interfacing with the database.
- Restore console logging in the application entry point for improved debuggability.

## User Interface

https://github.com/user-attachments/assets/001726e9-1604-4905-b110-53012047bc75

Resolves #195
