### PR TITLE
feat: add Licenses tab and third-party attributions to About dialog

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -15,15 +15,31 @@ or that ship as binary assets inside the wheel / PyInstaller bundle.
 
 ### DejaVu Fonts
 
-- **Files:** `src/le_beta_vis/common/fonts/DejaVuSans.ttf`,
-  `src/le_beta_vis/common/fonts/DejaVuSansMono.ttf`
-- **Full license text:** [`src/le_beta_vis/common/fonts/LICENSE_DEJAVU`](src/le_beta_vis/common/fonts/LICENSE_DEJAVU)
+- **Files:** `src/le_beta_vis/export/fonts/DejaVuSans.ttf`,
+  `src/le_beta_vis/export/fonts/DejaVuSansMono.ttf`
+- **Full license text:** [`src/le_beta_vis/export/fonts/LICENSE_DEJAVU`](src/le_beta_vis/export/fonts/LICENSE_DEJAVU)
 - **Summary:** Bitstream Vera Fonts Copyright (permissive, MIT-style).
   Reproduction and distribution are permitted; the full license text
   must accompany any redistribution — it does, via the file above,
   which is bundled alongside the TTFs in every wheel and PyInstaller
   build.
 - **Upstream:** <https://dejavu-fonts.github.io/>
+
+### Material Symbols
+
+- **Files:** `src/le_beta_vis/resources/icons/cancel.svg`,
+  `delete.svg`, `grabber.svg`, `info.svg`, `keep.svg`, `keep_off.svg`,
+  `pause_circle.svg`, `play_circle.svg`, `save.svg`, `toggle_off.svg`,
+  `toggle_on.svg`
+- **Full license text:** [`src/le_beta_vis/resources/icons/LICENSE_MATERIAL_SYMBOLS`](src/le_beta_vis/resources/icons/LICENSE_MATERIAL_SYMBOLS)
+- **Summary:** Google Material Symbols icon set, licensed under the
+  Apache License, Version 2.0. Icons are used unmodified except for
+  file renames to match the project's local naming convention and
+  runtime fill-colour substitution; the original SVG bytes ship
+  unchanged. The full license text accompanies the redistribution via
+  the file above, bundled alongside the SVGs in every wheel and
+  PyInstaller build.
+- **Upstream:** <https://fonts.google.com/icons>
 
 ---
 

--- a/packaging/lbnlvis.spec
+++ b/packaging/lbnlvis.spec
@@ -29,6 +29,8 @@ a = Analysis(
         (str(RESOURCES), "resources"),
         (str(CONFIG / "defaults.yaml"), "config"),
         (str(ROOT / "pyproject.toml"), "."),
+        (str(ROOT / "LICENSE"), "."),
+        (str(ROOT / "THIRD_PARTY_NOTICES.md"), "."),
         (str(FONTS), "le_beta_vis/export/fonts"),
     ],
     hiddenimports=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ packaging = [
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[project.urls]
+Repository = "https://github.com/OSUCSVisualizationTeam/le-beta-particle-vis-lbnl"
+
 [project.scripts]
 lbnlvis = "le_beta_vis.app:main"
 
@@ -61,8 +64,10 @@ le_beta_vis = [
     "backend/SAMPLE.env",
     "config/*.yaml",
     "resources/icons/*.png",
-    "common/fonts/*.ttf",
-    "common/fonts/LICENSE_DEJAVU",
+    "resources/icons/*.svg",
+    "resources/icons/LICENSE_MATERIAL_SYMBOLS",
+    "export/fonts/*.ttf",
+    "export/fonts/LICENSE_DEJAVU",
 ]
 
 [tool.pytest.ini_options]

--- a/src/le_beta_vis/common/AppInfo.py
+++ b/src/le_beta_vis/common/AppInfo.py
@@ -14,6 +14,28 @@ except ModuleNotFoundError:
 _logger = logging.getLogger(__name__)
 _PYPROJECT_PATH = Path(__file__).resolve().parents[3] / "pyproject.toml"
 
+_DEFAULT_REPOSITORY_URL = (
+    "https://github.com/OSUCSVisualizationTeam/le-beta-particle-vis-lbnl"
+)
+
+
+def _resolve_pyproject_path() -> Path:
+    """Return the pyproject.toml path, handling frozen and dev modes."""
+    if getattr(sys, "frozen", False):
+        return Path(sys._MEIPASS) / "pyproject.toml"  # type: ignore[attr-defined]
+    return _PYPROJECT_PATH
+
+
+def _load_pyproject() -> Optional[dict]:
+    """Parse the bundled/dev pyproject.toml, or None if unreadable."""
+    path = _resolve_pyproject_path()
+    try:
+        with open(path, "rb") as fh:
+            return tomllib.load(fh)
+    except Exception as exc:
+        _logger.warning("Could not read pyproject.toml: %s", exc)
+        return None
+
 
 def _read_pyproject_version() -> Optional[str]:
     """Return the version string, handling both frozen and dev modes."""
@@ -24,23 +46,24 @@ def _read_pyproject_version() -> Optional[str]:
         except Exception:
             _logger.debug("importlib.metadata unavailable in frozen app, "
                           "falling back to bundled pyproject.toml")
-        frozen_pyproject = Path(sys._MEIPASS) / "pyproject.toml"  # type: ignore[attr-defined]
-        try:
-            with open(frozen_pyproject, "rb") as fh:
-                data = tomllib.load(fh)
-            return data.get("project", {}).get("version")
-        except Exception as exc:
-            _logger.warning("Could not read version from bundled pyproject.toml: %s", exc)
-            return None
 
-    try:
-        with open(_PYPROJECT_PATH, "rb") as fh:
-            data = tomllib.load(fh)
-        return data.get("project", {}).get("version")
-    except Exception as exc:
-        _logger.warning("Could not read version from pyproject.toml: %s", exc)
+    data = _load_pyproject()
+    if data is None:
         return None
+    return data.get("project", {}).get("version")
+
+
+def _read_pyproject_repository_url() -> Optional[str]:
+    """Return the repository URL declared in pyproject.toml's [project.urls]."""
+    data = _load_pyproject()
+    if data is None:
+        return None
+    return data.get("project", {}).get("urls", {}).get("Repository")
 
 
 APP_VERSION: str = _read_pyproject_version() or "0.0.0"
 APP_NAME: str = "LE Beta Particle Visualization"
+APP_REPOSITORY_URL: str = (
+    _read_pyproject_repository_url() or _DEFAULT_REPOSITORY_URL
+)
+APP_REPOSITORY_BLOB_BASE_URL: str = f"{APP_REPOSITORY_URL}/blob/main/"

--- a/src/le_beta_vis/common/LicenseDocuments.py
+++ b/src/le_beta_vis/common/LicenseDocuments.py
@@ -1,0 +1,68 @@
+"""Raw text access to repo-root license and notice documents."""
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from pathlib import Path
+
+from .AppInfo import APP_REPOSITORY_BLOB_BASE_URL
+
+_logger = logging.getLogger(__name__)
+_REPO_ROOT_PATH = Path(__file__).resolve().parents[3]
+
+# Matches a markdown link target: `](target)`.
+_MARKDOWN_LINK_TARGET = re.compile(r"\]\(([^)]+)\)")
+
+
+def _resolve_repo_root_file(filename: str) -> Path:
+    """Return the path to a repo-root file, handling frozen and dev modes."""
+    if getattr(sys, "frozen", False):
+        return Path(sys._MEIPASS) / filename  # type: ignore[attr-defined]
+    return _REPO_ROOT_PATH / filename
+
+
+def _read_repo_root_text(filename: str, fallback: str) -> str:
+    """Read a repo-root file's text, returning fallback if unavailable."""
+    path = _resolve_repo_root_file(filename)
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception as exc:
+        _logger.warning("Could not read %s: %s", filename, exc)
+        return fallback
+
+
+def _rewrite_relative_links(markdown_text: str, base_url: str) -> str:
+    """Rewrite repo-relative markdown link targets to absolute `base_url` links.
+
+    THIRD_PARTY_NOTICES.md is authored to be browsed on GitHub or in a local
+    markdown editor, where repo-relative targets (e.g. "pyproject.toml")
+    resolve correctly against the file's own location. Neither assumption
+    holds once the text is embedded in the app, so relative targets are
+    rewritten here before display; already-absolute targets are untouched.
+    """
+    def _rewrite(match: "re.Match[str]") -> str:
+        target = match.group(1)
+        if "://" in target or target.startswith("#") or target.startswith("mailto:"):
+            return match.group(0)
+        return f"]({base_url}{target})"
+
+    return _MARKDOWN_LINK_TARGET.sub(_rewrite, markdown_text)
+
+
+def get_license_text() -> str:
+    """Return the raw text of the project's LICENSE file."""
+    return _read_repo_root_text(
+        "LICENSE",
+        "License file not found. See the project repository for license terms.",
+    )
+
+
+def get_third_party_notices_text() -> str:
+    """Return THIRD_PARTY_NOTICES.md text with relative links made absolute."""
+    text = _read_repo_root_text(
+        "THIRD_PARTY_NOTICES.md",
+        "Third-party notices file not found. See the project repository "
+        "for third-party license attributions.",
+    )
+    return _rewrite_relative_links(text, APP_REPOSITORY_BLOB_BASE_URL)

--- a/src/le_beta_vis/common/__init__.py
+++ b/src/le_beta_vis/common/__init__.py
@@ -41,7 +41,13 @@ from .LBNLOptimizedClusterExtractor import LBNLOptimizedClusterExtractor
 from .GeneralClusterExtractor import GeneralClusterExtractor
 from .ClusterExtractorFactory import ClusterExtractorMethod, create_cluster_extractor
 from .cluster_sigma import compute_cluster_sigmas
-from .AppInfo import APP_VERSION, APP_NAME
+from .AppInfo import (
+    APP_VERSION,
+    APP_NAME,
+    APP_REPOSITORY_URL,
+    APP_REPOSITORY_BLOB_BASE_URL,
+)
+from .LicenseDocuments import get_license_text, get_third_party_notices_text
 from .ThumbnailLoaderService import ThumbnailLoaderService
 from .PrefetchingThumbnailLoaderService import PrefetchingThumbnailLoaderService
 from .EventEnvelope import EventEnvelope, SCHEMA_VERSION

--- a/src/le_beta_vis/frontend/theme.py
+++ b/src/le_beta_vis/frontend/theme.py
@@ -135,6 +135,14 @@ class ClusterLocationMapColors:
     BORDER = "#3a3a3a"
 
 
+class LicensesTabColors:
+    """Colors for the About dialog's Licenses tab QTextBrowser."""
+
+    BACKGROUND = COLOR_BACKGROUND_SURFACE
+    TEXT = COLOR_TEXT_PRIMARY
+    BORDER = "#555555"
+
+
 class HUDAnnotationOverlayColors:
     """Colors for AnnotationOverlay rectangles on HDUVisualizationHUDWidget."""
 

--- a/src/le_beta_vis/frontend/viewmodels/AboutViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/AboutViewModel.py
@@ -1,6 +1,11 @@
 """ViewModel for the About dialog — pure Python, no Qt dependencies."""
 
-from le_beta_vis.common import APP_NAME, APP_VERSION
+from le_beta_vis.common import (
+    APP_NAME,
+    APP_REPOSITORY_BLOB_BASE_URL,
+    APP_REPOSITORY_URL,
+    APP_VERSION,
+)
 
 
 class AboutViewModel:
@@ -39,7 +44,17 @@ class AboutViewModel:
     @property
     def repository_url(self) -> str:
         """Return the source repository URL."""
-        return "https://github.com/OSUCSVisualizationTeam/le-beta-particle-vis-lbnl"
+        return APP_REPOSITORY_URL
+
+    @property
+    def repository_blob_base_url(self) -> str:
+        """Return the base URL for viewing repo files at the default branch."""
+        return APP_REPOSITORY_BLOB_BASE_URL
+
+    @property
+    def license_url(self) -> str:
+        """Return the URL of the LICENSE file in the source repository."""
+        return f"{self.repository_blob_base_url}LICENSE"
 
     def formatted_version(self) -> str:
         """Return a human-readable version label."""

--- a/src/le_beta_vis/frontend/viewmodels/LicensesViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/LicensesViewModel.py
@@ -1,0 +1,17 @@
+"""ViewModel for the About dialog's Licenses tab — pure Python, no Qt dependencies."""
+
+from le_beta_vis.common import get_license_text, get_third_party_notices_text
+
+
+class LicensesViewModel:
+    """Exposes raw license and third-party notices text for display."""
+
+    @property
+    def license_text(self) -> str:
+        """Return the raw text of the project's LICENSE file."""
+        return get_license_text()
+
+    @property
+    def third_party_notices_text(self) -> str:
+        """Return the raw text of the project's THIRD_PARTY_NOTICES.md file."""
+        return get_third_party_notices_text()

--- a/src/le_beta_vis/frontend/widgets/AboutDialog.py
+++ b/src/le_beta_vis/frontend/widgets/AboutDialog.py
@@ -12,15 +12,19 @@ from PySide6.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QLabel,
+    QTabWidget,
+    QTextBrowser,
     QVBoxLayout,
     QWidget,
 )
 
 from ..viewmodels.AboutViewModel import AboutViewModel
+from ..viewmodels.LicensesViewModel import LicensesViewModel
 from ..theme import (
     COLOR_BACKGROUND_SURFACE,
     COLOR_TEXT_PRIMARY,
     COLOR_ACCENT_LINK,
+    LicensesTabColors,
 )
 
 _ICON_SIZE = 80
@@ -41,13 +45,15 @@ class AboutDialog(QDialog):
     def __init__(
         self,
         viewModel: AboutViewModel,
+        licensesViewModel: LicensesViewModel = None,
         parent: QWidget = None,
     ) -> None:
         super().__init__(parent)
         self._vm = viewModel
+        self._licenses_vm = licensesViewModel or LicensesViewModel()
 
         self.setWindowTitle(self.tr("About {0}").format(self._vm.app_name))
-        self.setFixedSize(420, 340)
+        self.setFixedSize(480, 440)
         self.setStyleSheet(
             f"background-color: {COLOR_BACKGROUND_SURFACE};"
             f" color: {COLOR_TEXT_PRIMARY};"
@@ -62,11 +68,61 @@ class AboutDialog(QDialog):
         root = QVBoxLayout(self)
         root.setSpacing(12)
 
-        self._buildHeader(root)
-        self._buildSeparator(root)
-        self._buildDetails(root)
-        self._buildRepoLink(root)
+        tabs = QTabWidget()
+        tabs.addTab(self._buildAboutTab(), self.tr("About"))
+        tabs.addTab(self._buildLicensesTab(), self.tr("Licenses"))
+        root.addWidget(tabs)
+
         self._buildButtonBox(root)
+
+    def _buildAboutTab(self) -> QWidget:
+        """About tab — existing application metadata content, unchanged."""
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setSpacing(12)
+
+        self._buildHeader(layout)
+        self._buildSeparator(layout)
+        self._buildDetails(layout)
+        self._buildRepoLink(layout)
+        layout.addStretch()
+
+        return page
+
+    def _buildLicensesTab(self) -> QWidget:
+        """Licenses tab — MIT license and third-party notices, scrollable."""
+        browser = QTextBrowser()
+        browser.setReadOnly(True)
+        # LicensesViewModel.third_party_notices_text already rewrites
+        # THIRD_PARTY_NOTICES.md's repo-relative links to absolute GitHub
+        # URLs (see LicenseDocuments._rewrite_relative_links), so every link
+        # this browser ever renders is external — safe to hand off to
+        # QDesktopServices rather than navigating within the dialog.
+        browser.setOpenExternalLinks(True)
+        browser.setStyleSheet(
+            f"QTextBrowser {{"
+            f"  background-color: {LicensesTabColors.BACKGROUND};"
+            f"  color: {LicensesTabColors.TEXT};"
+            f"  border: 1px solid {LicensesTabColors.BORDER};"
+            f"}}"
+        )
+        browser.setMarkdown(self._composeLicensesMarkdown())
+        return browser
+
+    def _composeLicensesMarkdown(self) -> str:
+        """Combine LICENSE and THIRD_PARTY_NOTICES.md into one markdown doc.
+
+        LICENSE's paragraphs are already blank-line separated, so it reads
+        correctly as plain markdown text and word-wraps in QTextBrowser; a
+        fenced code block was tried first but disabled wrapping and forced
+        an unwanted horizontal scrollbar.
+        """
+        return (
+            "## MIT License\n\n"
+            f"{self._licenses_vm.license_text}\n\n"
+            "---\n\n"
+            f"{self._licenses_vm.third_party_notices_text}"
+        )
 
     def _buildHeader(self, layout: QVBoxLayout) -> None:
         """Icon + title/version row."""
@@ -102,6 +158,7 @@ class AboutDialog(QDialog):
             f"color: {COLOR_TEXT_PRIMARY}; font-size: 13px;"
         )
         titleStack.addWidget(versionLabel)
+        self._buildLicenseLink(titleStack)
         titleStack.addStretch()
 
         row.addLayout(titleStack)
@@ -147,6 +204,16 @@ class AboutDialog(QDialog):
         form.addRow(copyright_label)
 
         layout.addLayout(form)
+
+    def _buildLicenseLink(self, layout: QVBoxLayout) -> None:
+        url = self._vm.license_url
+        link = QLabel(
+            f'<a href="{url}" style="color: {COLOR_ACCENT_LINK};">'
+            f'{self.tr("View License")}</a>'
+        )
+        link.setOpenExternalLinks(True)
+        link.setStyleSheet("font-size: 11px;")
+        layout.addWidget(link)
 
     def _buildRepoLink(self, layout: QVBoxLayout) -> None:
         url = self._vm.repository_url

--- a/tests/test_AboutViewModel.py
+++ b/tests/test_AboutViewModel.py
@@ -1,7 +1,7 @@
 """Tests for AboutViewModel — pure Python, no QApplication required."""
 
 from le_beta_vis.frontend.viewmodels.AboutViewModel import AboutViewModel
-from le_beta_vis.common import APP_VERSION
+from le_beta_vis.common import APP_REPOSITORY_URL, APP_VERSION
 
 
 class TestAboutViewModel:
@@ -28,6 +28,15 @@ class TestAboutViewModel:
 
     def test_repository_url(self) -> None:
         assert "github.com" in self.vm.repository_url
+
+    def test_repository_url_matches_common(self) -> None:
+        assert self.vm.repository_url == APP_REPOSITORY_URL
+
+    def test_repository_blob_base_url(self) -> None:
+        assert self.vm.repository_blob_base_url == f"{APP_REPOSITORY_URL}/blob/main/"
+
+    def test_license_url_points_at_license_file(self) -> None:
+        assert self.vm.license_url == f"{APP_REPOSITORY_URL}/blob/main/LICENSE"
 
     def test_formatted_version_contains_version(self) -> None:
         result = self.vm.formatted_version()

--- a/tests/test_LicenseDocuments.py
+++ b/tests/test_LicenseDocuments.py
@@ -1,0 +1,32 @@
+"""Tests for LicenseDocuments' relative-link rewriting — pure Python, no Qt."""
+
+from le_beta_vis.common.LicenseDocuments import _rewrite_relative_links
+
+_BASE = "https://github.com/OSUCSVisualizationTeam/le-beta-particle-vis-lbnl/blob/main/"
+
+
+class TestRewriteRelativeLinks:
+    def test_relative_path_is_rewritten(self) -> None:
+        result = _rewrite_relative_links("[a](pyproject.toml)", _BASE)
+        assert result == f"[a]({_BASE}pyproject.toml)"
+
+    def test_nested_relative_path_is_rewritten(self) -> None:
+        text = "[x](src/le_beta_vis/export/fonts/LICENSE_DEJAVU)"
+        result = _rewrite_relative_links(text, _BASE)
+        assert result == f"[x]({_BASE}src/le_beta_vis/export/fonts/LICENSE_DEJAVU)"
+
+    def test_absolute_https_link_is_untouched(self) -> None:
+        text = "[a](https://dejavu-fonts.github.io/)"
+        assert _rewrite_relative_links(text, _BASE) == text
+
+    def test_anchor_link_is_untouched(self) -> None:
+        text = "[a](#section)"
+        assert _rewrite_relative_links(text, _BASE) == text
+
+    def test_mailto_link_is_untouched(self) -> None:
+        text = "[a](mailto:foo@example.com)"
+        assert _rewrite_relative_links(text, _BASE) == text
+
+    def test_text_without_links_is_untouched(self) -> None:
+        text = "Plain text, no links here."
+        assert _rewrite_relative_links(text, _BASE) == text

--- a/tests/test_LicensesViewModel.py
+++ b/tests/test_LicensesViewModel.py
@@ -1,0 +1,32 @@
+"""Tests for LicensesViewModel — pure Python, no QApplication required."""
+
+from le_beta_vis.common.LicenseDocuments import _resolve_repo_root_file
+from le_beta_vis.frontend.viewmodels.LicensesViewModel import LicensesViewModel
+
+
+class TestLicensesViewModel:
+    def setup_method(self) -> None:
+        self.vm = LicensesViewModel()
+
+    def test_license_text_contains_mit(self) -> None:
+        assert "MIT License" in self.vm.license_text
+
+    def test_license_text_contains_lbnl_copyright(self) -> None:
+        assert "Lawrence Berkeley National Laboratory" in self.vm.license_text
+
+    def test_third_party_notices_text_contains_header(self) -> None:
+        assert "Third-Party Notices" in self.vm.third_party_notices_text
+
+    def test_third_party_notices_relative_links_are_absolute(self) -> None:
+        text = self.vm.third_party_notices_text
+        assert "](pyproject.toml)" not in text
+        assert (
+            "](https://github.com/OSUCSVisualizationTeam/"
+            "le-beta-particle-vis-lbnl/blob/main/pyproject.toml)" in text
+        )
+
+    def test_license_file_exists_on_disk(self) -> None:
+        assert _resolve_repo_root_file("LICENSE").exists()
+
+    def test_third_party_notices_file_exists_on_disk(self) -> None:
+        assert _resolve_repo_root_file("THIRD_PARTY_NOTICES.md").exists()


### PR DESCRIPTION
Introduce a tabbed interface in the About dialog to display the project's MIT License and third-party notices.

- AboutDialog UI update: Transition from a static layout to a QTabWidget with "About" and "Licenses" tabs. The "Licenses" tab embeds a read-only QTextBrowser displaying combined markdown content for the license and notice files.
- LicenseDocuments utility: Load LICENSE and THIRD_PARTY_NOTICES.md from the installation root or PyInstaller's sys._MEIPASS. Differentiate between development and frozen build structures.
- Markdown link rewriting: Standardize relative links in THIRD_PARTY_NOTICES.md to point to absolute GitHub blob URLs, enabling QTextBrowser to delegate link navigation externally via QDesktopServices.
- Pure Python ViewModels: Introduce LicensesViewModel and expand AboutViewModel without GUI or Qt dependencies, keeping them unit-testable in headless CI environments.
- Packaging updates: Update lbnlvis.spec to include LICENSE and THIRD_PARTY_NOTICES.md, adjust font paths to le_beta_vis/export/fonts, and update pyproject.toml package data to match the path changes.
- Tests: Introduce unit tests for path resolution, link rewriting, and ViewModels in test_LicenseDocuments.py, test_LicensesViewModel.py, and test_AboutViewModel.py.

Resolves #189