### PR TITLE
feat: implement Raw Cluster Classify Dialog

### DIFF
--- a/src/le_beta_vis/common/ClassifierService.py
+++ b/src/le_beta_vis/common/ClassifierService.py
@@ -7,10 +7,12 @@ from le_beta_vis.common.ClassifierDataClasses import (
 )
 from le_beta_vis.common.ParticleType import ParticleType
 
+
 @dataclass
 class ClassificationScore:
     particle_type: ParticleType   # existing enum
     confidence: float             # 0.0–1.0
+
 
 @dataclass
 class ClassificationResult:
@@ -18,14 +20,29 @@ class ClassificationResult:
     model: str                            # "cnn" | "nrg" | "bdt"
     score: Optional[ClassificationScore]  # None if this cluster failed to classify
 
+
 @dataclass
 class ClassificationBatchResult:
     results: list[ClassificationResult]  # order guaranteed to match input clusters
     total: int
     failed: int
 
-ErrorCallback      = Callable[[Exception], None]
+
+ErrorCallback = Callable[[Exception], None]
 CompletionCallback = Callable[[ClassificationBatchResult], None]
+
+
+@dataclass(frozen=True)
+class ClusterScores:
+    """Per-cluster ML confidence scores, one value per model.
+
+    None for a model means that model failed for this cluster.
+    """
+
+    cnn: Optional[float]
+    nrg: Optional[float]
+    bdt: Optional[float]
+
 
 class ClassifierService(ABC):
     """

--- a/src/le_beta_vis/common/__init__.py
+++ b/src/le_beta_vis/common/__init__.py
@@ -69,5 +69,12 @@ from .ClassifierDataClasses import (
     ClassificationRequestCluster
 )
 from .ClassifierService import (
+    ClassificationBatchResult,
+    ClassificationResult,
+    ClassificationScore,
     ClassifierService,
+    ClusterScores,
+    CompletionCallback,
+    ErrorCallback,
 )
+from .MockClassifierService import MockClassifierService

--- a/src/le_beta_vis/frontend/theme.py
+++ b/src/le_beta_vis/frontend/theme.py
@@ -170,6 +170,23 @@ class RawClusterLabelingDialogColors:
     RESULT_TEXT = "#c8e6c9"
 
 
+class RawClusterClassificationDialogColors:
+    """Colors for the ML classification dialog."""
+
+    CALLOUT_BACKGROUND = "#1a2a3a"
+    CALLOUT_BORDER = "#1565c0"
+    CALLOUT_TEXT = "#bbdefb"
+    CLASSIFY_BUTTON_BACKGROUND = "#0078d7"
+    CLASSIFY_BUTTON_FOREGROUND = "#ffffff"
+    CLASSIFY_BUTTON_HOVER = "#005fa3"
+    CANCEL_BUTTON_BACKGROUND = "#3d3d3d"
+    CANCEL_BUTTON_FOREGROUND = "#cccccc"
+    CANCEL_BUTTON_BORDER = "#555555"
+    SCORE_LABEL_GOOD = "#81c784"
+    SCORE_LABEL_MEDIUM = "#ffb74d"
+    SCORE_LABEL_LOW = "#e57373"
+
+
 class ClusteredEventWidgetColors:
     BUTTON_DISABLED_TEXT = "#a0a0a0"
 

--- a/src/le_beta_vis/frontend/viewmodels/ClusterAnalysisViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/ClusterAnalysisViewModel.py
@@ -6,11 +6,12 @@ Pure Python — no Qt dependencies.
 import logging
 import threading
 from enum import Enum
-from typing import Callable, FrozenSet, List, Optional
+from typing import Callable, Dict, FrozenSet, List, Optional
 
 import numpy as np
 
 from le_beta_vis.common.BoundingBox import BoundingBox
+from le_beta_vis.common.ClassifierService import ClusterScores
 from le_beta_vis.common.ClusterExtractor import (
     ClusteredEventInfo,
     ClusterExtractor,
@@ -70,6 +71,10 @@ class ClusterAnalysisViewModel:
         self._export_handler: Optional[
             Callable[[List[ClusteredEventInfo]], None]
         ] = None
+        self._classify_handler: Optional[
+            Callable[[List[ClusteredEventInfo]], None]
+        ] = None
+        self._classification_scores: Dict[int, ClusterScores] = {}
 
     def _init_callbacks(self) -> None:
         """Initializes all observer callback registries to empty lists."""
@@ -81,6 +86,7 @@ class ClusterAnalysisViewModel:
         self._on_clustering_error_callbacks: List[Callable] = []
         self._on_clustering_progress_callbacks: List[Callable] = []
         self._on_selected_cluster_changed_callbacks: List[Callable] = []
+        self._on_classification_scores_changed_callbacks: List[Callable] = []
 
     # --- ROI ---
 
@@ -251,6 +257,11 @@ class ClusterAnalysisViewModel:
         return -1
 
     @property
+    def classificationScores(self) -> Dict[int, ClusterScores]:
+        """Current per-cluster ML scores. Empty until applyClassificationScores is called."""
+        return dict(self._classification_scores)
+
+    @property
     def selectedCluster(self) -> Optional[ClusteredEventInfo]:
         """Backward-compat: returns the single selected cluster, or None."""
         idx = self.selectedClusterIndex
@@ -280,12 +291,17 @@ class ClusterAnalysisViewModel:
         self.selectClusters([] if index < 0 else [index])
 
     def clearClusteringResults(self) -> None:
-        """Clears results and resets selection. Notifies listeners."""
-        if self._clusteringResults or self._selectedClusterIndices:
+        """Clears results, selection, and classification scores. Notifies listeners."""
+        had_results = bool(self._clusteringResults or self._selectedClusterIndices)
+        had_scores = bool(self._classification_scores)
+        if had_results:
             self._clusteringResults = []
             self._selectedClusterIndices = frozenset()
             self._notify_clustering_completed()
             self._notify_selected_cluster_changed()
+        if had_scores:
+            self._classification_scores = {}
+            self._notify_classification_scores_changed()
 
     def setExportHandler(
         self,
@@ -300,24 +316,61 @@ class ClusterAnalysisViewModel:
         """
         self._export_handler = handler
 
-    def classifySelectedCluster(self) -> None:
-        """Placeholder for cluster classification (issue #54).
+    def setClassifyHandler(
+        self,
+        handler: Optional[Callable[[List[ClusteredEventInfo]], None]],
+    ) -> None:
+        """Injects the classify callback for selected clusters.
 
-        Logs the request for all selected clusters; no-op until the
-        classification pipeline is wired.
+        The handler receives the full list of selected clusters and is
+        responsible for presenting the classification dialog and calling
+        applyClassificationScores with the results. Kept as an injection seam
+        so this pure-Python VM stays free of Qt dialog knowledge.
+        """
+        self._classify_handler = handler
+
+    def add_classification_scores_changed_callback(
+        self, cb: Callable[[], None]
+    ) -> None:
+        """Registers cb to be called when classification scores are updated or cleared."""
+        self._on_classification_scores_changed_callbacks.append(cb)
+
+    def _notify_classification_scores_changed(self) -> None:
+        for cb in list(self._on_classification_scores_changed_callbacks):
+            cb()
+
+    def classifySelectedCluster(self) -> None:
+        """Invokes the classify handler for all currently selected clusters.
+
+        No-op when no handler is wired or no clusters are selected.
         """
         clusters = self.selectedClusters
         if not clusters:
             logger.info("classifySelectedCluster: no cluster selected")
             return
-        for cluster in clusters:
+        if self._classify_handler is None:
             logger.info(
-                "classifySelectedCluster: placeholder for cluster at "
-                "(%d, %d) with energy %.2f ADU",
-                cluster.centerX,
-                cluster.centerY,
-                cluster.energy,
+                "classifySelectedCluster: no handler wired (%d cluster(s) selected)",
+                len(clusters),
             )
+            return
+        self._classify_handler(clusters)
+
+    def applyClassificationScores(
+        self, scores: Dict[int, ClusterScores]
+    ) -> None:
+        """Stores per-cluster ML scores and notifies the View to update badges.
+
+        Called by RawDataView after the classification dialog closes. Scores are
+        keyed by cluster list index and cleared by clearClusteringResults().
+
+        Args:
+            scores: Per-cluster scores from RawClusterClassificationViewModel.
+        """
+        if not scores:
+            return
+        self._classification_scores = dict(scores)
+        self._notify_classification_scores_changed()
 
     def exportSelectedCluster(self) -> None:
         """Requests an export for all currently selected clusters.

--- a/src/le_beta_vis/frontend/viewmodels/RawClusterClassificationViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawClusterClassificationViewModel.py
@@ -1,0 +1,195 @@
+"""ViewModel for the ML cluster classification dialog (issue #153).
+
+Scientists select clusters from a raw FITS frame and run the CNN, NRG, and BDT
+models to obtain per-cluster particle-type confidence scores. Results propagate
+back to ClusteredEventWidget via ClusterAnalysisViewModel.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from enum import Enum, auto
+from typing import Callable, Dict, List, Optional
+
+from le_beta_vis.common.ClassifierDataClasses import ClassificationRequestCluster
+from le_beta_vis.common.ClassifierService import (
+    ClassificationBatchResult,
+    ClassifierService,
+    ClusterScores,
+)
+from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
+from le_beta_vis.common.PhysicsConversionManager import PhysicsConversionManager
+
+logger = logging.getLogger(__name__)
+
+
+class Phase(Enum):
+    PRE = auto()
+    IN_FLIGHT = auto()
+    POST = auto()
+
+
+class RawClusterClassificationViewModel:
+    """Manages async ML classification for selected raw-data clusters.
+
+    Pure Python — no Qt imports, no QObject inheritance. The dialog binds
+    via add_phase_changed_callback and observes phase transitions to switch
+    between form / spinner / results pages.
+    """
+
+    def __init__(
+        self,
+        clusters: List[ClusteredEventInfo],
+        service: ClassifierService,
+        physics: PhysicsConversionManager,
+    ) -> None:
+        self._clusters = clusters
+        self._service = service
+        self._physics = physics
+        self._phase: Phase = Phase.PRE
+        self._scores: Dict[int, ClusterScores] = {}
+        self._error_message: Optional[str] = None
+        self._phase_changed_callbacks: List[Callable[[], None]] = []
+
+    # ------------------------------------------------------------------ state
+
+    @property
+    def clusters(self) -> List[ClusteredEventInfo]:
+        """The clusters offered for classification."""
+        return self._clusters
+
+    @property
+    def phase(self) -> Phase:
+        """Current classification phase."""
+        return self._phase
+
+    @property
+    def scores(self) -> Dict[int, ClusterScores]:
+        """Per-cluster scores keyed by cluster list index. Empty until POST."""
+        return dict(self._scores)
+
+    @property
+    def error_message(self) -> Optional[str]:
+        """Set when a model call fails; None otherwise."""
+        return self._error_message
+
+    def energy_kev(self, index: int) -> float:
+        """Returns cluster energy converted to keV."""
+        return float(self._physics.adu_to_kev(self._clusters[index].energy))
+
+    # --------------------------------------------------------------- callbacks
+
+    def add_phase_changed_callback(self, cb: Callable[[], None]) -> None:
+        """Registers cb to be called whenever the classification phase changes."""
+        self._phase_changed_callbacks.append(cb)
+
+    def remove_phase_changed_callback(self, cb: Callable[[], None]) -> None:
+        """Unregisters cb."""
+        try:
+            self._phase_changed_callbacks.remove(cb)
+        except ValueError:
+            pass
+
+    def _notify_phase_changed(self) -> None:
+        for cb in list(self._phase_changed_callbacks):
+            cb()
+
+    # ------------------------------------------------------------------ action
+
+    def classify(self) -> None:
+        """Starts async classification for all clusters.
+
+        Transitions PRE → IN_FLIGHT on the calling thread, then POST on the
+        background thread after all three models finish. Calling from any
+        phase other than PRE is a no-op.
+        """
+        if self._phase != Phase.PRE:
+            return
+        self._phase = Phase.IN_FLIGHT
+        self._error_message = None
+        self._notify_phase_changed()
+        threading.Thread(target=self._run_classification, daemon=True).start()
+
+    def _run_classification(self) -> None:
+        request_clusters = self._to_request_clusters()
+
+        def _call_model(
+            classify_fn: Callable,
+        ) -> Optional[ClassificationBatchResult]:
+            result: Optional[ClassificationBatchResult] = None
+            latch = threading.Event()
+
+            def on_complete(batch: ClassificationBatchResult) -> None:
+                nonlocal result
+                result = batch
+                latch.set()
+
+            def on_error(exc: Exception) -> None:
+                logger.error("Classifier model error: %s", exc)
+                latch.set()
+
+            # TODO(#XXX): MockClassifierService.classify_* fires on_complete
+            # synchronously on this thread. Safe here because we are already in
+            # a daemon Thread. ZMQBasedClassifierService fires on_complete from
+            # the ZMQ receive thread; the threading.Event latch handles both
+            # cases correctly.
+            classify_fn(request_clusters, on_complete, on_error)
+            latch.wait()
+            return result
+
+        try:
+            cnn_batch = _call_model(self._service.classify_cnn)
+            nrg_batch = _call_model(self._service.classify_nrg)
+            bdt_batch = _call_model(self._service.classify_bdt)
+        except Exception as exc:
+            logger.exception("Unexpected error during classification: %s", exc)
+            self._error_message = str(exc)
+            cnn_batch = nrg_batch = bdt_batch = None
+
+        self._scores = self._build_scores(cnn_batch, nrg_batch, bdt_batch)
+        self._phase = Phase.POST
+        self._notify_phase_changed()
+
+    def _build_scores(
+        self,
+        cnn_batch: Optional[ClassificationBatchResult],
+        nrg_batch: Optional[ClassificationBatchResult],
+        bdt_batch: Optional[ClassificationBatchResult],
+    ) -> Dict[int, ClusterScores]:
+        scores: Dict[int, ClusterScores] = {}
+        for i in range(len(self._clusters)):
+            scores[i] = ClusterScores(
+                cnn=_confidence_at(cnn_batch, i),
+                nrg=_confidence_at(nrg_batch, i),
+                bdt=_confidence_at(bdt_batch, i),
+            )
+        return scores
+
+    def _to_request_clusters(self) -> List[ClassificationRequestCluster]:
+        # TODO(#XXX): cluster_id is the list index because ClusteredEventInfo
+        # has no persistent ID. Safe because ClassificationBatchResult.results
+        # is ordered to match the input list.
+        result = []
+        for i, cluster in enumerate(self._clusters):
+            result.append(
+                ClassificationRequestCluster(
+                    data=cluster.data.tolist(),
+                    cluster_id=i,
+                    sigmaX=float(cluster.sigmaX),
+                    sigmaY=float(cluster.sigmaY),
+                    total_energy=float(cluster.energy),
+                    total_pixels=int(cluster.pixelCount),
+                )
+            )
+        return result
+
+
+def _confidence_at(
+    batch: Optional[ClassificationBatchResult], index: int
+) -> Optional[float]:
+    """Extracts confidence for the cluster at *index* from a batch, or None."""
+    if batch is None or index >= len(batch.results):
+        return None
+    score = batch.results[index].score
+    return score.confidence if score is not None else None

--- a/src/le_beta_vis/frontend/views/ClusterAnalysisView.py
+++ b/src/le_beta_vis/frontend/views/ClusterAnalysisView.py
@@ -78,6 +78,7 @@ class ClusterAnalysisView(QWidget):
         self._bindClusteringCallbacks()
         self._bindExtractionButton()
         self._bindWidgetSignals()
+        self._bindClassificationScoresCallback()
 
     def _bindClusteringCallbacks(self) -> None:
         def on_completed() -> None:
@@ -99,6 +100,16 @@ class ClusterAnalysisView(QWidget):
         self._vm.add_selected_cluster_changed_callback(
             on_selected_changed,
         )
+
+    def _bindClassificationScoresCallback(self) -> None:
+        def on_scores_changed() -> None:
+            QMetaObject.invokeMethod(
+                self,
+                "_updateClassificationScores",
+                Qt.AutoConnection,
+            )
+
+        self._vm.add_classification_scores_changed_callback(on_scores_changed)
 
     def _bindExtractionButton(self) -> None:
         def refresh() -> None:
@@ -146,6 +157,13 @@ class ClusterAnalysisView(QWidget):
         """Syncs the widget's multi-selection with ViewModel state."""
         self._clusteredEventWidget.setSelectedIndices(
             self._vm.selectedClusterIndices,
+        )
+
+    @Slot()
+    def _updateClassificationScores(self) -> None:
+        """Overlays ML scores on cluster rows after classification completes."""
+        self._clusteredEventWidget.updateClassificationResults(
+            self._vm.classificationScores,
         )
 
     @Slot()

--- a/src/le_beta_vis/frontend/views/raw_data_view/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/RawDataView.py
@@ -87,6 +87,7 @@ class RawDataView(QWidget):
         self._bindClusteringStateCallback()
         if self._repository is not None:
             self._cavm.setExportHandler(self._onExportRequested)
+        self._cavm.setClassifyHandler(self._onClassifyRequested)
 
     def _bindMosaicCallbacks(self) -> None:
         self.viewModel.mosaicViewModel.add_thumbnails_changed_callback(
@@ -191,6 +192,26 @@ class RawDataView(QWidget):
         dialog = _RawClusterLabelingDialog(vm, parent=self.window())
         if dialog.exec() == QDialog.Accepted:
             self._cavm.removeClustersByIndices(indices_to_remove)
+
+    def _onClassifyRequested(self, clusters: List[ClusteredEventInfo]) -> None:
+        # TODO(#XXX): Replace MockClassifierService with the production
+        # ZMQBasedClassifierService once it is wired through ServicesManager.
+        from le_beta_vis.common import MockClassifierService
+        from ...viewmodels.RawClusterClassificationViewModel import (
+            RawClusterClassificationViewModel,
+        )
+        from ._RawClusterClassificationDialog import _RawClusterClassificationDialog
+
+        vm = RawClusterClassificationViewModel(
+            clusters=clusters,
+            service=MockClassifierService(),
+            physics=self.viewModel.physics_manager,
+        )
+        dialog = _RawClusterClassificationDialog(vm, parent=self.window())
+        dialog.exec()
+        # Propagate scores regardless of accept/reject. Scores are only present
+        # when the user reached POST phase; empty dict is a safe no-op.
+        self._cavm.applyClassificationScores(vm.scores)
 
     def openClusterForAnalysis(
         self,

--- a/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterClassificationDialog.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterClassificationDialog.py
@@ -1,0 +1,365 @@
+"""ML classification dialog for raw-data clusters (issue #153).
+
+Private to the raw_data_view package. Binds to RawClusterClassificationViewModel.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from PySide6.QtCore import QMetaObject, Qt, Slot
+from PySide6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ...fitsconverters import Colormap
+from ...theme import RawClusterClassificationDialogColors as _C
+from ...viewmodels.RawClusterClassificationViewModel import (
+    Phase,
+    RawClusterClassificationViewModel,
+)
+from ...widgets.ArcSpinner import ArcSpinner
+from ...widgets.EnergyClusterWidget import EnergyClusterWidget
+
+_THUMBNAIL_SIZE = 64
+
+
+class _RawClusterClassificationDialog(QDialog):
+    """Shows selected clusters and runs CNN/NRG/BDT classification on demand.
+
+    Three-page flow managed by a QStackedWidget:
+      0 — PRE:       cluster list + Classify / Cancel buttons
+      1 — IN_FLIGHT: ArcSpinner while models are running
+      2 — POST:      per-cluster CNN/NRG/BDT scores + particle badge
+
+    Results are propagated to ClusterAnalysisViewModel by the caller after
+    dialog.exec() returns regardless of accept/reject outcome.
+    Never exceeds the size of the parent window.
+    """
+
+    _PAGE_PRE = 0
+    _PAGE_SPINNER = 1
+    _PAGE_POST = 2
+
+    def __init__(
+        self,
+        viewModel: RawClusterClassificationViewModel,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._vm = viewModel
+        self._score_rows: List[QWidget] = []
+        self.setWindowTitle(self.tr("Classify Clusters"))
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        self.setMinimumWidth(480)
+        self.setMaximumHeight(500)
+        if parent is not None:
+            self.setMaximumWidth(parent.width() - 40)
+        self._initUI()
+        self._bindViewModel()
+
+    # ------------------------------------------------------------------- UI
+
+    def _initUI(self) -> None:
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+
+        self._stack = QStackedWidget()
+        self._stack.addWidget(self._buildPrePage())
+        self._stack.addWidget(self._buildSpinnerPage())
+        self._stack.addWidget(self._buildPostPage())
+        root.addWidget(self._stack, 1)
+
+        root.addLayout(self._buildButtonRow())
+
+    def _buildCallout(self, text: str) -> QLabel:
+        callout = QLabel(text)
+        callout.setWordWrap(True)
+        callout.setStyleSheet(
+            f"background-color: {_C.CALLOUT_BACKGROUND};"
+            f"border: 1px solid {_C.CALLOUT_BORDER};"
+            f"color: {_C.CALLOUT_TEXT};"
+            "border-radius: 4px;"
+            "padding: 8px 10px;"
+            "font-size: 12px;"
+        )
+        return callout
+
+    def _buildPrePage(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(16, 16, 16, 8)
+        layout.setSpacing(10)
+
+        layout.addWidget(
+            self._buildCallout(
+                self.tr(
+                    "Run the CNN, NRG, and BDT models on the selected clusters. "
+                    "Each cluster receives a tritium confidence score (0–100%) "
+                    "from each model."
+                )
+            )
+        )
+        layout.addWidget(self._buildPreScrollArea(), 1)
+        return page
+
+    def _buildPreScrollArea(self) -> QScrollArea:
+        area = QScrollArea()
+        area.setWidgetResizable(True)
+        area.setFrameShape(QFrame.NoFrame)
+        area.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        content = QWidget()
+        content_layout = QVBoxLayout(content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(6)
+
+        for i, cluster in enumerate(self._vm.clusters):
+            content_layout.addWidget(self._buildPreRow(i, cluster))
+
+        content_layout.addStretch()
+        area.setWidget(content)
+        return area
+
+    def _buildPreRow(self, index: int, cluster) -> QFrame:
+        row = QFrame()
+        row.setFrameShape(QFrame.StyledPanel)
+        h = QHBoxLayout(row)
+        h.setContentsMargins(6, 6, 6, 6)
+        h.setSpacing(10)
+
+        thumb = EnergyClusterWidget(size=_THUMBNAIL_SIZE)
+        thumb.setCluster(cluster.data, Colormap.VIRIDIS)
+        h.addWidget(thumb)
+
+        info = QVBoxLayout()
+        info.setSpacing(2)
+        info.addWidget(
+            QLabel(
+                self.tr("σx {sx:.1f}  σy {sy:.1f}  {px} px").format(
+                    sx=cluster.sigmaX,
+                    sy=cluster.sigmaY,
+                    px=cluster.pixelCount,
+                )
+            )
+        )
+        info.addWidget(
+            QLabel(
+                self.tr("{e:.2f} keV").format(e=self._vm.energy_kev(index))
+            )
+        )
+        h.addLayout(info, 1)
+        return row
+
+    def _buildSpinnerPage(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setSpacing(12)
+
+        self._spinner = ArcSpinner()
+        self._spinner.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        layout.addWidget(self._spinner, 0, Qt.AlignHCenter)
+
+        lbl = QLabel(self.tr("Classifying…"))
+        lbl.setAlignment(Qt.AlignCenter)
+        layout.addWidget(lbl)
+        return page
+
+    def _buildPostPage(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(16, 16, 16, 8)
+        layout.setSpacing(10)
+
+        layout.addWidget(
+            self._buildCallout(self.tr("Classification complete."))
+        )
+
+        area = QScrollArea()
+        area.setWidgetResizable(True)
+        area.setFrameShape(QFrame.NoFrame)
+        area.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        self._postContent = QWidget()
+        self._postLayout = QVBoxLayout(self._postContent)
+        self._postLayout.setContentsMargins(0, 0, 0, 0)
+        self._postLayout.setSpacing(6)
+        self._postLayout.addStretch()
+
+        area.setWidget(self._postContent)
+        layout.addWidget(area, 1)
+        return page
+
+    def _buildButtonRow(self) -> QHBoxLayout:
+        row = QHBoxLayout()
+        row.setContentsMargins(16, 12, 16, 12)
+        row.addStretch()
+
+        self._cancelBtn = QPushButton(self.tr("Cancel"))
+        self._cancelBtn.setStyleSheet(
+            "QPushButton {"
+            f"  background-color: {_C.CANCEL_BUTTON_BACKGROUND};"
+            f"  color: {_C.CANCEL_BUTTON_FOREGROUND};"
+            f"  border: 1px solid {_C.CANCEL_BUTTON_BORDER};"
+            "  border-radius: 4px;"
+            "  padding: 6px 16px;"
+            "}"
+        )
+        self._cancelBtn.clicked.connect(self._onCancelClicked)
+        row.addWidget(self._cancelBtn)
+        row.addSpacing(8)
+
+        self._classifyBtn = QPushButton(self.tr("Classify"))
+        self._classifyBtn.setStyleSheet(
+            "QPushButton {"
+            f"  background-color: {_C.CLASSIFY_BUTTON_BACKGROUND};"
+            f"  color: {_C.CLASSIFY_BUTTON_FOREGROUND};"
+            "  border: none;"
+            "  border-radius: 4px;"
+            "  padding: 6px 16px;"
+            "  font-weight: bold;"
+            "}"
+            "QPushButton:hover {"
+            f"  background-color: {_C.CLASSIFY_BUTTON_HOVER};"
+            "}"
+            "QPushButton:disabled { background-color: #555555; color: #888888; }"
+        )
+        self._classifyBtn.clicked.connect(self._vm.classify)
+        row.addWidget(self._classifyBtn)
+
+        return row
+
+    # --------------------------------------------------------- ViewModel binding
+
+    def _bindViewModel(self) -> None:
+        self._vm.add_phase_changed_callback(
+            lambda: QMetaObject.invokeMethod(
+                self, "_onPhaseChanged", Qt.AutoConnection
+            )
+        )
+
+    # ------------------------------------------------------------------ slots
+
+    @Slot()
+    def _onPhaseChanged(self) -> None:
+        phase = self._vm.phase
+        if phase == Phase.IN_FLIGHT:
+            self._stack.setCurrentIndex(self._PAGE_SPINNER)
+            self._spinner.start()
+            self._classifyBtn.setEnabled(False)
+            self._cancelBtn.setEnabled(False)
+        elif phase == Phase.POST:
+            self._spinner.stop()
+            self._populatePostRows()
+            self._stack.setCurrentIndex(self._PAGE_POST)
+            self._classifyBtn.setEnabled(False)
+            self._cancelBtn.setEnabled(True)
+            self._cancelBtn.setText(self.tr("Close"))
+
+    def _populatePostRows(self) -> None:
+        """Rebuilds the POST page with per-cluster score rows."""
+        while self._postLayout.count() > 1:
+            item = self._postLayout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+
+        scores = self._vm.scores
+        for i, cluster in enumerate(self._vm.clusters):
+            cluster_scores = scores.get(i)
+            row = self._buildPostRow(i, cluster, cluster_scores)
+            self._postLayout.insertWidget(self._postLayout.count() - 1, row)
+
+    def _buildPostRow(self, index: int, cluster, cluster_scores) -> QFrame:
+        from le_beta_vis.common.ParticleType import (
+            CLASSIFICATION_THRESHOLD,
+            ParticleType,
+        )
+
+        row = QFrame()
+        row.setFrameShape(QFrame.StyledPanel)
+        h = QHBoxLayout(row)
+        h.setContentsMargins(6, 6, 6, 6)
+        h.setSpacing(10)
+
+        thumb = EnergyClusterWidget(size=_THUMBNAIL_SIZE)
+        thumb.setCluster(cluster.data, Colormap.VIRIDIS)
+        h.addWidget(thumb)
+
+        info = QVBoxLayout()
+        info.setSpacing(2)
+        info.addWidget(
+            QLabel(
+                self.tr("σx {sx:.1f}  σy {sy:.1f}  {px} px").format(
+                    sx=cluster.sigmaX,
+                    sy=cluster.sigmaY,
+                    px=cluster.pixelCount,
+                )
+            )
+        )
+        info.addWidget(
+            QLabel(
+                self.tr("{e:.2f} keV").format(e=self._vm.energy_kev(index))
+            )
+        )
+
+        if cluster_scores is not None:
+            for model, val in (
+                ("CNN", cluster_scores.cnn),
+                ("NRG", cluster_scores.nrg),
+                ("BDT", cluster_scores.bdt),
+            ):
+                score_str = f"{val * 100:.0f}%" if val is not None else "?"
+                color = self._score_color(val)
+                lbl = QLabel(
+                    self.tr("{model}: <b>{score}</b>").format(
+                        model=model, score=score_str
+                    )
+                )
+                lbl.setStyleSheet(f"color: {color};")
+                info.addWidget(lbl)
+
+            valid = [
+                v
+                for v in (cluster_scores.cnn, cluster_scores.nrg, cluster_scores.bdt)
+                if v is not None
+            ]
+            particle = (
+                ParticleType.TRITIUM
+                if valid and max(valid) >= CLASSIFICATION_THRESHOLD
+                else ParticleType.UNCLASSIFIED
+            )
+            badge = QLabel(
+                self.tr("Type: {symbol}").format(symbol=particle.symbol)
+            )
+            info.addWidget(badge)
+
+        h.addLayout(info, 1)
+        return row
+
+    @staticmethod
+    def _score_color(val: Optional[float]) -> str:
+        from le_beta_vis.frontend.theme import RawClusterClassificationDialogColors
+        if val is None:
+            return RawClusterClassificationDialogColors.SCORE_LABEL_LOW
+        if val >= 0.75:
+            return RawClusterClassificationDialogColors.SCORE_LABEL_GOOD
+        if val >= 0.5:
+            return RawClusterClassificationDialogColors.SCORE_LABEL_MEDIUM
+        return RawClusterClassificationDialogColors.SCORE_LABEL_LOW
+
+    @Slot()
+    def _onCancelClicked(self) -> None:
+        if self._vm.phase == Phase.POST:
+            self.accept()
+        else:
+            self.reject()

--- a/src/le_beta_vis/frontend/widgets/ClusteredEventWidget.py
+++ b/src/le_beta_vis/frontend/widgets/ClusteredEventWidget.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from PySide6.QtCore import Signal, Slot
 from PySide6.QtWidgets import (
@@ -13,9 +13,14 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from le_beta_vis.common.ClassifierService import ClusterScores
 from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
+from le_beta_vis.common.ParticleType import CLASSIFICATION_THRESHOLD, ParticleType
 from le_beta_vis.frontend.fitsconverters.interface import Colormap
-from le_beta_vis.frontend.theme import ClusteredEventWidgetColors as _CEC
+from le_beta_vis.frontend.theme import (
+    ClusteredEventWidgetColors as _CEC,
+    RawClusterClassificationDialogColors as _SC,
+)
 from le_beta_vis.frontend.widgets.EnergyClusterWidget import (
     EnergyClusterWidget,
 )
@@ -50,6 +55,7 @@ class ClusteredEventWidget(QWidget):
         self._colormap: Optional[Colormap] = None
         self._displayKeV: bool = True
         self._kevConversion: float = 1.02857e-5
+        self._classification_scores: Dict[int, ClusterScores] = {}
         self._initUI()
 
     def _initUI(self) -> None:
@@ -119,28 +125,50 @@ class ClusteredEventWidget(QWidget):
     def setResults(self, results: List[ClusteredEventInfo]) -> None:
         """Populates the list with clustered events.
 
-        Replaces any existing content. Generates thumbnails and
-        builds list entries with summary metadata.
+        Replaces any existing content. Clears any prior classification scores
+        so stale badges do not appear on the new result set.
 
         Args:
             results: List of ClusteredEventInfo from extraction.
         """
         self._results = list(results)
+        self._classification_scores = {}
+        self._rebuildRows()
+
+    def updateClassificationResults(
+        self, scores: Dict[int, ClusterScores]
+    ) -> None:
+        """Overlays ML classification scores on the existing cluster rows.
+
+        Rebuilds the list so each row gains CNN/NRG/BDT score labels and a
+        particle-type badge. Call after a classification dialog closes with
+        results; no-op when *scores* is empty.
+
+        Args:
+            scores: Per-cluster scores keyed by cluster list index.
+        """
+        if not scores:
+            return
+        self._classification_scores = dict(scores)
+        self._rebuildRows()
+
+    def clear(self) -> None:
+        """Clears the list and resets to empty state."""
+        self.setResults([])
+
+    def _rebuildRows(self) -> None:
+        """Rebuilds QListWidget rows from the current results and scores."""
         self._listWidget.clear()
         self._updateCountLabel()
         self._btnClassify.setEnabled(False)
         self._btnExport.setEnabled(False)
 
-        for i, event in enumerate(results):
+        for i, event in enumerate(self._results):
             item = QListWidgetItem()
             widget = self._createEntryWidget(i, event)
             item.setSizeHint(widget.sizeHint())
             self._listWidget.addItem(item)
             self._listWidget.setItemWidget(item, widget)
-
-    def clear(self) -> None:
-        """Clears the list and resets to empty state."""
-        self.setResults([])
 
     def setSelectedIndices(self, indices: List[int]) -> None:
         """Programmatically sets the multi-selection from a list of indices.
@@ -218,9 +246,53 @@ class ClusteredEventWidget(QWidget):
             QLabel(self.tr("Pixels: {count}").format(count=event.pixelCount))
         )
 
+        if index in self._classification_scores:
+            self._appendScoreLabels(metaLayout, self._classification_scores[index])
+
         layout.addLayout(metaLayout)
         layout.setStretch(1, 1)
         return entry
+
+    def _appendScoreLabels(
+        self, layout: QVBoxLayout, scores: ClusterScores
+    ) -> None:
+        """Appends CNN/NRG/BDT score rows and a particle badge to *layout*."""
+
+        def _fmt(v: Optional[float]) -> str:
+            return f"{v * 100:.0f}%" if v is not None else "?"
+
+        def _color(v: Optional[float]) -> str:
+            if v is None:
+                return _SC.SCORE_LABEL_LOW
+            if v >= CLASSIFICATION_THRESHOLD:
+                return _SC.SCORE_LABEL_GOOD
+            if v >= 0.5:
+                return _SC.SCORE_LABEL_MEDIUM
+            return _SC.SCORE_LABEL_LOW
+
+        for model, val in (
+            ("CNN", scores.cnn),
+            ("NRG", scores.nrg),
+            ("BDT", scores.bdt),
+        ):
+            lbl = QLabel(
+                self.tr("{model}: <b>{score}</b>").format(
+                    model=model, score=_fmt(val)
+                )
+            )
+            lbl.setStyleSheet(f"color: {_color(val)};")
+            layout.addWidget(lbl)
+
+        valid = [v for v in (scores.cnn, scores.nrg, scores.bdt) if v is not None]
+        particle = (
+            ParticleType.TRITIUM
+            if valid and max(valid) >= CLASSIFICATION_THRESHOLD
+            else ParticleType.UNCLASSIFIED
+        )
+        badge = QLabel(
+            self.tr("Type: {symbol}").format(symbol=particle.symbol)
+        )
+        layout.addWidget(badge)
 
     def _createEnergyLabel(self, event: ClusteredEventInfo) -> QLabel:
         """Creates the energy label, converting to keV if enabled."""

--- a/tests/test_RawClusterClassificationViewModel.py
+++ b/tests/test_RawClusterClassificationViewModel.py
@@ -1,0 +1,241 @@
+"""Unit tests for RawClusterClassificationViewModel (issue #153)."""
+import threading
+from typing import List, Optional
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from le_beta_vis.common.ClassifierDataClasses import ClassificationRequestCluster
+from le_beta_vis.common.ClassifierService import (
+    ClassificationBatchResult,
+    ClassificationResult,
+    ClassificationScore,
+    ClassifierService,
+    ClusterScores,
+    CompletionCallback,
+    ErrorCallback,
+)
+from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
+from le_beta_vis.common.BoundingBox import BoundingBox
+from le_beta_vis.frontend.viewmodels.RawClusterClassificationViewModel import (
+    Phase,
+    RawClusterClassificationViewModel,
+    _confidence_at,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_cluster(energy: float = 1000.0) -> ClusteredEventInfo:
+    bb = BoundingBox(top=0, left=0, bottom=4, right=4)
+    cluster = ClusteredEventInfo.__new__(ClusteredEventInfo)
+    cluster.boundingBox = bb
+    cluster.data = np.ones((4, 4), dtype=np.float32) * energy
+    cluster.centerX = 2
+    cluster.centerY = 2
+    cluster.sigmaX = 1.0
+    cluster.sigmaY = 1.0
+    cluster.energy = energy
+    cluster.pixelCount = 16
+    return cluster
+
+
+def _make_batch(
+    n: int,
+    model: str,
+    confidence: Optional[float] = 0.9,
+) -> ClassificationBatchResult:
+    results = [
+        ClassificationResult(
+            cluster_id=i,
+            model=model,
+            score=ClassificationScore(
+                particle_type=MagicMock(), confidence=confidence
+            )
+            if confidence is not None
+            else None,
+        )
+        for i in range(n)
+    ]
+    failed = sum(1 for r in results if r.score is None)
+    return ClassificationBatchResult(results=results, total=n, failed=failed)
+
+
+class _SyncClassifierService(ClassifierService):
+    """Minimal synchronous mock used by tests."""
+
+    def __init__(
+        self,
+        cnn_conf: Optional[float] = 0.8,
+        nrg_conf: Optional[float] = 0.6,
+        bdt_conf: Optional[float] = 0.7,
+    ) -> None:
+        self._cnn_conf = cnn_conf
+        self._nrg_conf = nrg_conf
+        self._bdt_conf = bdt_conf
+
+    def _call(
+        self,
+        n: int,
+        model: str,
+        confidence: Optional[float],
+        on_complete: CompletionCallback,
+        on_error: Optional[ErrorCallback],
+    ) -> None:
+        on_complete(_make_batch(n, model, confidence))
+
+    def classify_cnn(self, clusters, on_complete, on_error=None):
+        self._call(len(clusters), "CNN", self._cnn_conf, on_complete, on_error)
+
+    def classify_nrg(self, clusters, on_complete, on_error=None):
+        self._call(len(clusters), "NRG", self._nrg_conf, on_complete, on_error)
+
+    def classify_bdt(self, clusters, on_complete, on_error=None):
+        self._call(len(clusters), "BDT", self._bdt_conf, on_complete, on_error)
+
+
+def _build_vm(
+    clusters: Optional[List[ClusteredEventInfo]] = None,
+    service: Optional[ClassifierService] = None,
+) -> RawClusterClassificationViewModel:
+    if clusters is None:
+        clusters = [_make_cluster(), _make_cluster(500.0)]
+    if service is None:
+        service = _SyncClassifierService()
+    physics = MagicMock()
+    physics.adu_to_kev.side_effect = lambda e: float(e) * 1e-5
+    return RawClusterClassificationViewModel(
+        clusters=clusters, service=service, physics=physics
+    )
+
+
+def _run_and_wait(vm: RawClusterClassificationViewModel) -> None:
+    """Calls classify() and blocks until POST phase is reached."""
+    done = threading.Event()
+    phases: List[Phase] = []
+
+    def on_phase():
+        phases.append(vm.phase)
+        if vm.phase == Phase.POST:
+            done.set()
+
+    vm.add_phase_changed_callback(on_phase)
+    vm.classify()
+    done.wait(timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_initial_phase_is_pre():
+    vm = _build_vm()
+    assert vm.phase == Phase.PRE
+
+
+def test_initial_scores_empty():
+    vm = _build_vm()
+    assert vm.scores == {}
+
+
+def test_classify_transitions_to_in_flight_then_post():
+    vm = _build_vm()
+    seen: List[Phase] = []
+    done = threading.Event()
+
+    def on_phase():
+        seen.append(vm.phase)
+        if vm.phase == Phase.POST:
+            done.set()
+
+    vm.add_phase_changed_callback(on_phase)
+    vm.classify()
+    done.wait(timeout=5.0)
+
+    assert Phase.IN_FLIGHT in seen
+    assert Phase.POST in seen
+    assert seen[-1] == Phase.POST
+
+
+def test_scores_populated_after_classification():
+    clusters = [_make_cluster(), _make_cluster(200.0), _make_cluster(300.0)]
+    vm = _build_vm(clusters=clusters)
+    _run_and_wait(vm)
+
+    assert len(vm.scores) == 3
+    for i in range(3):
+        assert i in vm.scores
+        s = vm.scores[i]
+        assert isinstance(s, ClusterScores)
+        assert s.cnn == pytest.approx(0.8)
+        assert s.nrg == pytest.approx(0.6)
+        assert s.bdt == pytest.approx(0.7)
+
+
+def test_failed_model_produces_none_confidence():
+    service = _SyncClassifierService(cnn_conf=None, nrg_conf=0.5, bdt_conf=0.4)
+    vm = _build_vm(service=service)
+    _run_and_wait(vm)
+
+    assert vm.scores[0].cnn is None
+    assert vm.scores[0].nrg == pytest.approx(0.5)
+    assert vm.scores[0].bdt == pytest.approx(0.4)
+
+
+def test_classify_from_post_is_noop():
+    vm = _build_vm()
+    _run_and_wait(vm)
+    assert vm.phase == Phase.POST
+
+    callback_count = []
+    vm.add_phase_changed_callback(lambda: callback_count.append(1))
+    vm.classify()
+    # No new background thread should have fired any callback
+    assert callback_count == []
+    assert vm.phase == Phase.POST
+
+
+def test_energy_kev_delegates_to_physics():
+    clusters = [_make_cluster(1000.0)]
+    vm = _build_vm(clusters=clusters)
+    assert vm.energy_kev(0) == pytest.approx(1000.0 * 1e-5)
+
+
+def test_to_request_clusters_uses_index_as_cluster_id():
+    clusters = [_make_cluster(), _make_cluster()]
+    vm = _build_vm(clusters=clusters)
+    request = vm._to_request_clusters()
+    assert request[0].cluster_id == 0
+    assert request[1].cluster_id == 1
+
+
+def test_confidence_at_returns_none_for_empty_batch():
+    assert _confidence_at(None, 0) is None
+
+
+def test_confidence_at_returns_none_for_failed_result():
+    batch = _make_batch(1, "CNN", confidence=None)
+    assert _confidence_at(batch, 0) is None
+
+
+def test_confidence_at_returns_confidence_for_valid_result():
+    batch = _make_batch(1, "CNN", confidence=0.85)
+    assert _confidence_at(batch, 0) == pytest.approx(0.85)
+
+
+def test_phase_changed_callback_remove():
+    vm = _build_vm()
+    calls = []
+    def cb(): return calls.append(1)
+    vm.add_phase_changed_callback(cb)
+    vm.remove_phase_changed_callback(cb)
+
+    done = threading.Event()
+    vm.add_phase_changed_callback(lambda: done.set() if vm.phase == Phase.POST else None)
+    vm.classify()
+    done.wait(timeout=5.0)
+
+    assert calls == []


### PR DESCRIPTION
Implemented the user interface and logic for performing ML-based classification on raw data clusters. Since the production Keras classifier is not yet ready, a mock classifier (`MockClassifierService`) is used as a placeholder to verify the classification pipeline.

- **Core ML Service**: Added the `ClusterScores` dataclass to `ClassifierService.py` and updated `src/le_beta_vis/common/__init__.py` to publish relevant service classes and `MockClassifierService`.
- **View Model**: Created `RawClusterClassificationViewModel` to manage async classification requests (PRE -> IN_FLIGHT -> POST phases) and map results, completely decoupled from Qt.
- **ClusterAnalysisViewModel**: Added hooks for triggering classification, handling classification handlers, and applying/notifying changed scores to the view.
- **Classification Dialog**: Created `_RawClusterClassificationDialog` showing selected cluster thumbnails, physical properties (keV, size, sigma), a processing spinner, and confidence score outputs (CNN/NRG/BDT) with status-colored tags and particle type badges.
- **Event Widget**: Updated `ClusteredEventWidget` to display classification confidence metrics and particle type badges inline for classified clusters.

## User Interface

https://github.com/user-attachments/assets/89a7fea3-6311-4b20-be51-256070953e0b

Resolves #153 
