### PR TITLE
feat: add bounded paged cluster retrieval support

### DIFF
--- a/src/le_beta_vis/backend/EventPersistenceService.py
+++ b/src/le_beta_vis/backend/EventPersistenceService.py
@@ -1,4 +1,5 @@
 from le_beta_vis.common.ZMQEventHandlerClient import DEFAULT_EVENT_PUB_ENDPOINT
+import dataclasses
 import mysql.connector
 from le_beta_vis.common.YAMLBackedConfigurationService import (
     YAMLBackedConfigurationService,
@@ -13,7 +14,8 @@ from le_beta_vis.common.EPSDataClasses import (
     ClusterStoreRequest,
     ClassificationUpdateRequest,
     EPSClusterRecord,
-    EPSFitsRecord
+    EPSFitsRecord,
+    PagedRetrieveClustersResponse,
 )
 from le_beta_vis.backend.PagedClusterRetrieval import (
     paged_retrieve_clusters as _paged_retrieve_clusters,
@@ -224,7 +226,7 @@ class EventPersistence:
             try:
                 paged_filter = ClusterPagedQueryFilter.from_eps_dict(request)
                 response = self.paged_retrieve_clusters(paged_filter)
-                socket.send_json(response)
+                socket.send_json(dataclasses.asdict(response))
             except Exception as err:
                 socket.send_json(
                     {"result": "failure", "clusters": None, "error": str(err)}
@@ -541,7 +543,7 @@ class EventPersistence:
         except mysql.connector.Error as err:
             logger.warning(f"Could not connect: {str(err)}")
 
-    def paged_retrieve_clusters(self, paged_filter: ClusterPagedQueryFilter) -> dict:
+    def paged_retrieve_clusters(self, paged_filter: ClusterPagedQueryFilter) -> PagedRetrieveClustersResponse:
         """Selects clusters matching ``paged_filter`` with bounded pagination.
 
         Defaults and caps the effective ``limit`` from

--- a/src/le_beta_vis/backend/EventPersistenceService.py
+++ b/src/le_beta_vis/backend/EventPersistenceService.py
@@ -4,6 +4,7 @@ from le_beta_vis.common.YAMLBackedConfigurationService import (
     YAMLBackedConfigurationService,
 )
 from le_beta_vis.common.EPSDataClasses import (
+    ClusterPagedQueryFilter,
     ClusterQueryFilter,
     ClusterRecentQueryFilter,
     FitsQueryFilter,
@@ -13,6 +14,9 @@ from le_beta_vis.common.EPSDataClasses import (
     ClassificationUpdateRequest,
     EPSClusterRecord,
     EPSFitsRecord
+)
+from le_beta_vis.backend.PagedClusterRetrieval import (
+    paged_retrieve_clusters as _paged_retrieve_clusters,
 )
 import os
 import zmq
@@ -216,6 +220,16 @@ class EventPersistence:
                     {"result": "failure", "error": str(err)}
                 )
 
+        elif request.get("Action") == "PagedRetrieval":
+            try:
+                paged_filter = ClusterPagedQueryFilter.from_eps_dict(request)
+                response = self.paged_retrieve_clusters(paged_filter)
+                socket.send_json(response)
+            except Exception as err:
+                socket.send_json(
+                    {"result": "failure", "clusters": None, "error": str(err)}
+                )
+
     def fits_event(self, request: dict, socket: zmq.Socket):
         """Processes a requested cluster event and calls storage or retrieval of cluster."""
         logger.info("Fits request received by EPS.")
@@ -315,7 +329,7 @@ class EventPersistence:
                 cluster.sigma_x,
                 cluster.sigma_y,
                 cluster.classification,
-                None,       #null values for per model classifications
+                None,  # null values for per model classifications
                 None,
                 None,
                 cluster.total_pixels,
@@ -338,7 +352,7 @@ class EventPersistence:
     def retrieve_fits(self, fits: FitsQueryFilter) -> dict:
         """Selects from the database all values from the fits table that match any and all values from the request."""
         try:
-            if not self.conn: 
+            if not self.conn:
                 self.conn = self.db_connect()
             cursor = self.conn.cursor(dictionary=True)
 
@@ -459,21 +473,21 @@ class EventPersistence:
 
             cursor.execute(select_query, tuple(select_argv))
             # saving results into a list of tuples
-            results = cursor.fetchall() # Temporarily limit result set size to avoid a crash in macOS
+            results = cursor.fetchall()  # Temporarily limit result set size to avoid a crash in macOS
 
             cursor.close()
             return self.process_retrieval_clusters(results)
 
         except mysql.connector.Error as err:
             logger.warning(f"Could not connect: {str(err)}")
-        
+
     def classify_cluster(self, cluster: ClassificationUpdateRequest) -> dict:
         """Executes the insert_classifications stored procedure in the database based on the EPS
-            UpdateClassification request. 
+            UpdateClassification request.
         """
         try:
             if not self.conn:
-                    self.conn = self.db_connect()
+                self.conn = self.db_connect()
             cursor = self.conn.cursor()
             cluster_id = cluster.cluster_id
             classification = cluster.classification
@@ -488,14 +502,14 @@ class EventPersistence:
                 self.conn.commit()
                 cursor.close()
                 return {"result": "failure", "error": "No clusters were updated, incorrect ID or classification."}
-            else:    
+            else:
                 self.conn.close()
                 self.conn = None
                 raise FailedProcException
 
         except mysql.connector.Error as err:
             logger.warning(f"Could not connect: {str(err)}")
-        
+
     def retrieve_recent_clusters(self, recent_clusters: ClusterRecentQueryFilter) -> dict:
         """Selects the newest clusters ordered by FITS date, paginated.
 
@@ -526,6 +540,21 @@ class EventPersistence:
 
         except mysql.connector.Error as err:
             logger.warning(f"Could not connect: {str(err)}")
+
+    def paged_retrieve_clusters(self, paged_filter: ClusterPagedQueryFilter) -> dict:
+        """Selects clusters matching ``paged_filter`` with bounded pagination.
+
+        Defaults and caps the effective ``limit`` from
+        ``eps:retrieval_limit_default`` / ``eps:retrieval_limit_max`` so an
+        unbounded or excessive client request cannot return the entire
+        table. Delegates the query and formatting to
+        ``PagedClusterRetrieval.paged_retrieve_clusters``.
+        """
+        if not self.conn:
+            self.conn = self.db_connect()
+        default_limit = int(self.config.get("eps:retrieval_limit_default", 500))
+        max_limit = int(self.config.get("eps:retrieval_limit_max", 2000))
+        return _paged_retrieve_clusters(self.conn, paged_filter, default_limit, max_limit)
 
     def process_retrieval_fits(self, results) -> dict:
         """Takes the results from a fits retrieval SELECT statement and formats the EPS response into JSON.

--- a/src/le_beta_vis/backend/PagedClusterRetrieval.py
+++ b/src/le_beta_vis/backend/PagedClusterRetrieval.py
@@ -13,7 +13,11 @@ from typing import Any, List, Tuple
 
 import mysql.connector
 
-from le_beta_vis.common.EPSDataClasses import ClusterPagedQueryFilter, ClusterQueryFilter
+from le_beta_vis.common.EPSDataClasses import (
+    ClusterPagedQueryFilter,
+    ClusterQueryFilter,
+    EPSClusterRecord,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -106,30 +110,7 @@ def _build_cluster_select(filters: ClusterQueryFilter) -> Tuple[str, List[Any]]:
 
 def _format_cluster_rows(results) -> List[dict]:
     """Maps cluster/fits_files row dicts to the EPS cluster response shape."""
-    clusters_list = []
-    for result in results:
-        clusters_list.append(
-            {
-                "fits_id": result["fitsFile"],
-                "cluster_id": result["clusterID"],
-                "hdu_id": result["hdu_id"],
-                "bounding_box": {
-                    "top": result["box_top"],
-                    "left": result["box_left"],
-                    "bottom": result["box_bottom"],
-                    "right": result["box_right"],
-                },
-                "data": None,
-                "total_energy": result["totalEnergy"],
-                "sigmaX": result["sigmaX"],
-                "sigmaY": result["sigmaY"],
-                "classification": result["classification"],
-                "total_pixels": result["pixelCount"],
-                "filename": result["filename"],
-                "date": str(result["date"]),
-            }
-        )
-    return clusters_list
+    return [EPSClusterRecord.from_db_row(result).to_response_dict() for result in results]
 
 
 def paged_retrieve_clusters(

--- a/src/le_beta_vis/backend/PagedClusterRetrieval.py
+++ b/src/le_beta_vis/backend/PagedClusterRetrieval.py
@@ -1,0 +1,174 @@
+"""Paged cluster retrieval for the Event Persistence Service.
+
+Kept separate from ``EventPersistenceService`` (already large) so the
+"PagedRetrieval" action's SQL/formatting logic does not grow that file
+further. The filter-clause and row-formatting helpers here intentionally
+mirror (rather than reuse) the logic in
+``EventPersistenceService.retrieve_clusters`` / ``process_retrieval_clusters``
+so that method remains unchanged.
+"""
+
+import logging
+from typing import Any, List, Tuple
+
+import mysql.connector
+
+from le_beta_vis.common.EPSDataClasses import ClusterPagedQueryFilter, ClusterQueryFilter
+
+logger = logging.getLogger(__name__)
+
+
+# Simple equality/threshold filters: (value, SQL clause).
+_SIMPLE_FILTER_CLAUSES: List[Tuple[str, str]] = [
+    ("hdu_id", "hdu_id = %s"),
+    ("fits_id", "fitsFile = %s"),
+    ("cluster_id", "clusterId = %s"),
+    ("min_sigma_x", "sigmaX >= %s"),
+    ("min_sigma_y", "sigmaY >= %s"),
+    ("min_total_energy", "totalEnergy >= %s"),
+    ("min_total_pixels", "pixelCount >= %s"),
+    ("classification", "classification = %s"),
+]
+
+
+def _bounding_box_clause(bounding_box: dict) -> Tuple[List[str], List[Any]]:
+    """Returns the WHERE clauses and values for a bounding-box filter."""
+    return (
+        ["box_top = %s", "box_left = %s", "box_bottom = %s", "box_right = %s"],
+        [
+            bounding_box["top"],
+            bounding_box["left"],
+            bounding_box["bottom"],
+            bounding_box["right"],
+        ],
+    )
+
+
+def _date_range_clause(filters: ClusterQueryFilter) -> Tuple[List[str], List[Any]]:
+    """Returns the WHERE clause and values for a date-range filter."""
+    # Imported lazily to avoid a circular top-level import between this
+    # module and EventPersistenceService.
+    from le_beta_vis.backend.EventPersistenceService import _parse_date_filter
+
+    date_start = str(filters.date_start) if filters.date_start else None
+    date_end = str(filters.date_end) if filters.date_end else None
+    date_range = _parse_date_filter({"start": date_start, "end": date_end})
+    if date_range is None:
+        return [], []
+    return ["fits_files.date BETWEEN %s AND %s"], list(date_range)
+
+
+def _fits_list_clause(fits_list: List[int]) -> Tuple[List[str], List[Any]]:
+    """Returns the WHERE clause and values for an ``IN`` filter on fits IDs."""
+    placeholder = ", ".join(["%s"] * len(fits_list))
+    return [f"fitsFile in ({placeholder})"], list(fits_list)
+
+
+def _build_cluster_select(filters: ClusterQueryFilter) -> Tuple[str, List[Any]]:
+    """Builds the base ``SELECT ... WHERE ...`` clause for a cluster query.
+
+    Returns the query string (without ``LIMIT``/``OFFSET``) and the list of
+    bind parameters for the ``WHERE`` clause.
+    """
+    select_query = (
+        "SELECT clusters.*, fits_files.filename, fits_files.date "
+        "FROM clusters INNER JOIN fits_files "
+        "ON clusters.fitsFile = fits_files.fitsID"
+    )
+    select_args: List[str] = []
+    select_argv: List[Any] = []
+
+    for attr, clause in _SIMPLE_FILTER_CLAUSES:
+        value = getattr(filters, attr)
+        if value:
+            select_args.append(clause)
+            select_argv.append(value)
+
+    if filters.bounding_box:
+        clauses, values = _bounding_box_clause(filters.bounding_box)
+        select_args.extend(clauses)
+        select_argv.extend(values)
+
+    if filters.fits_list:
+        clauses, values = _fits_list_clause(filters.fits_list)
+        select_args.extend(clauses)
+        select_argv.extend(values)
+
+    date_clauses, date_values = _date_range_clause(filters)
+    select_args.extend(date_clauses)
+    select_argv.extend(date_values)
+
+    if select_args:
+        select_query += " WHERE " + " AND ".join(select_args)
+
+    return select_query, select_argv
+
+
+def _format_cluster_rows(results) -> List[dict]:
+    """Maps cluster/fits_files row dicts to the EPS cluster response shape."""
+    clusters_list = []
+    for result in results:
+        clusters_list.append(
+            {
+                "fits_id": result["fitsFile"],
+                "cluster_id": result["clusterID"],
+                "hdu_id": result["hdu_id"],
+                "bounding_box": {
+                    "top": result["box_top"],
+                    "left": result["box_left"],
+                    "bottom": result["box_bottom"],
+                    "right": result["box_right"],
+                },
+                "data": None,
+                "total_energy": result["totalEnergy"],
+                "sigmaX": result["sigmaX"],
+                "sigmaY": result["sigmaY"],
+                "classification": result["classification"],
+                "total_pixels": result["pixelCount"],
+                "filename": result["filename"],
+                "date": str(result["date"]),
+            }
+        )
+    return clusters_list
+
+
+def paged_retrieve_clusters(
+    conn,
+    paged_filter: ClusterPagedQueryFilter,
+    default_limit: int,
+    max_limit: int,
+) -> dict:
+    """Runs a bounded, paginated cluster retrieval against the database.
+
+    Applies ``default_limit`` when the request does not specify ``limit``,
+    and rejects (raises ``ValueError``) any effective limit that is
+    non-positive or exceeds ``max_limit``.
+    """
+    effective_limit = (
+        paged_filter.limit if paged_filter.limit is not None else default_limit
+    )
+    if effective_limit <= 0 or effective_limit > max_limit:
+        raise ValueError(
+            f"limit must be between 1 and {max_limit}, got {effective_limit}"
+        )
+
+    try:
+        cursor = conn.cursor(dictionary=True)
+
+        select_query, select_argv = _build_cluster_select(paged_filter.filters)
+        select_query += " LIMIT %s OFFSET %s"
+        select_argv = select_argv + [effective_limit, paged_filter.offset]
+
+        cursor.execute(select_query, tuple(select_argv))
+        results = cursor.fetchall()
+        cursor.close()
+
+        return {
+            "result": "success",
+            "clusters": _format_cluster_rows(results),
+            "limit": effective_limit,
+            "offset": paged_filter.offset,
+        }
+    except mysql.connector.Error as err:
+        logger.warning("Could not retrieve paged clusters: %s", err)
+        return {"result": "failure", "clusters": None, "error": str(err)}

--- a/src/le_beta_vis/backend/PagedClusterRetrieval.py
+++ b/src/le_beta_vis/backend/PagedClusterRetrieval.py
@@ -17,6 +17,7 @@ from le_beta_vis.common.EPSDataClasses import (
     ClusterPagedQueryFilter,
     ClusterQueryFilter,
     EPSClusterRecord,
+    PagedRetrieveClustersResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -118,7 +119,7 @@ def paged_retrieve_clusters(
     paged_filter: ClusterPagedQueryFilter,
     default_limit: int,
     max_limit: int,
-) -> dict:
+) -> PagedRetrieveClustersResponse:
     """Runs a bounded, paginated cluster retrieval against the database.
 
     Applies ``default_limit`` when the request does not specify ``limit``,
@@ -144,12 +145,18 @@ def paged_retrieve_clusters(
         results = cursor.fetchall()
         cursor.close()
 
-        return {
-            "result": "success",
-            "clusters": _format_cluster_rows(results),
-            "limit": effective_limit,
-            "offset": paged_filter.offset,
-        }
+        return PagedRetrieveClustersResponse(
+            result="success",
+            clusters=_format_cluster_rows(results),
+            limit=effective_limit,
+            offset=paged_filter.offset,
+        )
     except mysql.connector.Error as err:
         logger.warning("Could not retrieve paged clusters: %s", err)
-        return {"result": "failure", "clusters": None, "error": str(err)}
+        return PagedRetrieveClustersResponse(
+            result="failure",
+            clusters=None,
+            limit=0,
+            offset=0,
+            error=str(err),
+        )

--- a/src/le_beta_vis/common/EPSDataClasses.py
+++ b/src/le_beta_vis/common/EPSDataClasses.py
@@ -421,6 +421,54 @@ class EPSClusterRecord:
             date=str(d.get("date", "")),
         )
 
+    @staticmethod
+    def from_db_row(row: Dict[str, Any]) -> "EPSClusterRecord":
+        """Parses one ``clusters``/``fits_files`` join row from a dictionary cursor.
+
+        Unlike :meth:`from_eps_dict`, the source keys are database column
+        names (``fitsFile``, ``clusterID``, ``box_top``, ``totalEnergy``,
+        ``pixelCount``, ...) rather than the EPS wire-format keys. Pixel
+        data is never hydrated from the database — ``data`` is always
+        ``None``.
+        """
+        return EPSClusterRecord(
+            fits_id=row["fitsFile"],
+            fits_list=None,
+            hdu_id=row["hdu_id"],
+            cluster_id=row["clusterID"],
+            bounding_box={
+                "top": row["box_top"],
+                "left": row["box_left"],
+                "bottom": row["box_bottom"],
+                "right": row["box_right"],
+            },
+            data=None,
+            total_energy=row["totalEnergy"],
+            sigma_x=row["sigmaX"],
+            sigma_y=row["sigmaY"],
+            classification=row["classification"],
+            total_pixels=row["pixelCount"],
+            filename=row["filename"],
+            date=str(row["date"]),
+        )
+
+    def to_response_dict(self) -> Dict[str, Any]:
+        """Builds the EPS wire-format dict for a single cluster response entry."""
+        return {
+            "fits_id": self.fits_id,
+            "cluster_id": self.cluster_id,
+            "hdu_id": self.hdu_id,
+            "bounding_box": self.bounding_box,
+            "data": self.data,
+            "total_energy": self.total_energy,
+            "sigmaX": self.sigma_x,
+            "sigmaY": self.sigma_y,
+            "classification": self.classification,
+            "total_pixels": self.total_pixels,
+            "filename": self.filename,
+            "date": self.date,
+        }
+
 
 @dataclass(frozen=True)
 class EPSFitsRecord:

--- a/src/le_beta_vis/common/EPSDataClasses.py
+++ b/src/le_beta_vis/common/EPSDataClasses.py
@@ -471,6 +471,26 @@ class EPSClusterRecord:
 
 
 @dataclass(frozen=True)
+class PagedRetrieveClustersResponse:
+    """Typed envelope for a PagedRetrieval EPS response.
+
+    ``clusters`` holds the pre-serialized cluster dicts produced by
+    ``_format_cluster_rows`` so that ``dataclasses.asdict()`` round-trips
+    to JSON without any custom serialization logic.
+    """
+
+    result: str
+    clusters: Optional[List[dict]]
+    limit: int
+    offset: int
+    error: Optional[str] = None
+
+    @property
+    def is_success(self) -> bool:
+        return self.result == "success"
+
+
+@dataclass(frozen=True)
 class EPSFitsRecord:
     """A single FITS file record from an EPS FITS Retrieval response."""
 

--- a/src/le_beta_vis/common/EPSDataClasses.py
+++ b/src/le_beta_vis/common/EPSDataClasses.py
@@ -5,7 +5,7 @@ sockets.  All classes are frozen dataclasses with conversion helpers
 (``to_eps_dict`` for requests, ``from_eps_dict`` for responses).
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -103,19 +103,60 @@ class ClusterQueryFilter:
         """Parses one ClusterQueryFilter request."""
         date = d.get("date", None)
         return ClusterQueryFilter(
-            cluster_id = d.get("cluster_id", None),
-            fits_id = d.get("fits_id", None),
-            fits_list = d.get("fits_list", None),
-            hdu_id = d.get("hdu_id", None),
-            bounding_box = d.get("bounding_box", None),
-            date_start = datetime.strptime(date.get("start", None), _DATE_FILTER_FORMAT) if date else None,
-            date_end = datetime.strptime(date.get("end", None), _DATE_FILTER_FORMAT) if date else None,
-            min_sigma_x = d.get("sigmaX", None),
-            min_sigma_y = d.get("sigmaY", None),
-            min_total_energy = d.get("total_energy", None),
-            min_total_pixels = d.get("total_pixels", None),
-            classification = d.get("classification", None),
+            cluster_id=d.get("cluster_id", None),
+            fits_id=d.get("fits_id", None),
+            fits_list=d.get("fits_list", None),
+            hdu_id=d.get("hdu_id", None),
+            bounding_box=d.get("bounding_box", None),
+            date_start=datetime.strptime(date.get("start", None), _DATE_FILTER_FORMAT) if date else None,
+            date_end=datetime.strptime(date.get("end", None), _DATE_FILTER_FORMAT) if date else None,
+            min_sigma_x=d.get("sigmaX", None),
+            min_sigma_y=d.get("sigmaY", None),
+            min_total_energy=d.get("total_energy", None),
+            min_total_pixels=d.get("total_pixels", None),
+            classification=d.get("classification", None),
         )
+
+
+@dataclass(frozen=True)
+class ClusterPagedQueryFilter:
+    """Request for the EPS PagedRetrieval action.
+
+    Wraps a ``ClusterQueryFilter`` for filter criteria and adds
+    ``limit``/``offset`` pagination fields. ``limit`` of ``None`` means
+    the EPS should apply its configured server-side default.
+    """
+
+    filters: ClusterQueryFilter = field(default_factory=ClusterQueryFilter)
+    limit: Optional[int] = None
+    offset: int = 0
+
+    def __post_init__(self) -> None:
+        if self.limit is not None and (
+            not isinstance(self.limit, int) or self.limit <= 0
+        ):
+            raise ValueError("limit must be a positive int or None")
+        if not isinstance(self.offset, int) or self.offset < 0:
+            raise ValueError("offset must be a non-negative int")
+
+    def to_eps_dict(self) -> Dict[str, Any]:
+        """Builds the JSON dict for the PagedRetrieval action."""
+        d = self.filters.to_eps_dict()
+        d["Action"] = "PagedRetrieval"
+        if self.limit is not None:
+            d["limit"] = self.limit
+        d["offset"] = self.offset
+        return d
+
+    @staticmethod
+    def from_eps_dict(d: Dict[str, Any]) -> "ClusterPagedQueryFilter":
+        """Parses one ClusterPagedQueryFilter request."""
+        return ClusterPagedQueryFilter(
+            filters=ClusterQueryFilter.from_eps_dict(d),
+            limit=d.get("limit"),
+            offset=d.get("offset", 0),
+        )
+
 
 @dataclass(frozen=True)
 class ClusterRecentQueryFilter:
@@ -150,6 +191,7 @@ class ClusterRecentQueryFilter:
             limit=(d.get("limit")),
             offset=(d.get("offset", 0))
         )
+
 
 @dataclass(frozen=True)
 class FitsQueryFilter:
@@ -191,14 +233,15 @@ class FitsQueryFilter:
         """Parses one FitsQueryFilter request"""
         date = d.get("date", None)
         return FitsQueryFilter(
-            fits_id = d.get("fits_id", None),
-            filename = d.get("filename", None),
-            date_start = datetime.strptime(date.get("start", None), _DATE_FILTER_FORMAT) if date else None,
-            date_end = datetime.strptime(date.get("end", None), _DATE_FILTER_FORMAT) if date else None,
-            minimum = d.get("minimum", None),
-            maximum = d.get("maximum", None),
-            exposure_time = d.get("exposure_time", None),
+            fits_id=d.get("fits_id", None),
+            filename=d.get("filename", None),
+            date_start=datetime.strptime(date.get("start", None), _DATE_FILTER_FORMAT) if date else None,
+            date_end=datetime.strptime(date.get("end", None), _DATE_FILTER_FORMAT) if date else None,
+            minimum=d.get("minimum", None),
+            maximum=d.get("maximum", None),
+            exposure_time=d.get("exposure_time", None),
         )
+
 
 @dataclass(frozen=True)
 class FitsClusterQueryFilter:
@@ -235,6 +278,7 @@ class FitsClusterQueryFilter:
             d["exposure_time"] = self.exposure_time
         return d
 
+
 @dataclass(frozen=True)
 class FitsStoreRequest:
     """Payload for an EPS Fits Storage request"""
@@ -265,7 +309,6 @@ class FitsStoreRequest:
             max=d.get("max", 0.0),
             exposure_time=d.get("exposure_time", 0.0),
         )
-
 
 
 @dataclass(frozen=True)
@@ -334,7 +377,7 @@ class ClassificationUpdateRequest:
         return ClassificationUpdateRequest(
             cluster_id=(d.get("cluster_id", 0)),
             classification=(d.get("classification", ""))
-         )
+        )
 
 # ---------------------------------------------------------------------------
 # Response DTOs

--- a/src/le_beta_vis/common/EventRepository.py
+++ b/src/le_beta_vis/common/EventRepository.py
@@ -37,6 +37,45 @@ class EventRepository(ABC):
         Implementations should return a list of ``Cluster``
         objects with classification scores and pixel data
         populated.
+
+        .. deprecated::
+            Implementations are not required to bound this request, which
+            can return an entire table in one reply. Prefer
+            :meth:`fetch_clusters`, which is bounded by
+            ``eps:retrieval_limit_default``/``eps:retrieval_limit_max``.
+        """
+        raise NotImplementedError
+
+    def fetch_clusters(
+        self,
+        query_filter: Optional[ClusterQueryFilter],
+        limit: Optional[int],
+        offset: int,
+        callback: onCluster,
+        on_error: onError,
+    ) -> None:
+        """Bounded, paginated cluster retrieval.
+
+        Args:
+            query_filter: Optional filter criteria. ``None`` means no
+                filtering beyond pagination.
+            limit: Maximum number of clusters to return. ``None`` means
+                the implementation should apply its configured default
+                (e.g. ``eps:retrieval_limit_default``).
+            offset: Number of rows to skip.
+        """
+        raise NotImplementedError
+
+    def fetch_clusters_sync(
+        self,
+        query_filter: Optional[ClusterQueryFilter] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> List[Cluster]:
+        """Synchronous counterpart to :meth:`fetch_clusters`.
+
+        Callers already running on a background thread may call this
+        directly to avoid an async callback round-trip.
         """
         raise NotImplementedError
 

--- a/src/le_beta_vis/common/NoOpEventRepository.py
+++ b/src/le_beta_vis/common/NoOpEventRepository.py
@@ -34,6 +34,30 @@ class NoOpEventRepository(EventRepository):
         logger.warning("NoOpEventRepository: fetch_events called but EPS is unavailable")
         callback([])
 
+    def fetch_clusters(
+        self,
+        query_filter: Optional[ClusterQueryFilter],
+        limit: Optional[int],
+        offset: int,
+        callback: onCluster,
+        on_error: onError,
+    ) -> None:
+        """Invokes ``callback`` with an empty list — EPS is unavailable."""
+        logger.warning("NoOpEventRepository: fetch_clusters called but EPS is unavailable")
+        callback([])
+
+    def fetch_clusters_sync(
+        self,
+        query_filter: Optional[ClusterQueryFilter] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> List[Cluster]:
+        """Returns an empty list — EPS is unavailable."""
+        logger.warning(
+            "NoOpEventRepository: fetch_clusters_sync called but EPS is unavailable"
+        )
+        return []
+
     def query_clusters(
         self,
         query_filter: Optional[ClusterQueryFilter],

--- a/src/le_beta_vis/common/ZMQBasedEventRepository.py
+++ b/src/le_beta_vis/common/ZMQBasedEventRepository.py
@@ -31,6 +31,7 @@ from .EPSDataClasses import (
     FitsClusterQueryFilter,
     FitsQueryFilter,
     FitsStoreRequest,
+    PagedRetrieveClustersResponse,
 )
 from .EventRepository import EventRepository, onCluster, onError, onFits, onUpdate
 
@@ -140,16 +141,21 @@ class ZMQBasedEventRepository(EventRepository):
         if response is None:
             return []
 
-        if response.get("result") != "success":
+        paged = PagedRetrieveClustersResponse(
+            result=response.get("result", "failure"),
+            clusters=response.get("clusters"),
+            limit=response.get("limit", 0),
+            offset=response.get("offset", 0),
+            error=response.get("error"),
+        )
+        if not paged.is_success:
             logger.warning(
-                "EPS paged cluster query returned failure: %s",
-                response.get("result"),
+                "EPS paged cluster query returned failure: %s", paged.error
             )
-            raise Exception(f"EPS paged cluster query failed: {response.get('result')}")
+            raise Exception(f"EPS paged cluster query failed: {paged.error}")
 
-        raw_clusters = response.get("clusters", [])
         clusters: List[Cluster] = []
-        for raw in raw_clusters:
+        for raw in (paged.clusters or []):
             record = EPSClusterRecord.from_eps_dict(raw)
             cluster = self._map_to_cluster(record, record.filename, record.date)
             if cluster is not None:

--- a/src/le_beta_vis/common/ZMQBasedEventRepository.py
+++ b/src/le_beta_vis/common/ZMQBasedEventRepository.py
@@ -8,6 +8,7 @@ is down — they return empty/default values and log warnings.
 import json
 import logging
 import math
+import warnings
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 import threading
@@ -21,6 +22,7 @@ from .ConfigurationService import ConfigurationService
 from .CCDCaptureModel import CCDCaptureModel
 from .EPSDataClasses import (
     ClassificationUpdateRequest,
+    ClusterPagedQueryFilter,
     ClusterQueryFilter,
     ClusterRecentQueryFilter,
     ClusterStoreRequest,
@@ -79,12 +81,80 @@ class ZMQBasedEventRepository(EventRepository):
             callback: onCluster,
             on_error: onError
     ) -> None:
-        """Returns all cluster events from the EPS asynchronously."""
+        """Returns all cluster events from the EPS asynchronously.
+
+        .. deprecated::
+            Sends an unbounded ``{"Action": "Retrieval"}`` request — the
+            EPS may return its entire `clusters` table in one reply. Use
+            :meth:`fetch_clusters` instead, which sends a bounded
+            ``PagedRetrieval`` request.
+        """
+        warnings.warn(
+            "fetch_events sends an unbounded request; use fetch_clusters instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._run_async(
             function=lambda: self.query_clusters_sync(query_filter=None),
             callback=callback,
             on_error=on_error
         )
+
+    def fetch_clusters(
+        self,
+        query_filter: Optional[ClusterQueryFilter],
+        limit: Optional[int],
+        offset: int,
+        callback: onCluster,
+        on_error: onError,
+    ) -> None:
+        """Initiates a bounded PagedRetrieval request asynchronously."""
+        self._run_async(
+            function=lambda: self.fetch_clusters_sync(query_filter, limit, offset),
+            callback=callback,
+            on_error=on_error,
+        )
+
+    def fetch_clusters_sync(
+        self,
+        query_filter: Optional[ClusterQueryFilter] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> List[Cluster]:
+        """Sends a bounded PagedRetrieval request to the EPS Cluster socket.
+
+        ``limit`` defaults to ``eps:retrieval_limit_default`` when not
+        supplied. Callers may override it (e.g. for a smaller page size),
+        but the EPS enforces ``eps:retrieval_limit_max`` regardless.
+        """
+        if limit is None:
+            limit = int(self._config.get("eps:retrieval_limit_default", 500))
+
+        paged_filter = ClusterPagedQueryFilter(
+            filters=query_filter or ClusterQueryFilter(),
+            limit=limit,
+            offset=offset,
+        )
+
+        response = self._send_cluster(paged_filter.to_eps_dict())
+        if response is None:
+            return []
+
+        if response.get("result") != "success":
+            logger.warning(
+                "EPS paged cluster query returned failure: %s",
+                response.get("result"),
+            )
+            raise Exception(f"EPS paged cluster query failed: {response.get('result')}")
+
+        raw_clusters = response.get("clusters", [])
+        clusters: List[Cluster] = []
+        for raw in raw_clusters:
+            record = EPSClusterRecord.from_eps_dict(raw)
+            cluster = self._map_to_cluster(record, record.filename, record.date)
+            if cluster is not None:
+                clusters.append(cluster)
+        return clusters
 
     def query_clusters(
         self,

--- a/src/le_beta_vis/common/__init__.py
+++ b/src/le_beta_vis/common/__init__.py
@@ -26,6 +26,7 @@ from .EPSDataClasses import (
     FitsClusterQueryFilter,
     EPSClusterRecord,
     EPSFitsRecord,
+    PagedRetrieveClustersResponse,
 )
 from .ClusterProvider import ClusterBatch, ClusterProvider, NoOpClusterProvider
 from .EventRepository import EventRepository

--- a/src/le_beta_vis/config/defaults.yaml
+++ b/src/le_beta_vis/config/defaults.yaml
@@ -477,6 +477,22 @@ eps:timeout_ms:
     Timeout in milliseconds for ZMQ send/receive operations
     against the EPS.
 
+eps:retrieval_limit_default:
+  type: int
+  default: 500
+  description: >-
+    Default `limit` applied to PagedRetrieval cluster queries when the
+    client does not supply one. Should be injected by every paged
+    cluster-retrieval call site (overridable per call).
+
+eps:retrieval_limit_max:
+  type: int
+  default: 2000
+  description: >-
+    Server-side hard cap for PagedRetrieval cluster queries. Requests
+    with a `limit` <= 0 or > this value are rejected, closing the
+    unbounded-result crash path regardless of client input.
+
 # ---------------------------------------------------------------------------
 # Event Handler (pub/sub bus)
 # ---------------------------------------------------------------------------

--- a/src/le_beta_vis/frontend/viewmodels/HistoricalViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/HistoricalViewModel.py
@@ -237,11 +237,15 @@ class HistoricalViewModel:
                     on_error=lambda error: self._on_repository_error(request_id, error),
                 )
             except NotImplementedError:
+                # TODO(#151): migrate to fetch_clusters() with paging once
+                # the Historical grid supports paged loading.
                 self._repository.fetch_events(
                     callback=lambda events: self._on_repository_loaded(request_id, events),
                     on_error=lambda error: self._on_repository_error(request_id, error),
                 )
         else:
+            # TODO(#151): migrate to fetch_clusters() with paging once
+            # the Historical grid supports paged loading.
             self._repository.fetch_events(
                 callback=lambda events: self._on_repository_loaded(request_id, events),
                 on_error=lambda error: self._on_repository_error(request_id, error),

--- a/tests/test_EPSDataClasses.py
+++ b/tests/test_EPSDataClasses.py
@@ -10,6 +10,7 @@ import pytest
 
 from le_beta_vis.common.EPSDataClasses import (
     ClassificationUpdateRequest,
+    ClusterPagedQueryFilter,
     ClusterQueryFilter,
     ClusterStoreRequest,
     EPSClusterRecord,
@@ -135,6 +136,70 @@ class TestClusterQueryFilter:
     #                 }
     #             }
     #         )
+
+
+# -------------------------------------------------------------------
+# ClusterPagedQueryFilter
+# -------------------------------------------------------------------
+
+class TestClusterPagedQueryFilter:
+
+    def test_default_to_eps_dict(self):
+        """No filters/limit produces just Action + offset."""
+        pf = ClusterPagedQueryFilter()
+        d = pf.to_eps_dict()
+        assert d["Action"] == "PagedRetrieval"
+        assert d["offset"] == 0
+        assert "limit" not in d
+
+    def test_limit_and_offset_included(self):
+        pf = ClusterPagedQueryFilter(limit=50, offset=100)
+        d = pf.to_eps_dict()
+        assert d["limit"] == 50
+        assert d["offset"] == 100
+
+    def test_filters_merged_into_dict(self):
+        pf = ClusterPagedQueryFilter(
+            filters=ClusterQueryFilter(fits_id=7, classification="tritium"),
+            limit=10,
+        )
+        d = pf.to_eps_dict()
+        assert d["Action"] == "PagedRetrieval"
+        assert d["fits_id"] == 7
+        assert d["classification"] == "tritium"
+        assert d["limit"] == 10
+
+    def test_negative_limit_raises(self):
+        with pytest.raises(ValueError):
+            ClusterPagedQueryFilter(limit=-1)
+
+    def test_zero_limit_raises(self):
+        with pytest.raises(ValueError):
+            ClusterPagedQueryFilter(limit=0)
+
+    def test_negative_offset_raises(self):
+        with pytest.raises(ValueError):
+            ClusterPagedQueryFilter(offset=-1)
+
+    def test_from_eps_dict_round_trip(self):
+        original = ClusterPagedQueryFilter(
+            filters=ClusterQueryFilter(fits_id=3), limit=25, offset=50,
+        )
+        parsed = ClusterPagedQueryFilter.from_eps_dict(original.to_eps_dict())
+        assert parsed == original
+
+    def test_from_eps_dict_defaults_offset_to_zero(self):
+        parsed = ClusterPagedQueryFilter.from_eps_dict({"Action": "PagedRetrieval"})
+        assert parsed.limit is None
+        assert parsed.offset == 0
+
+    def test_frozen(self):
+        pf = ClusterPagedQueryFilter(limit=10)
+        try:
+            pf.limit = 20
+            assert False, "Should have raised"
+        except AttributeError:
+            pass
 
 
 # -------------------------------------------------------------------

--- a/tests/test_EPSDataClasses.py
+++ b/tests/test_EPSDataClasses.py
@@ -409,6 +409,72 @@ class TestEPSClusterRecord:
         assert rec.total_energy == 42.0
         assert rec.hdu_id == 0
 
+    def test_from_db_row_maps_column_names(self):
+        row = {
+            "fitsFile": 1,
+            "clusterID": 10,
+            "hdu_id": 0,
+            "box_top": 1,
+            "box_left": 2,
+            "box_bottom": 3,
+            "box_right": 4,
+            "data": b"raw bytes",
+            "totalEnergy": 500.0,
+            "sigmaX": 1.5,
+            "sigmaY": 2.0,
+            "classification": "tritium",
+            "pixelCount": 20,
+            "filename": "test.fits",
+            "date": "2026-01-01",
+        }
+        rec = EPSClusterRecord.from_db_row(row)
+        assert rec.fits_id == 1
+        assert rec.cluster_id == 10
+        assert rec.bounding_box == {"top": 1, "left": 2, "bottom": 3, "right": 4}
+        assert rec.data is None
+        assert rec.total_energy == 500.0
+        assert rec.sigma_x == 1.5
+        assert rec.sigma_y == 2.0
+        assert rec.classification == "tritium"
+        assert rec.total_pixels == 20
+        assert rec.filename == "test.fits"
+        assert rec.date == "2026-01-01"
+
+    def test_from_db_row_stringifies_date(self):
+        row = {
+            "fitsFile": 1, "clusterID": 10, "hdu_id": 0,
+            "box_top": 1, "box_left": 2, "box_bottom": 3, "box_right": 4,
+            "data": None, "totalEnergy": 0.0, "sigmaX": 0.0, "sigmaY": 0.0,
+            "classification": "", "pixelCount": 0, "filename": "f.fits",
+            "date": datetime(2026, 1, 1),
+        }
+        rec = EPSClusterRecord.from_db_row(row)
+        assert rec.date == "2026-01-01 00:00:00"
+
+    def test_to_response_dict_round_trip_from_db_row(self):
+        row = {
+            "fitsFile": 1, "clusterID": 10, "hdu_id": 2,
+            "box_top": 1, "box_left": 2, "box_bottom": 3, "box_right": 4,
+            "data": None, "totalEnergy": 500.0, "sigmaX": 1.5, "sigmaY": 2.0,
+            "classification": "tritium", "pixelCount": 20, "filename": "test.fits",
+            "date": "2026-01-01",
+        }
+        d = EPSClusterRecord.from_db_row(row).to_response_dict()
+        assert d == {
+            "fits_id": 1,
+            "cluster_id": 10,
+            "hdu_id": 2,
+            "bounding_box": {"top": 1, "left": 2, "bottom": 3, "right": 4},
+            "data": None,
+            "total_energy": 500.0,
+            "sigmaX": 1.5,
+            "sigmaY": 2.0,
+            "classification": "tritium",
+            "total_pixels": 20,
+            "filename": "test.fits",
+            "date": "2026-01-01",
+        }
+
 
 # -------------------------------------------------------------------
 # EPSFitsRecord

--- a/tests/test_EventPersistenceService.py
+++ b/tests/test_EventPersistenceService.py
@@ -3,6 +3,21 @@
 # Adapted from GitHub Copilot:
 # I need to create unit tests for this file under the tests directory, name it test_EventPersistenceService.
 # Ensure that all functions, edge cases, and paths are tested for storage and retrieval.
+import zmq
+from le_beta_vis.common.EPSDataClasses import (
+    ClassificationUpdateRequest,
+    ClusterPagedQueryFilter,
+    ClusterQueryFilter,
+    ClusterRecentQueryFilter,
+    ClusterStoreRequest,
+    FitsQueryFilter,
+    FitsStoreRequest,
+)
+from le_beta_vis.backend.EventPersistenceService import (
+    EventPersistence,
+    FailedProcException,
+    _parse_date_filter,
+)
 import unittest
 from datetime import datetime
 from unittest.mock import Mock, MagicMock, patch, call
@@ -29,21 +44,6 @@ except ModuleNotFoundError:
     mysql_module.connector = connector_module
     sys.modules["mysql"] = mysql_module
     sys.modules["mysql.connector"] = connector_module
-
-from le_beta_vis.backend.EventPersistenceService import (
-    EventPersistence,
-    FailedProcException,
-    _parse_date_filter,
-)
-from le_beta_vis.common.EPSDataClasses import (
-    ClassificationUpdateRequest,
-    ClusterQueryFilter,
-    ClusterRecentQueryFilter,
-    ClusterStoreRequest,
-    FitsQueryFilter,
-    FitsStoreRequest,
-)
-import zmq
 
 
 class TestParseDateFilter(unittest.TestCase):
@@ -163,7 +163,7 @@ class TestEventPersistenceDatabaseConnection(unittest.TestCase):
         """Test successful database connection"""
         mock_connection = MagicMock()
         mock_mysql_connect.return_value = mock_connection
-        
+
         instance = mock_config.return_value
         instance.get.side_effect = lambda key: {
             "global:db:hostname": "localhost",
@@ -190,7 +190,7 @@ class TestEventPersistenceDatabaseConnection(unittest.TestCase):
         """Test database connection failure"""
         import mysql.connector
         mock_mysql_connect.side_effect = mysql.connector.Error("Connection failed")
-        
+
         instance = mock_config.return_value
         instance.get.side_effect = lambda key: {
             "global:db:hostname": "localhost",
@@ -222,7 +222,7 @@ class TestEventPersistenceStoreFits(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_cursor = MagicMock()
         mock_connection = MagicMock()
         mock_connection.cursor.return_value = mock_cursor
@@ -260,7 +260,7 @@ class TestEventPersistenceStoreFits(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_cursor = MagicMock()
         mock_connection = MagicMock()
         mock_connection.cursor.return_value = mock_cursor
@@ -295,7 +295,7 @@ class TestEventPersistenceStoreFits(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_cursor = MagicMock()
         mock_connection = MagicMock()
         mock_connection.cursor.return_value = mock_cursor
@@ -331,7 +331,7 @@ class TestEventPersistenceStoreClusters(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_cursor = MagicMock()
         mock_connection = MagicMock()
         mock_connection.cursor.return_value = mock_cursor
@@ -381,7 +381,7 @@ class TestEventPersistenceStoreClusters(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_cursor = MagicMock()
         mock_connection = MagicMock()
         mock_connection.cursor.return_value = mock_cursor
@@ -431,7 +431,7 @@ class TestEventPersistenceRetrieveFits(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_cursor = MagicMock()
         mock_connection = MagicMock()
         mock_connection.cursor.return_value = mock_cursor
@@ -484,7 +484,7 @@ class TestEventPersistenceRetrieveFits(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_cursor = MagicMock()
         mock_connection = MagicMock()
         mock_connection.cursor.return_value = mock_cursor
@@ -535,7 +535,7 @@ class TestEventPersistenceRetrieveClusters(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_cursor = MagicMock()
         mock_connection = MagicMock()
         mock_connection.cursor.return_value = mock_cursor
@@ -702,6 +702,108 @@ class TestEventPersistenceRecentRetrieval(unittest.TestCase):
         self.assertEqual(sent["result"], "success")
 
 
+class TestEventPersistencePagedRetrieval(unittest.TestCase):
+    """Test cases for the PagedRetrieval endpoint (issue #147)."""
+
+    @patch('le_beta_vis.backend.EventPersistenceService.YAMLBackedConfigurationService')
+    @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.initialize_server')
+    @patch.object(EventPersistence, 'paged_retrieve_clusters')
+    @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.db_connect')
+    def test_cluster_event_dispatches_paged_retrieval(
+        self, mock_db_connect, mock_paged_retrieve, mock_init_server, mock_config,
+    ):
+        """cluster_event routes 'PagedRetrieval' to paged_retrieve_clusters."""
+        instance = mock_config.return_value
+        instance.get.side_effect = lambda key, default=None: {
+            "global:db:hostname": "localhost",
+            "global:db:username": "test_user",
+            "global:db:password": "test_pass",
+            "global:db:database": "test_db",
+        }.get(key, default)
+
+        mock_socket = MagicMock()
+        mock_paged_retrieve.return_value = {
+            "result": "success",
+            "clusters": [],
+            "limit": 10,
+            "offset": 20,
+        }
+
+        ep = EventPersistence()
+        request = {"Action": "PagedRetrieval", "limit": 10, "offset": 20}
+        ep.cluster_event(request, mock_socket)
+
+        mock_paged_retrieve.assert_called_once()
+        paged_filter = mock_paged_retrieve.call_args.args[0]
+        self.assertIsInstance(paged_filter, ClusterPagedQueryFilter)
+        self.assertEqual(paged_filter.limit, 10)
+        self.assertEqual(paged_filter.offset, 20)
+        mock_socket.send_json.assert_called_once()
+        sent = mock_socket.send_json.call_args[0][0]
+        self.assertEqual(sent["result"], "success")
+
+    @patch('le_beta_vis.backend.EventPersistenceService.YAMLBackedConfigurationService')
+    @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.initialize_server')
+    @patch('le_beta_vis.backend.EventPersistenceService._paged_retrieve_clusters')
+    @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.db_connect')
+    def test_paged_retrieve_clusters_uses_configured_limits(
+        self, mock_db_connect, mock_paged_retrieve, mock_init_server, mock_config,
+    ):
+        """paged_retrieve_clusters injects eps:retrieval_limit_default/_max from config."""
+        instance = mock_config.return_value
+        instance.get.side_effect = lambda key, default=None: {
+            "global:db:hostname": "localhost",
+            "global:db:username": "test_user",
+            "global:db:password": "test_pass",
+            "global:db:database": "test_db",
+            "eps:retrieval_limit_default": 100,
+            "eps:retrieval_limit_max": 200,
+        }.get(key, default)
+
+        mock_connection = MagicMock()
+        mock_db_connect.return_value = mock_connection
+        mock_paged_retrieve.return_value = {"result": "success", "clusters": []}
+
+        ep = EventPersistence()
+        ep.conn = mock_connection
+        paged_filter = ClusterPagedQueryFilter(limit=10, offset=0)
+
+        result = ep.paged_retrieve_clusters(paged_filter)
+
+        mock_paged_retrieve.assert_called_once_with(mock_connection, paged_filter, 100, 200)
+        self.assertEqual(result["result"], "success")
+
+    @patch('le_beta_vis.backend.EventPersistenceService.YAMLBackedConfigurationService')
+    @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.initialize_server')
+    @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.db_connect')
+    def test_cluster_event_paged_retrieval_over_limit_returns_failure(
+        self, mock_db_connect, mock_init_server, mock_config,
+    ):
+        """A limit beyond eps:retrieval_limit_max surfaces as a failure response."""
+        instance = mock_config.return_value
+        instance.get.side_effect = lambda key, default=None: {
+            "global:db:hostname": "localhost",
+            "global:db:username": "test_user",
+            "global:db:password": "test_pass",
+            "global:db:database": "test_db",
+            "eps:retrieval_limit_default": 500,
+            "eps:retrieval_limit_max": 2000,
+        }.get(key, default)
+
+        mock_connection = MagicMock()
+        mock_db_connect.return_value = mock_connection
+        mock_socket = MagicMock()
+
+        ep = EventPersistence()
+        ep.conn = mock_connection
+        request = {"Action": "PagedRetrieval", "limit": 99999, "offset": 0}
+        ep.cluster_event(request, mock_socket)
+
+        mock_socket.send_json.assert_called_once()
+        sent = mock_socket.send_json.call_args[0][0]
+        self.assertEqual(sent["result"], "failure")
+
+
 class TestEventPersistenceClassifyCluster(unittest.TestCase):
     """Test cases for classify_cluster method"""
 
@@ -852,7 +954,7 @@ class TestEventPersistenceProcessRetrievalFits(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         ep = EventPersistence()
 
         results = [
@@ -895,7 +997,7 @@ class TestEventPersistenceProcessRetrievalFits(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         ep = EventPersistence()
 
         results = []
@@ -916,7 +1018,7 @@ class TestEventPersistenceProcessRetrievalFits(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         ep = EventPersistence()
 
         error_msg = "Database error occurred"
@@ -942,7 +1044,7 @@ class TestEventPersistenceProcessRetrievalClusters(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         ep = EventPersistence()
 
         # Dictionary rows returned by mysql cursor(dictionary=True)
@@ -1003,7 +1105,7 @@ class TestEventPersistenceProcessRetrievalClusters(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         ep = EventPersistence()
 
         results = []
@@ -1024,7 +1126,7 @@ class TestEventPersistenceProcessRetrievalClusters(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         ep = EventPersistence()
 
         error_msg = "Database error occurred"
@@ -1051,7 +1153,7 @@ class TestEventPersistenceClusterEvent(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_socket = MagicMock()
         mock_store_cluster.return_value = 42
 
@@ -1091,7 +1193,7 @@ class TestEventPersistenceClusterEvent(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_socket = MagicMock()
         mock_store_cluster.return_value = None
 
@@ -1131,7 +1233,7 @@ class TestEventPersistenceClusterEvent(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_socket = MagicMock()
         mock_retrieve_clusters.return_value = {"result": "success", "clusters": []}
 
@@ -1160,7 +1262,8 @@ class TestEventPersistenceClusterEvent(unittest.TestCase):
     @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.initialize_server')
     @patch.object(EventPersistence, 'classify_cluster')
     @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.db_connect')
-    def test_cluster_event_update_classification_success(self, mock_db_connect, mock_classify_cluster, mock_init_server, mock_config):
+    def test_cluster_event_update_classification_success(
+            self, mock_db_connect, mock_classify_cluster, mock_init_server, mock_config):
         """Test cluster event with UpdateClassification action"""
         instance = mock_config.return_value
         instance.get.side_effect = lambda key: {
@@ -1193,7 +1296,8 @@ class TestEventPersistenceClusterEvent(unittest.TestCase):
     @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.initialize_server')
     @patch.object(EventPersistence, 'classify_cluster')
     @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.db_connect')
-    def test_cluster_event_update_classification_exception(self, mock_db_connect, mock_classify_cluster, mock_init_server, mock_config):
+    def test_cluster_event_update_classification_exception(
+            self, mock_db_connect, mock_classify_cluster, mock_init_server, mock_config):
         """Test UpdateClassification action when classify_cluster raises exception"""
         instance = mock_config.return_value
         instance.get.side_effect = lambda key: {
@@ -1234,7 +1338,7 @@ class TestEventPersistenceClusterEvent(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_socket = MagicMock()
         mock_store_cluster.return_value = None
 
@@ -1250,6 +1354,7 @@ class TestEventPersistenceClusterEvent(unittest.TestCase):
         mock_socket.send_json.assert_called_once()
         sent = mock_socket.send_json.call_args[0][0]
         self.assertEqual(sent["result"], "failure")
+
 
 class TestEventPersistenceFitsEvent(unittest.TestCase):
     """Test cases for fits_event method"""
@@ -1267,7 +1372,7 @@ class TestEventPersistenceFitsEvent(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_socket = MagicMock()
         mock_store_fits.return_value = 42
 
@@ -1303,7 +1408,7 @@ class TestEventPersistenceFitsEvent(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_socket = MagicMock()
         mock_store_fits.return_value = None
 
@@ -1339,7 +1444,7 @@ class TestEventPersistenceFitsEvent(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_socket = MagicMock()
         mock_retrieve_fits.return_value = {"result": "success", "fits": []}
 
@@ -1364,7 +1469,8 @@ class TestEventPersistenceFitsEvent(unittest.TestCase):
     @patch.object(EventPersistence, 'retrieve_fits')
     @patch.object(EventPersistence, 'retrieve_clusters')
     @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.db_connect')
-    def test_fits_event_clusters(self, mock_db_connect, mock_retrieve_clusters, mock_retrieve_fits, mock_init_server, mock_config):
+    def test_fits_event_clusters(self, mock_db_connect, mock_retrieve_clusters,
+                                 mock_retrieve_fits, mock_init_server, mock_config):
         """Test fits event with Clusters action"""
         instance = mock_config.return_value
         instance.get.side_effect = lambda key: {
@@ -1373,7 +1479,7 @@ class TestEventPersistenceFitsEvent(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_socket = MagicMock()
         mock_retrieve_fits.return_value = {"result": "success", "fits": [{"fits_id": 1}]}
         mock_retrieve_clusters.return_value = {"result": "success", "clusters": []}
@@ -1407,7 +1513,7 @@ class TestEventPersistenceFitsEvent(unittest.TestCase):
             "global:db:password": "test_pass",
             "global:db:database": "test_db"
         }.get(key, None)
-        
+
         mock_socket = MagicMock()
         mock_store_fits.return_value = None
 
@@ -1421,6 +1527,7 @@ class TestEventPersistenceFitsEvent(unittest.TestCase):
         mock_socket.send_json.assert_called_once()
         sent = mock_socket.send_json.call_args[0][0]
         self.assertEqual(sent["result"], "failure")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_EventPersistenceService.py
+++ b/tests/test_EventPersistenceService.py
@@ -721,13 +721,11 @@ class TestEventPersistencePagedRetrieval(unittest.TestCase):
             "global:db:database": "test_db",
         }.get(key, default)
 
+        from le_beta_vis.common.EPSDataClasses import PagedRetrieveClustersResponse
         mock_socket = MagicMock()
-        mock_paged_retrieve.return_value = {
-            "result": "success",
-            "clusters": [],
-            "limit": 10,
-            "offset": 20,
-        }
+        mock_paged_retrieve.return_value = PagedRetrieveClustersResponse(
+            result="success", clusters=[], limit=10, offset=20
+        )
 
         ep = EventPersistence()
         request = {"Action": "PagedRetrieval", "limit": 10, "offset": 20}
@@ -762,7 +760,10 @@ class TestEventPersistencePagedRetrieval(unittest.TestCase):
 
         mock_connection = MagicMock()
         mock_db_connect.return_value = mock_connection
-        mock_paged_retrieve.return_value = {"result": "success", "clusters": []}
+        from le_beta_vis.common.EPSDataClasses import PagedRetrieveClustersResponse
+        mock_paged_retrieve.return_value = PagedRetrieveClustersResponse(
+            result="success", clusters=[], limit=10, offset=0
+        )
 
         ep = EventPersistence()
         ep.conn = mock_connection
@@ -771,7 +772,7 @@ class TestEventPersistencePagedRetrieval(unittest.TestCase):
         result = ep.paged_retrieve_clusters(paged_filter)
 
         mock_paged_retrieve.assert_called_once_with(mock_connection, paged_filter, 100, 200)
-        self.assertEqual(result["result"], "success")
+        self.assertTrue(result.is_success)
 
     @patch('le_beta_vis.backend.EventPersistenceService.YAMLBackedConfigurationService')
     @patch('le_beta_vis.backend.EventPersistenceService.EventPersistence.initialize_server')

--- a/tests/test_NoOpEventRepository.py
+++ b/tests/test_NoOpEventRepository.py
@@ -30,6 +30,31 @@ def test_fetch_events_returns_empty(caplog):
     assert "fetch_events" in caplog.text
 
 
+def test_fetch_clusters_returns_empty(caplog):
+    repo = _make_repo()
+    qf = ClusterQueryFilter(fits_id=1)
+    got = {"events": None, "error": None}
+    with caplog.at_level(logging.WARNING):
+        repo.fetch_clusters(
+            qf,
+            limit=10,
+            offset=0,
+            callback=lambda events: got.__setitem__("events", events),
+            on_error=lambda error: got.__setitem__("error", error),
+        )
+    assert got["events"] == []
+    assert got["error"] is None
+    assert "fetch_clusters" in caplog.text
+
+
+def test_fetch_clusters_sync_returns_empty(caplog):
+    repo = _make_repo()
+    with caplog.at_level(logging.WARNING):
+        result = repo.fetch_clusters_sync()
+    assert result == []
+    assert "fetch_clusters_sync" in caplog.text
+
+
 def test_query_clusters_returns_empty(caplog):
     repo = _make_repo()
     qf = ClusterQueryFilter(fits_id=1)

--- a/tests/test_PagedClusterRetrieval.py
+++ b/tests/test_PagedClusterRetrieval.py
@@ -1,0 +1,146 @@
+"""Tests for PagedClusterRetrieval.paged_retrieve_clusters (issue #147)."""
+from le_beta_vis.common.EPSDataClasses import ClusterPagedQueryFilter, ClusterQueryFilter
+from le_beta_vis.backend.PagedClusterRetrieval import paged_retrieve_clusters
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+# Add the src directory to the path so we can import the module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# Keep tests importable even when mysql-connector isn't installed locally.
+try:
+    import mysql.connector  # type: ignore # noqa: F401
+except ModuleNotFoundError:
+    mysql_module = types.ModuleType("mysql")
+    connector_module = types.ModuleType("mysql.connector")
+
+    class _DummyMySQLError(Exception):
+        pass
+
+    connector_module.Error = _DummyMySQLError
+    connector_module.connect = MagicMock()
+    mysql_module.connector = connector_module
+    sys.modules["mysql"] = mysql_module
+    sys.modules["mysql.connector"] = connector_module
+
+
+def _make_row(cluster_id: int) -> dict:
+    return {
+        "fitsFile": 1,
+        "clusterID": cluster_id,
+        "hdu_id": 0,
+        "box_top": 1,
+        "box_left": 2,
+        "box_bottom": 3,
+        "box_right": 4,
+        "data": b"data",
+        "totalEnergy": 1000.0,
+        "sigmaX": 1.0,
+        "sigmaY": 1.0,
+        "classification": "tritium",
+        "pixelCount": 10,
+        "filename": "test.fits",
+        "date": "2026-01-01",
+    }
+
+
+def _make_conn(rows):
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = rows
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    return mock_conn, mock_cursor
+
+
+class TestPagedRetrieveClusters(unittest.TestCase):
+    """Unit tests for paged_retrieve_clusters."""
+
+    def test_first_page_uses_requested_limit_and_offset(self):
+        mock_conn, mock_cursor = _make_conn([_make_row(1), _make_row(2)])
+
+        paged_filter = ClusterPagedQueryFilter(limit=10, offset=0)
+        result = paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
+
+        self.assertEqual(result["result"], "success")
+        self.assertEqual(len(result["clusters"]), 2)
+        self.assertEqual(result["limit"], 10)
+        self.assertEqual(result["offset"], 0)
+
+        sql, params = mock_cursor.execute.call_args[0]
+        self.assertIn("LIMIT %s OFFSET %s", sql)
+        self.assertEqual(params[-2:], (10, 0))
+
+    def test_second_page_uses_offset(self):
+        mock_conn, mock_cursor = _make_conn([_make_row(3)])
+
+        paged_filter = ClusterPagedQueryFilter(limit=10, offset=50)
+        result = paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
+
+        self.assertEqual(result["offset"], 50)
+        _, params = mock_cursor.execute.call_args[0]
+        self.assertEqual(params[-2:], (10, 50))
+
+    def test_empty_page_returns_empty_clusters(self):
+        mock_conn, _ = _make_conn([])
+
+        paged_filter = ClusterPagedQueryFilter(limit=10, offset=0)
+        result = paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
+
+        self.assertEqual(result["result"], "success")
+        self.assertEqual(result["clusters"], [])
+
+    def test_default_limit_applied_when_limit_is_none(self):
+        mock_conn, mock_cursor = _make_conn([_make_row(1)])
+
+        paged_filter = ClusterPagedQueryFilter()
+        result = paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
+
+        self.assertEqual(result["limit"], 500)
+        _, params = mock_cursor.execute.call_args[0]
+        self.assertEqual(params[-2:], (500, 0))
+
+    def test_filters_are_applied_to_where_clause(self):
+        mock_conn, mock_cursor = _make_conn([_make_row(1)])
+
+        paged_filter = ClusterPagedQueryFilter(
+            filters=ClusterQueryFilter(fits_id=7, classification="tritium"),
+            limit=10,
+        )
+        paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
+
+        sql, params = mock_cursor.execute.call_args[0]
+        self.assertIn("fitsFile = %s", sql)
+        self.assertIn("classification = %s", sql)
+        self.assertIn(7, params)
+        self.assertIn("tritium", params)
+
+    def test_limit_above_max_raises_value_error(self):
+        mock_conn, _ = _make_conn([])
+        paged_filter = ClusterPagedQueryFilter(limit=2500)
+
+        with self.assertRaises(ValueError):
+            paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
+
+    def test_non_positive_default_limit_raises_value_error(self):
+        mock_conn, _ = _make_conn([])
+        paged_filter = ClusterPagedQueryFilter()
+
+        with self.assertRaises(ValueError):
+            paged_retrieve_clusters(mock_conn, paged_filter, default_limit=0, max_limit=2000)
+
+    def test_mysql_error_returns_failure(self):
+        mock_conn, mock_cursor = _make_conn([])
+        mock_cursor.execute.side_effect = mysql.connector.Error("boom")
+
+        paged_filter = ClusterPagedQueryFilter(limit=10)
+        result = paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
+
+        self.assertEqual(result["result"], "failure")
+        self.assertIsNone(result["clusters"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_PagedClusterRetrieval.py
+++ b/tests/test_PagedClusterRetrieval.py
@@ -64,10 +64,10 @@ class TestPagedRetrieveClusters(unittest.TestCase):
         paged_filter = ClusterPagedQueryFilter(limit=10, offset=0)
         result = paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
 
-        self.assertEqual(result["result"], "success")
-        self.assertEqual(len(result["clusters"]), 2)
-        self.assertEqual(result["limit"], 10)
-        self.assertEqual(result["offset"], 0)
+        self.assertTrue(result.is_success)
+        self.assertEqual(len(result.clusters), 2)
+        self.assertEqual(result.limit, 10)
+        self.assertEqual(result.offset, 0)
 
         sql, params = mock_cursor.execute.call_args[0]
         self.assertIn("LIMIT %s OFFSET %s", sql)
@@ -79,7 +79,7 @@ class TestPagedRetrieveClusters(unittest.TestCase):
         paged_filter = ClusterPagedQueryFilter(limit=10, offset=50)
         result = paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
 
-        self.assertEqual(result["offset"], 50)
+        self.assertEqual(result.offset, 50)
         _, params = mock_cursor.execute.call_args[0]
         self.assertEqual(params[-2:], (10, 50))
 
@@ -89,8 +89,8 @@ class TestPagedRetrieveClusters(unittest.TestCase):
         paged_filter = ClusterPagedQueryFilter(limit=10, offset=0)
         result = paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
 
-        self.assertEqual(result["result"], "success")
-        self.assertEqual(result["clusters"], [])
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.clusters, [])
 
     def test_default_limit_applied_when_limit_is_none(self):
         mock_conn, mock_cursor = _make_conn([_make_row(1)])
@@ -98,7 +98,7 @@ class TestPagedRetrieveClusters(unittest.TestCase):
         paged_filter = ClusterPagedQueryFilter()
         result = paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
 
-        self.assertEqual(result["limit"], 500)
+        self.assertEqual(result.limit, 500)
         _, params = mock_cursor.execute.call_args[0]
         self.assertEqual(params[-2:], (500, 0))
 
@@ -138,8 +138,8 @@ class TestPagedRetrieveClusters(unittest.TestCase):
         paged_filter = ClusterPagedQueryFilter(limit=10)
         result = paged_retrieve_clusters(mock_conn, paged_filter, default_limit=500, max_limit=2000)
 
-        self.assertEqual(result["result"], "failure")
-        self.assertIsNone(result["clusters"])
+        self.assertFalse(result.is_success)
+        self.assertIsNone(result.clusters)
 
 
 if __name__ == "__main__":

--- a/tests/test_ZMQBasedEventRepository.py
+++ b/tests/test_ZMQBasedEventRepository.py
@@ -190,6 +190,126 @@ class TestQueryClusters:
         sent = sock.send_json.call_args[0][0]
         assert sent == {"Action": "Retrieval"}
 
+    def test_fetch_events_emits_deprecation_warning(self):
+        ctx, sock = _mock_context({"result": "success", "clusters": []})
+        repo = _make_repo(ctx)
+        done = threading.Event()
+
+        with pytest.warns(DeprecationWarning):
+            repo.fetch_events(
+                callback=lambda _: done.set(),
+                on_error=lambda _: done.set(),
+            )
+        _await_callback(done)
+
+
+# -------------------------------------------------------------------
+# fetch_clusters / fetch_clusters_sync (PagedRetrieval action, issue #147)
+# -------------------------------------------------------------------
+
+
+class TestFetchClusters:
+
+    def test_success_returns_clusters(self):
+        raw_response = {
+            "result": "success",
+            "clusters": [
+                {
+                    "fits_id": 1,
+                    "hdu_id": 0,
+                    "cluster_id": 10,
+                    "bounding_box": {"top": 10, "left": 20, "bottom": 30, "right": 40},
+                    "data": None,
+                    "total_energy": 500.0,
+                    "sigmaX": 1.5,
+                    "sigmaY": 2.0,
+                    "classification": "tritium",
+                    "total_pixels": 20,
+                    "filename": "a.fits",
+                    "date": "2026-01-01",
+                },
+            ],
+            "limit": 10,
+            "offset": 0,
+        }
+        ctx, sock = _mock_context(raw_response)
+        repo = _make_repo(ctx)
+
+        clusters = repo.fetch_clusters_sync(limit=10, offset=0)
+
+        assert len(clusters) == 1
+        assert clusters[0].fitsId == 1
+        assert clusters[0].clusterId == 10
+        assert clusters[0].energy == 500.0
+
+    def test_failure_raises(self):
+        ctx, sock = _mock_context({"result": "failure"})
+        repo = _make_repo(ctx)
+
+        with pytest.raises(Exception):
+            repo.fetch_clusters_sync(limit=10, offset=0)
+
+    def test_zmq_error_returns_empty(self):
+        ctx, sock = _mock_context()
+        sock.send_json.side_effect = zmq.ZMQError("timeout")
+        repo = _make_repo(ctx)
+
+        assert repo.fetch_clusters_sync(limit=10, offset=0) == []
+
+    def test_default_limit_injected_from_config(self):
+        ctx, sock = _mock_context({"result": "success", "clusters": []})
+        config = MockConfigurationService()
+        config._store["eps:retrieval_limit_default"] = 250
+        repo = _make_repo(ctx, config=config)
+
+        repo.fetch_clusters_sync()
+
+        sent = sock.send_json.call_args[0][0]
+        assert sent["Action"] == "PagedRetrieval"
+        assert sent["limit"] == 250
+        assert sent["offset"] == 0
+
+    def test_explicit_limit_overrides_default(self):
+        ctx, sock = _mock_context({"result": "success", "clusters": []})
+        config = MockConfigurationService()
+        config._store["eps:retrieval_limit_default"] = 250
+        repo = _make_repo(ctx, config=config)
+
+        repo.fetch_clusters_sync(limit=5, offset=15)
+
+        sent = sock.send_json.call_args[0][0]
+        assert sent["limit"] == 5
+        assert sent["offset"] == 15
+
+    def test_filter_merged_into_request(self):
+        ctx, sock = _mock_context({"result": "success", "clusters": []})
+        repo = _make_repo(ctx)
+        qf = ClusterQueryFilter(fits_id=42, classification="tritium")
+
+        repo.fetch_clusters_sync(query_filter=qf, limit=10, offset=0)
+
+        sent = sock.send_json.call_args[0][0]
+        assert sent["Action"] == "PagedRetrieval"
+        assert sent["fits_id"] == 42
+        assert sent["classification"] == "tritium"
+
+    def test_async_fetch_clusters_invokes_callback(self):
+        ctx, sock = _mock_context({"result": "success", "clusters": []})
+        repo = _make_repo(ctx)
+        done = threading.Event()
+        got = {"clusters": None}
+
+        repo.fetch_clusters(
+            query_filter=None,
+            limit=10,
+            offset=0,
+            callback=lambda clusters: (got.__setitem__("clusters", clusters), done.set()),
+            on_error=lambda _: done.set(),
+        )
+        _await_callback(done)
+
+        assert got["clusters"] == []
+
 
 # -------------------------------------------------------------------
 # query_recent_clusters (RecentRetrieval action)


### PR DESCRIPTION
Introduces bounded pagination for cluster retrieval to replace unbounded database queries, eliminating potential performance and memory issues. It also hardens the serialization layer using type-safe data classes for paged responses.

## Key Changes

### 1. Pagination & Deprecation
- Deprecated `EventRepository.fetch_events()` to prevent unbounded queries.
- Introduced bounded pagination via `EventRepository.fetch_clusters()` and `fetch_clusters_sync()`.
- Added `ClusterPagedQueryFilter` to encapsulate pagination parameters (`limit` and `offset`) and filter criteria.

### 2. Backend & Serialization
- Added handling for `PagedRetrieval` ZMQ action in the `EventPersistenceService` backend.
- Delegated database query generation and mapping to the helper module `PagedClusterRetrieval.py`.
- Hardened serialization in `_format_cluster_rows` using data classes.
- Used type-safe data classes for paged responses.

### 3. Configuration & UI
- Defined config settings `eps:retrieval_limit_default` (500) and `eps:retrieval_limit_max` (2000) in `defaults.yaml`.
- Added migration TODOs in `HistoricalViewModel` to transition away from deprecated unbounded fetches.

### 4. Verification
- Added unit tests covering pagination logic, limit boundaries, repository methods, and serialization.


Resolves #147
