### PR TITLE
feat: Make magnifier info label font size configurable

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -84,4 +84,4 @@ jobs:
         env:
           PYTHONPATH: src
         run: |
-          pytest --ignore=tests/test_MagnifierGraphicsItem.py --ignore=tests/test_CaptureGraphicsView.py --ignore=tests/test_SectionHeaderFormatting.py --ignore=tests/test_VerticalRangeControlUI.py --ignore=tests/test_HUDBoxSelectionItem.py --ignore=tests/test_HUDMagnifierBorderItem.py tests
+          pytest --ignore=tests/test_MagnifierGraphicsItem.py --ignore=tests/test_CaptureGraphicsView.py --ignore=tests/test_SectionHeaderFormatting.py --ignore=tests/test_VerticalRangeControlUI.py --ignore=tests/test_HUDBoxSelectionItem.py --ignore=tests/test_HUDMagnifierBorderItem.py --ignore=tests/test_HDUVisualizationHUDWidget.py tests

--- a/src/le_beta_vis/config/defaults.yaml
+++ b/src/le_beta_vis/config/defaults.yaml
@@ -145,6 +145,13 @@ gui:raw_analysis:magnifier_factor_step:
     Increment/decrement step when adjusting magnification
     via scroll wheel or keyboard.
 
+gui:raw_analysis:magnifier_info_label_font_size:
+  type: float
+  default: 1.0
+  description: >-
+    Multiplier applied to the magnifier info label's font size
+    (Min/Max/Val/Zoom panel and hint text). Range: 0.5-2.0.
+
 gui:raw_analysis:magnifier_move_step:
   type: int
   default: 1

--- a/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
@@ -508,6 +508,16 @@ class RawDataViewModel:
         return self._config.get("gui:raw_analysis:show_tool_hints", True)
 
     @property
+    def magnifierInfoLabelFontSize(self) -> float:
+        """Font-size multiplier for the magnifier info label (0.5-2.0)."""
+        return self._config.get_float(
+            "gui:raw_analysis:magnifier_info_label_font_size",
+            1.0,
+            minimum=0.5,
+            maximum=2.0,
+        )
+
+    @property
     def autoRangeOnLoad(self) -> bool:
         """Whether to auto-set the visualization range on load."""
         return self._config.get("gui:raw_analysis:auto_range_on_load", False)

--- a/src/le_beta_vis/frontend/widgets/HDUVisualizationHUDWidget.py
+++ b/src/le_beta_vis/frontend/widgets/HDUVisualizationHUDWidget.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from PySide6.QtCore import QPointF, QRectF, Qt, Signal
 from PySide6.QtGui import QPainter, QShowEvent
 from PySide6.QtWidgets import QGraphicsScene, QGraphicsView, QWidget
+from shiboken6 import isValid
 
 from le_beta_vis.common import AnnotationOverlay
 from .CaptureGraphicsView import CaptureGraphicsView
@@ -31,6 +32,7 @@ class HDUVisualizationHUDWidget(QGraphicsView):
         self,
         sourceView: CaptureGraphicsView,
         parent: Optional[QWidget] = None,
+        fontScale: float = 1.0,
     ) -> None:
         super().__init__(parent)
         self._sourceView = sourceView
@@ -42,7 +44,7 @@ class HDUVisualizationHUDWidget(QGraphicsView):
         self._hudScene.addItem(self._boxSelectionItem)
         self._boxSelectionSceneRect: Optional[QRectF] = None
 
-        self._magnifierBorderItem = _HUDMagnifierBorderItem()
+        self._magnifierBorderItem = _HUDMagnifierBorderItem(fontScale=fontScale)
         self._magnifierBorderItem.setVisible(False)
         self._hudScene.addItem(self._magnifierBorderItem)
         self._magnifierItem: Optional[MagnifierGraphicsItem] = None
@@ -129,6 +131,7 @@ class HDUVisualizationHUDWidget(QGraphicsView):
         if (
             not self._magnifierVisible
             or self._magnifierItem is None
+            or not isValid(self._magnifierItem)
             or not self._magnifierItem.hasSource
         ):
             self._magnifierBorderItem.setState(

--- a/src/le_beta_vis/frontend/widgets/HDUVisualizationView.py
+++ b/src/le_beta_vis/frontend/widgets/HDUVisualizationView.py
@@ -125,7 +125,8 @@ class HDUVisualizationView(QWidget):
         self.graphicsView.setGeometry(self._stackHost.rect())
 
         self._hudWidget = HDUVisualizationHUDWidget(
-            self.graphicsView, self._stackHost
+            self.graphicsView, self._stackHost,
+            fontScale=self._vm.magnifierInfoLabelFontSize,
         )
         self._hudWidget.setGeometry(self._stackHost.rect())
         self._hudWidget.raise_()

--- a/src/le_beta_vis/frontend/widgets/_HUDMagnifierBorderItem.py
+++ b/src/le_beta_vis/frontend/widgets/_HUDMagnifierBorderItem.py
@@ -2,7 +2,7 @@ import math
 from typing import List, Optional, Tuple
 
 from PySide6.QtCore import QRectF, Qt
-from PySide6.QtGui import QColor, QFont, QPainter, QPen
+from PySide6.QtGui import QColor, QFont, QFontMetrics, QPainter, QPen
 from PySide6.QtWidgets import (
     QGraphicsItem,
     QStyleOptionGraphicsItem,
@@ -26,7 +26,11 @@ class _HUDMagnifierBorderItem(QGraphicsItem):
     _VALUE_FONT_POINT_SIZE = 8
     _HINT_FONT_POINT_SIZE = 7
 
-    def __init__(self, parent: Optional[QGraphicsItem] = None) -> None:
+    def __init__(
+        self,
+        parent: Optional[QGraphicsItem] = None,
+        fontScale: float = 1.0,
+    ) -> None:
         super().__init__(parent)
         self._widgetRect: Optional[QRectF] = None
         self._unit: str = ""
@@ -37,8 +41,18 @@ class _HUDMagnifierBorderItem(QGraphicsItem):
             math.nan,
         )
         self._hintLines: List[str] = []
+        self._fontScale = fontScale
         self.setZValue(100)
         self.setVisible(False)
+
+    def _valueFont(self) -> QFont:
+        return QFont("Arial", round(self._VALUE_FONT_POINT_SIZE * self._fontScale))
+
+    def _hintFont(self) -> QFont:
+        return QFont("Arial", round(self._HINT_FONT_POINT_SIZE * self._fontScale))
+
+    def _scaledLabelWidth(self) -> float:
+        return self._LABEL_WIDTH * self._fontScale
 
     def setState(
         self,
@@ -61,9 +75,10 @@ class _HUDMagnifierBorderItem(QGraphicsItem):
     def boundingRect(self) -> QRectF:
         if self._widgetRect is None:
             return QRectF()
+        lineHeight = QFontMetrics(self._valueFont()).height() + 2
         extraLines = 4 + (len(self._hintLines) + 1 if self._hintLines else 0)
-        labelWidth = self._LABEL_PADDING + self._LABEL_WIDTH + 8
-        labelHeight = extraLines * 16 + 8
+        labelWidth = self._LABEL_PADDING + self._scaledLabelWidth() + 8
+        labelHeight = extraLines * lineHeight + 8
         right = self._widgetRect.right() + labelWidth
         bottom = max(self._widgetRect.bottom(), self._widgetRect.top() + labelHeight)
         margin = self._BORDER_WIDTH + 1
@@ -93,7 +108,7 @@ class _HUDMagnifierBorderItem(QGraphicsItem):
 
     def _drawLabels(self, painter: QPainter) -> None:
         assert self._widgetRect is not None
-        painter.setFont(QFont("Arial", self._VALUE_FONT_POINT_SIZE))
+        painter.setFont(self._valueFont())
         metrics = painter.fontMetrics()
         lineHeight = metrics.height() + 2
 
@@ -104,7 +119,7 @@ class _HUDMagnifierBorderItem(QGraphicsItem):
         labelX = self._widgetRect.right() + self._LABEL_PADDING
         labelY = self._widgetRect.top()
         bgRect = QRectF(
-            labelX - 4, labelY, self._LABEL_WIDTH + 4, bgHeight
+            labelX - 4, labelY, self._scaledLabelWidth() + 4, bgHeight
         )
         painter.fillRect(bgRect, QColor(0, 0, 0, int(255 * 0.8)))
 
@@ -131,7 +146,7 @@ class _HUDMagnifierBorderItem(QGraphicsItem):
     def _drawHints(self, painter: QPainter) -> None:
         if not self._hintLines or self._widgetRect is None:
             return
-        painter.setFont(QFont("Arial", self._HINT_FONT_POINT_SIZE))
+        painter.setFont(self._hintFont())
         metrics = painter.fontMetrics()
         lineHeight = metrics.height() + 2
         labelX = self._widgetRect.right() + self._LABEL_PADDING

--- a/tests/test_HDUVisualizationHUDWidget.py
+++ b/tests/test_HDUVisualizationHUDWidget.py
@@ -1,0 +1,41 @@
+import sys
+
+import numpy as np
+import shiboken6
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import QApplication
+
+from le_beta_vis.frontend.widgets.CaptureGraphicsView import (
+    CaptureGraphicsView,
+)
+from le_beta_vis.frontend.widgets.HDUVisualizationHUDWidget import (
+    HDUVisualizationHUDWidget,
+)
+from le_beta_vis.frontend.widgets.MagnifierGraphicsItem import (
+    MagnifierGraphicsItem,
+)
+
+app = QApplication.instance() or QApplication(sys.argv)
+
+
+def test_reproject_magnifier_survives_deleted_item():
+    """Issue #188: closing the app while the magnifier is bound must not
+    raise when the C++ side of the MagnifierGraphicsItem is torn down
+    before the HUD widget's viewport-changed slot stops firing."""
+    sourceView = CaptureGraphicsView()
+    hud = HDUVisualizationHUDWidget(sourceView)
+
+    magnifier = MagnifierGraphicsItem(
+        fixedDisplaySize=127, initialMagnificationFactor=3.0
+    )
+    pixmap = QPixmap(10, 10)
+    pixmap.fill()
+    magnifier.setSourceData(pixmap, np.zeros((10, 10)), None)
+    magnifier.setPixelPos(5, 5)
+
+    hud.bindMagnifier(magnifier)
+    hud.setMagnifierVisible(True)
+
+    shiboken6.delete(magnifier)
+
+    hud._onViewportChanged()

--- a/tests/test_HUDMagnifierBorderItem.py
+++ b/tests/test_HUDMagnifierBorderItem.py
@@ -39,3 +39,22 @@ def test_clear_hides():
     )
     item.setState(None, "", 1.0, (math.nan, math.nan, math.nan), [])
     assert not item.isVisible()
+
+
+def test_font_scale_grows_bounding_rect():
+    state_args = (
+        QRectF(5, 6, 127, 127),
+        "keV",
+        3.0,
+        (0.1, 0.9, 0.5),
+        ["tip"],
+    )
+    normal = _HUDMagnifierBorderItem(fontScale=1.0)
+    normal.setState(*state_args)
+    scaled = _HUDMagnifierBorderItem(fontScale=2.0)
+    scaled.setState(*state_args)
+
+    scaledRect = scaled.boundingRect()
+    normalRect = normal.boundingRect()
+    assert scaledRect.height() > normalRect.height()
+    assert scaledRect.width() > normalRect.width()

--- a/tests/test_RawDataViewModel.py
+++ b/tests/test_RawDataViewModel.py
@@ -49,6 +49,28 @@ def test_initial_colormap_from_config():
     assert vm.colormap == "plasma"
 
 
+def test_magnifier_info_label_font_size_default():
+    """Test the font-size multiplier defaults to 1.0 when unset."""
+    config = MockConfigurationService()
+    physics_manager = PhysicsConversionManagerImpl(config)
+    vm = RawDataViewModel(config, physics_manager)
+    assert vm.magnifierInfoLabelFontSize == 1.0
+
+
+def test_magnifier_info_label_font_size_clamps_to_range():
+    """Test the font-size multiplier is clamped to [0.5, 2.0]."""
+    config = MockConfigurationService()
+    physics_manager = PhysicsConversionManagerImpl(config)
+
+    config.set("gui:raw_analysis:magnifier_info_label_font_size", 3.0)
+    vm = RawDataViewModel(config, physics_manager)
+    assert vm.magnifierInfoLabelFontSize == 2.0
+
+    config.set("gui:raw_analysis:magnifier_info_label_font_size", 0.1)
+    vm = RawDataViewModel(config, physics_manager)
+    assert vm.magnifierInfoLabelFontSize == 0.5
+
+
 def test_initial_state(view_model):
     """Test the initial state of the ViewModel."""
     assert view_model.activeIndex == -1


### PR DESCRIPTION
- Add option `gui:raw_analysis:magnifier_info_label_font_size` (float, default 1.0, range 0.5-2.0) to default configurations.
- Expose magnifierInfoLabelFontSize property in RawDataViewModel, clamping input values.
- Scale font sizes and bounding box of HUDMagnifierBorderItem labels and hints using the configured font size scale.
- Add test_reproject_magnifier_survives_deleted_item to verify lifetime robustness, and ignore it in headless CI pipeline.
- Add test_font_scale_grows_bounding_rect to verify border item size scaling.
- Add tests for magnifier info label font size property default and clamping logic.
- Fix a RuntimeError during application teardown where the class HDUVisualizationHUDWidget attempts to access self._magnifierItem (MagnifierGraphicsItem) after its C++ object has been deleted. Used shiboken6.isValid to check validity.

Resolves #188
