### PR TITLE
feat: migrate raw data analysis styles to QSS

### DIFF
--- a/src/le_beta_vis/frontend/theme.py
+++ b/src/le_beta_vis/frontend/theme.py
@@ -14,14 +14,10 @@ COLOR_ACCENT_LINK = "#4fc3f7"
 
 
 class ProgressOverlayColors:
-    """Colors for ProgressOverlay and its subclasses."""
+    """Colors for ProgressOverlay's dim-backdrop paintEvent (not
+    QSS-styleable; card/label/button chrome lives in progress_overlays.qss)."""
 
     DIM_RGBA = (0, 0, 0, 80)
-    CARD_BACKGROUND = "rgba(255, 255, 255, 64)"
-    CARD_TEXT = "#000000"
-    PROGRESS_BACKGROUND = "rgba(0, 0, 0, 40)"
-    PROGRESS_CHUNK = "#3daee9"
-    ACTION_BUTTON_BACKGROUND = "rgba(0, 0, 0, 180)"
 
 
 class EventGridSectionHeaderColors:
@@ -123,12 +119,6 @@ class HUDAnnotationOverlayColors:
     BORDER = "#FFFF00"
 
 
-class RawDataManipulationToolbarColors:
-    """Colors for RawDataManipulationToolbar."""
-
-    HDU_LABEL = "#aaaaaa"
-
-
 class MosaicThumbnailColors:
     """Colors for ThumbnailButton paintEvent overlay."""
 
@@ -137,33 +127,10 @@ class MosaicThumbnailColors:
     LABEL_BACKGROUND_RGBA = (0, 0, 0, 140)
 
 
-class RawClusterLabelingDialogColors:
-    """Colors for the raw-data cluster labeling / training export dialog."""
-
-    CALLOUT_BACKGROUND = "#1a3a1a"
-    CALLOUT_BORDER = "#2e7d32"
-    CALLOUT_TEXT = "#c8e6c9"
-    SUBMIT_BUTTON_BACKGROUND = "#0078d7"
-    SUBMIT_BUTTON_FOREGROUND = "#ffffff"
-    SUBMIT_BUTTON_HOVER = "#005fa3"
-    CANCEL_BUTTON_BACKGROUND = "#3d3d3d"
-    CANCEL_BUTTON_FOREGROUND = "#cccccc"
-    CANCEL_BUTTON_BORDER = "#555555"
-    RESULT_TEXT = "#c8e6c9"
-
-
 class RawClusterClassificationDialogColors:
-    """Colors for the ML classification dialog."""
+    """Colors for the ML classification dialog and other tritium-confidence
+    score labels (also consumed by ClusteredEventWidget)."""
 
-    CALLOUT_BACKGROUND = "#1a2a3a"
-    CALLOUT_BORDER = "#1565c0"
-    CALLOUT_TEXT = "#bbdefb"
-    CLASSIFY_BUTTON_BACKGROUND = "#0078d7"
-    CLASSIFY_BUTTON_FOREGROUND = "#ffffff"
-    CLASSIFY_BUTTON_HOVER = "#005fa3"
-    CANCEL_BUTTON_BACKGROUND = "#3d3d3d"
-    CANCEL_BUTTON_FOREGROUND = "#cccccc"
-    CANCEL_BUTTON_BORDER = "#555555"
     SCORE_LABEL_GOOD = "#81c784"
     SCORE_LABEL_MEDIUM = "#ffb74d"
     SCORE_LABEL_LOW = "#e57373"
@@ -174,13 +141,12 @@ class ClusteredEventWidgetColors:
 
 
 class TooltipStyle:
-    """Shared QToolTip stylesheet snippets.
+    """Shared QToolTip stylesheet snippet.
 
-    ``BODY`` is the property body — usable inside a ``QToolTip { ... }``
-    rule embedded in a widget stylesheet, or inside an HTML
-    ``<span style='...'>`` wrapper for ``QToolTip.showText`` calls.
-    ``QSS`` is the convenience full rule for embedding directly into
-    a widget stylesheet.
+    ``BODY`` is the property body, used inside an HTML
+    ``<span style='...'>`` wrapper for ``QToolTip.showText`` calls
+    (mirrored as a global ``QToolTip { ... }`` rule in base.qss for
+    widget-level tooltips).
 
     ``font-weight: normal`` defeats inheritance from any bold parent
     widget so tooltips render with a consistent weight regardless of
@@ -191,7 +157,6 @@ class TooltipStyle:
         "color: black; background-color: white; padding: 2px;"
         " border: 1px solid #ccc; font-weight: normal;"
     )
-    QSS = f"QToolTip {{ {BODY} }}"
 
 
 class FilterPipelinePanelColors:

--- a/src/le_beta_vis/frontend/views/MosaicView.py
+++ b/src/le_beta_vis/frontend/views/MosaicView.py
@@ -68,37 +68,9 @@ class MosaicView(QWidget):
         self.scrollArea.setWidgetResizable(True)
         self.scrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.scrollArea.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        self.scrollArea.setStyleSheet(
-            """
-            QScrollArea {
-                background-color: #1e1e1e;
-                border: none;
-            }
-            QScrollBar:horizontal {
-                height: 12px;
-                background: transparent;
-                margin: 0px;
-            }
-            QScrollBar::handle:horizontal {
-                background: rgba(100, 100, 100, 165);
-                min-width: 30px;
-                border-radius: 6px;
-                margin: 2px;
-            }
-            QScrollBar::handle:horizontal:hover {
-                background: rgba(150, 150, 150, 200);
-            }
-            QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {
-                width: 0px;
-            }
-            QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {
-                background: transparent;
-            }
-            """
-        )
 
         self.container = QWidget()
-        self.container.setStyleSheet("background-color: #1e1e1e;")
+        self.container.setObjectName("mosaicContainer")
         self.containerLayout = QHBoxLayout(self.container)
         self.containerLayout.setContentsMargins(5, 5, 5, 5)  # Top/Bottom margins
         self.containerLayout.setSpacing(10)
@@ -184,24 +156,6 @@ class MosaicView(QWidget):
 
             btn.setCheckable(True)
             btn.setAutoExclusive(True)  # Only one can be checked
-            btn.setStyleSheet(
-                """
-                QToolButton {
-                    background-color: #333;
-                    color: #ccc;
-                    border: 1px solid #555;
-                    border-radius: 4px;
-                    font-size: 10px;
-                }
-                QToolButton:checked {
-                    background-color: #444;
-                    border: 2px solid #0078d7;
-                }
-                QToolButton:hover {
-                    border: 1px solid #888;
-                }
-            """
-            )
 
             # Use lambda with default arg to capture 'i' correctly
             btn.clicked.connect(lambda checked, idx=i: self.viewModel.selectIndex(idx))

--- a/src/le_beta_vis/frontend/views/raw_data_view/_CenterImageAreaView.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_CenterImageAreaView.py
@@ -19,7 +19,6 @@ from ...viewmodels.RawDataViewModel import RawDataViewModel
 from ...widgets.ClusteringProgressOverlay import ClusteringProgressOverlay
 from ...widgets.HDUVisualizationView import HDUVisualizationView
 from ._RawDataManipulationToolbar import _RawDataManipulationToolbar
-from ._RawDataViewStyle import _Style
 
 
 class _CenterImageAreaView(QWidget):
@@ -79,8 +78,8 @@ class _CenterImageAreaView(QWidget):
 
     def _createStatusBar(self) -> QWidget:
         statusBar = QWidget()
+        statusBar.setObjectName("rawDataStatusBar")
         statusBar.setFixedHeight(24)
-        statusBar.setStyleSheet(_Style.STATUS_BAR)
         statusBarLayout = QHBoxLayout(statusBar)
         statusBarLayout.setContentsMargins(0, 0, 0, 0)
         statusBarLayout.setSpacing(0)
@@ -89,8 +88,8 @@ class _CenterImageAreaView(QWidget):
         statusBarLayout.addWidget(self._statusLabel, 1)
 
         self._hintLabel = QLabel()
+        self._hintLabel.setObjectName("rawDataToolHintLabel")
         self._hintLabel.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
-        self._hintLabel.setStyleSheet("padding-right: 8px;")
         self._hintLabel.setMinimumWidth(220)
         self._hintLabel.setVisible(False)
         statusBarLayout.addWidget(self._hintLabel)

--- a/src/le_beta_vis/frontend/views/raw_data_view/_LeftToolbarView.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_LeftToolbarView.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from PySide6.QtWidgets import QFrame, QVBoxLayout
 
 from ...widgets.VerticalRangeControl import VerticalRangeControl
-from ._RawDataViewStyle import _Style
 
 if TYPE_CHECKING:
     from ...viewmodels.RawDataViewModel import RawDataViewModel
@@ -21,7 +20,6 @@ class _LeftToolbarView(QFrame):
 
     def _initUI(self) -> None:
         self.setFixedWidth(100)
-        self.setStyleSheet(_Style.LEFT_TOOLBAR)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(5, 10, 5, 10)
         layout.setSpacing(0)

--- a/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterClassificationDialog.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterClassificationDialog.py
@@ -21,7 +21,6 @@ from PySide6.QtWidgets import (
 )
 
 from ...fitsconverters import Colormap
-from ...theme import RawClusterClassificationDialogColors as _C
 from ...viewmodels.RawClusterClassificationViewModel import (
     Phase,
     RawClusterClassificationViewModel,
@@ -84,14 +83,7 @@ class _RawClusterClassificationDialog(QDialog):
     def _buildCallout(self, text: str) -> QLabel:
         callout = QLabel(text)
         callout.setWordWrap(True)
-        callout.setStyleSheet(
-            f"background-color: {_C.CALLOUT_BACKGROUND};"
-            f"border: 1px solid {_C.CALLOUT_BORDER};"
-            f"color: {_C.CALLOUT_TEXT};"
-            "border-radius: 4px;"
-            "padding: 8px 10px;"
-            "font-size: 12px;"
-        )
+        callout.setProperty("class", "callout")
         return callout
 
     def _buildPrePage(self) -> QWidget:
@@ -206,34 +198,13 @@ class _RawClusterClassificationDialog(QDialog):
         row.addStretch()
 
         self._cancelBtn = QPushButton(self.tr("Cancel"))
-        self._cancelBtn.setStyleSheet(
-            "QPushButton {"
-            f"  background-color: {_C.CANCEL_BUTTON_BACKGROUND};"
-            f"  color: {_C.CANCEL_BUTTON_FOREGROUND};"
-            f"  border: 1px solid {_C.CANCEL_BUTTON_BORDER};"
-            "  border-radius: 4px;"
-            "  padding: 6px 16px;"
-            "}"
-        )
+        self._cancelBtn.setProperty("styleRole", "secondary")
         self._cancelBtn.clicked.connect(self._onCancelClicked)
         row.addWidget(self._cancelBtn)
         row.addSpacing(8)
 
         self._classifyBtn = QPushButton(self.tr("Classify"))
-        self._classifyBtn.setStyleSheet(
-            "QPushButton {"
-            f"  background-color: {_C.CLASSIFY_BUTTON_BACKGROUND};"
-            f"  color: {_C.CLASSIFY_BUTTON_FOREGROUND};"
-            "  border: none;"
-            "  border-radius: 4px;"
-            "  padding: 6px 16px;"
-            "  font-weight: bold;"
-            "}"
-            "QPushButton:hover {"
-            f"  background-color: {_C.CLASSIFY_BUTTON_HOVER};"
-            "}"
-            "QPushButton:disabled { background-color: #555555; color: #888888; }"
-        )
+        self._classifyBtn.setProperty("styleRole", "primary")
         self._classifyBtn.clicked.connect(self._vm.classify)
         row.addWidget(self._classifyBtn)
 
@@ -319,13 +290,12 @@ class _RawClusterClassificationDialog(QDialog):
                 ("BDT", cluster_scores.bdt),
             ):
                 score_str = f"{val * 100:.0f}%" if val is not None else "?"
-                color = self._score_color(val)
                 lbl = QLabel(
                     self.tr("{model}: <b>{score}</b>").format(
                         model=model, score=score_str
                     )
                 )
-                lbl.setStyleSheet(f"color: {color};")
+                lbl.setProperty("scoreLevel", self._score_level(val))
                 info.addWidget(lbl)
 
             valid = [
@@ -347,15 +317,14 @@ class _RawClusterClassificationDialog(QDialog):
         return row
 
     @staticmethod
-    def _score_color(val: Optional[float]) -> str:
-        from le_beta_vis.frontend.theme import RawClusterClassificationDialogColors
+    def _score_level(val: Optional[float]) -> str:
         if val is None:
-            return RawClusterClassificationDialogColors.SCORE_LABEL_LOW
+            return "low"
         if val >= 0.75:
-            return RawClusterClassificationDialogColors.SCORE_LABEL_GOOD
+            return "good"
         if val >= 0.5:
-            return RawClusterClassificationDialogColors.SCORE_LABEL_MEDIUM
-        return RawClusterClassificationDialogColors.SCORE_LABEL_LOW
+            return "medium"
+        return "low"
 
     @Slot()
     def _onCancelClicked(self) -> None:

--- a/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterLabelingDialog.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_RawClusterLabelingDialog.py
@@ -23,7 +23,6 @@ from PySide6.QtWidgets import (
 )
 
 from ...fitsconverters import Colormap
-from ...theme import RawClusterLabelingDialogColors as _C
 from ...viewmodels.RawClusterLabelingViewModel import Phase, RawClusterLabelingViewModel
 from ...widgets.ArcSpinner import ArcSpinner
 from ...widgets.EnergyClusterWidget import EnergyClusterWidget
@@ -99,14 +98,7 @@ class _RawClusterLabelingDialog(QDialog):
             )
         )
         callout.setWordWrap(True)
-        callout.setStyleSheet(
-            f"background-color: {_C.CALLOUT_BACKGROUND};"
-            f"border: 1px solid {_C.CALLOUT_BORDER};"
-            f"color: {_C.CALLOUT_TEXT};"
-            "border-radius: 4px;"
-            "padding: 8px 10px;"
-            "font-size: 12px;"
-        )
+        callout.setProperty("class", "callout")
         return callout
 
     def _buildLabelAllRow(self) -> QWidget:
@@ -213,34 +205,13 @@ class _RawClusterLabelingDialog(QDialog):
         row.addStretch()
 
         self._cancelBtn = QPushButton(self.tr("Cancel"))
-        self._cancelBtn.setStyleSheet(
-            "QPushButton {"
-            f"  background-color: {_C.CANCEL_BUTTON_BACKGROUND};"
-            f"  color: {_C.CANCEL_BUTTON_FOREGROUND};"
-            f"  border: 1px solid {_C.CANCEL_BUTTON_BORDER};"
-            "  border-radius: 4px;"
-            "  padding: 6px 16px;"
-            "}"
-        )
+        self._cancelBtn.setProperty("styleRole", "secondary")
         self._cancelBtn.clicked.connect(self.reject)
         row.addWidget(self._cancelBtn)
         row.addSpacing(8)
 
         self._submitBtn = QPushButton(self.tr("Add to Training Set"))
-        self._submitBtn.setStyleSheet(
-            "QPushButton {"
-            f"  background-color: {_C.SUBMIT_BUTTON_BACKGROUND};"
-            f"  color: {_C.SUBMIT_BUTTON_FOREGROUND};"
-            "  border: none;"
-            "  border-radius: 4px;"
-            "  padding: 6px 16px;"
-            "  font-weight: bold;"
-            "}"
-            "QPushButton:hover {"
-            f"  background-color: {_C.SUBMIT_BUTTON_HOVER};"
-            "}"
-            "QPushButton:disabled { background-color: #555555; color: #888888; }"
-        )
+        self._submitBtn.setProperty("styleRole", "primary")
         self._submitBtn.setEnabled(False)
         self._submitBtn.clicked.connect(self._vm.submit)
         row.addWidget(self._submitBtn)

--- a/src/le_beta_vis/frontend/views/raw_data_view/_RawDataManipulationToolbar.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_RawDataManipulationToolbar.py
@@ -16,26 +16,7 @@ from PySide6.QtWidgets import (
     QToolButton,
 )
 
-from ...theme import RawDataManipulationToolbarColors, TooltipStyle
 from ...viewmodels.RawDataViewModel import ActiveTool, RawDataViewModel
-
-
-class _Style:
-    TOOLBAR = "background-color: #2d2d2d; border-bottom: 1px solid #3d3d3d;"
-    BUTTON = "QToolButton { font-weight: bold; color: #ffffff; }" f"{TooltipStyle.QSS}"
-    DIVIDER = "background-color: #555555;"
-    ZOOM_IN = (
-        "QToolButton { font-size: 20px; font-weight: bold; color: #ffffff; }"
-        f"{TooltipStyle.QSS}"
-    )
-    ZOOM_OUT = (
-        "QToolButton { font-size: 20px; font-weight: bold; color: #ffffff; }"
-        f"{TooltipStyle.QSS}"
-    )
-    HDU_LABEL = (
-        f"color: {RawDataManipulationToolbarColors.HDU_LABEL};"
-        " font-size: 11px; padding-left: 8px; font-weight: bold;"
-    )
 
 
 class _RawDataManipulationToolbar(QFrame):
@@ -49,7 +30,6 @@ class _RawDataManipulationToolbar(QFrame):
 
     def _setupUI(self) -> None:
         self.setFixedHeight(46)
-        self.setStyleSheet(_Style.TOOLBAR)
         layout = QHBoxLayout(self)
         layout.setContentsMargins(8, 3, 8, 3)
         layout.setSpacing(4)
@@ -70,7 +50,6 @@ class _RawDataManipulationToolbar(QFrame):
         self.btnBoxSelect.setCheckable(True)
         self.btnBoxSelect.setChecked(True)
         self.btnBoxSelect.setFixedSize(btn_size)
-        self.btnBoxSelect.setStyleSheet(_Style.BUTTON)
         self.btnBoxSelect.clicked.connect(
             lambda: self._viewModel.setActiveTool(ActiveTool.BOX_SELECT)
         )
@@ -82,7 +61,6 @@ class _RawDataManipulationToolbar(QFrame):
         self.btnMagnifier.setToolTip(self.tr("Magnifier: Inspect pixels in detail"))
         self.btnMagnifier.setCheckable(True)
         self.btnMagnifier.setFixedSize(btn_size)
-        self.btnMagnifier.setStyleSheet(_Style.BUTTON)
         self.btnMagnifier.clicked.connect(
             lambda: self._viewModel.setActiveTool(ActiveTool.MAGNIFIER)
         )
@@ -96,7 +74,7 @@ class _RawDataManipulationToolbar(QFrame):
         sep = QFrame()
         sep.setFrameShape(QFrame.VLine)
         sep.setFrameShadow(QFrame.Sunken)
-        sep.setStyleSheet(_Style.DIVIDER)
+        sep.setObjectName("toolbarDivider")
         sep.setFixedHeight(28)
         layout.addWidget(sep)
 
@@ -104,7 +82,7 @@ class _RawDataManipulationToolbar(QFrame):
         self.btnZoomIn.setText("+")
         self.btnZoomIn.setToolTip(self.tr("Zoom In"))
         self.btnZoomIn.setFixedSize(btn_size)
-        self.btnZoomIn.setStyleSheet(_Style.ZOOM_IN)
+        self.btnZoomIn.setProperty("class", "zoomButton")
         self.btnZoomIn.clicked.connect(self._viewModel.zoomIn)
         layout.addWidget(self.btnZoomIn)
 
@@ -112,7 +90,6 @@ class _RawDataManipulationToolbar(QFrame):
         self.btnZoomReset.setText("1x")
         self.btnZoomReset.setToolTip(self.tr("Reset Zoom (1:1)"))
         self.btnZoomReset.setFixedSize(btn_size)
-        self.btnZoomReset.setStyleSheet(_Style.BUTTON)
         self.btnZoomReset.clicked.connect(self._viewModel.resetZoom)
         layout.addWidget(self.btnZoomReset)
 
@@ -120,14 +97,14 @@ class _RawDataManipulationToolbar(QFrame):
         self.btnZoomOut.setText("-")
         self.btnZoomOut.setToolTip(self.tr("Zoom Out"))
         self.btnZoomOut.setFixedSize(btn_size)
-        self.btnZoomOut.setStyleSheet(_Style.ZOOM_OUT)
+        self.btnZoomOut.setProperty("class", "zoomButton")
         self.btnZoomOut.clicked.connect(self._viewModel.zoomOut)
         layout.addWidget(self.btnZoomOut)
 
     def _createHDULabel(self, layout: QHBoxLayout) -> None:
         layout.addStretch()
         self.selectedHDULabel = QLabel()
-        self.selectedHDULabel.setStyleSheet(_Style.HDU_LABEL)
+        self.selectedHDULabel.setObjectName("rawDataToolbarHduLabel")
         layout.addWidget(self.selectedHDULabel)
 
     def _createMagnifierIcon(self) -> QIcon:

--- a/src/le_beta_vis/frontend/views/raw_data_view/_RawDataViewStyle.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_RawDataViewStyle.py
@@ -1,6 +1,0 @@
-class _Style:
-    LEFT_TOOLBAR = "background-color: #2d2d2d; border-right: 1px solid #3d3d3d;"
-    STATUS_BAR = (
-        "background-color: #1e1e1e; color: #cccccc;"
-        " font-size: 12px; padding-left: 8px;"
-    )

--- a/src/le_beta_vis/frontend/widgets/ClusteringProgressOverlay.py
+++ b/src/le_beta_vis/frontend/widgets/ClusteringProgressOverlay.py
@@ -5,7 +5,6 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from ..theme import ProgressOverlayColors as _C
 from .ProgressOverlay import ProgressOverlay
 
 
@@ -28,11 +27,6 @@ class ClusteringProgressOverlay(ProgressOverlay):
         btn_row.setAlignment(Qt.AlignCenter)
         self._cancelBtn = QPushButton(self.tr("Cancel"))
         self._cancelBtn.setFixedWidth(80)
-        self._cancelBtn.setStyleSheet(
-            f"background-color: {_C.ACTION_BUTTON_BACKGROUND};"
-            " color: #ffffff; border-radius: 4px;"
-            " padding: 4px 8px;"
-        )
         self._cancelBtn.clicked.connect(self.cancelRequested.emit)
         btn_row.addWidget(self._cancelBtn)
         self._accessoryLayout().addLayout(btn_row)

--- a/src/le_beta_vis/frontend/widgets/HDUVisualizationHUDWidget.py
+++ b/src/le_beta_vis/frontend/widgets/HDUVisualizationHUDWidget.py
@@ -56,7 +56,6 @@ class HDUVisualizationHUDWidget(QGraphicsView):
 
         self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
         self.setAttribute(Qt.WA_TranslucentBackground, True)
-        self.setStyleSheet("background: transparent; border: 0px;")
         self.setFrameShape(QGraphicsView.NoFrame)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)

--- a/src/le_beta_vis/frontend/widgets/HDUVisualizationView.py
+++ b/src/le_beta_vis/frontend/widgets/HDUVisualizationView.py
@@ -16,54 +16,6 @@ from .MagnifierGraphicsItem import MagnifierGraphicsItem
 from ..viewmodels.RawDataViewModel import RawDataViewModel
 
 
-_GRAPHICS_VIEW_STYLE = """
-    QGraphicsView {
-        background-color: #000;
-        border: none;
-    }
-    QScrollBar:vertical {
-        width: 12px;
-        background: transparent;
-        margin: 0px;
-    }
-    QScrollBar::handle:vertical {
-        background: rgba(100, 100, 100, 165);
-        min-height: 30px;
-        border-radius: 6px;
-        margin: 2px;
-    }
-    QScrollBar::handle:vertical:hover {
-        background: rgba(150, 150, 150, 200);
-    }
-    QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
-        height: 0px;
-    }
-    QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
-        background: transparent;
-    }
-    QScrollBar:horizontal {
-        height: 12px;
-        background: transparent;
-        margin: 0px;
-    }
-    QScrollBar::handle:horizontal {
-        background: rgba(100, 100, 100, 165);
-        min-width: 30px;
-        border-radius: 6px;
-        margin: 2px;
-    }
-    QScrollBar::handle:horizontal:hover {
-        background: rgba(150, 150, 150, 200);
-    }
-    QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {
-        width: 0px;
-    }
-    QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {
-        background: transparent;
-    }
-"""
-
-
 class HDUVisualizationView(QWidget):
     """Visualization surface for the active HDU.
 
@@ -110,7 +62,6 @@ class HDUVisualizationView(QWidget):
         self.scene = QGraphicsScene()
         self.graphicsView = CaptureGraphicsView()
         self.graphicsView.setScene(self.scene)
-        self.graphicsView.setStyleSheet(_GRAPHICS_VIEW_STYLE)
         self.graphicsView.setAlignment(Qt.AlignCenter)
 
         self.pixmapItem = QGraphicsPixmapItem()

--- a/src/le_beta_vis/frontend/widgets/InteractiveHistogramWidget.py
+++ b/src/le_beta_vis/frontend/widgets/InteractiveHistogramWidget.py
@@ -37,17 +37,6 @@ _TOOLTIP_OFFSET_X = 12
 _TOOLTIP_OFFSET_Y = -28
 
 
-class _Style:
-    PLACEHOLDER = "color: #999999; font-style: italic; padding: 20px;"
-    TOOLTIP = (
-        "background-color: rgba(44,62,80,220);"
-        "color: #ffffff;"
-        "padding: 4px 8px;"
-        "border-radius: 3px;"
-        "font-size: 11px;"
-    )
-
-
 _SUPERSCRIPTS = str.maketrans("0123456789-", "⁰¹²³⁴⁵⁶⁷⁸⁹⁻")
 
 
@@ -140,7 +129,7 @@ class InteractiveHistogramWidget(QWidget):
 
         # Page 0: placeholder label
         self._placeholder = QLabel(self.tr("Draw an ROI to see energy distribution"))
-        self._placeholder.setStyleSheet(_Style.PLACEHOLDER)
+        self._placeholder.setProperty("class", "placeholder")
         self._placeholder.setAlignment(Qt.AlignCenter)
         self._placeholder.setWordWrap(True)
         self._placeholder.setSizePolicy(
@@ -166,7 +155,7 @@ class InteractiveHistogramWidget(QWidget):
 
         # Hover tooltip overlay
         self._tooltip = QLabel(self._plot)
-        self._tooltip.setStyleSheet(_Style.TOOLTIP)
+        self._tooltip.setProperty("class", "histogramTooltip")
         self._tooltip.setVisible(False)
         self._tooltip.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
 

--- a/src/le_beta_vis/frontend/widgets/ProgressOverlay.py
+++ b/src/le_beta_vis/frontend/widgets/ProgressOverlay.py
@@ -47,11 +47,8 @@ class ProgressOverlay(QWidget):
     def _buildCard(self) -> QWidget:
         """Builds the centered card containing all overlay content."""
         card = QWidget(self)
+        card.setObjectName("progressOverlayCard")
         card.setMinimumSize(200, 140)
-        card.setStyleSheet(
-            f"background-color: {_C.CARD_BACKGROUND};"
-            " border-radius: 12px;"
-        )
 
         layout = QVBoxLayout(card)
         layout.setAlignment(Qt.AlignCenter)
@@ -76,11 +73,8 @@ class ProgressOverlay(QWidget):
 
     def _buildHeaderLabel(self, parent: QWidget) -> QLabel:
         label = QLabel(self.tr(self._title), parent)
+        label.setObjectName("progressOverlayHeaderLabel")
         label.setFixedHeight(24)
-        label.setStyleSheet(
-            f"background: transparent; color: {_C.CARD_TEXT};"
-            " font-size: 16px;"
-        )
         label.setAlignment(Qt.AlignCenter)
         return label
 
@@ -90,22 +84,12 @@ class ProgressOverlay(QWidget):
         bar.setValue(0)
         bar.setFixedWidth(160)
         bar.setFixedHeight(20)
-        bar.setStyleSheet(
-            f"QProgressBar {{ background: {_C.PROGRESS_BACKGROUND};"
-            " border-radius: 4px; text-align: center;"
-            f" color: {_C.CARD_TEXT}; }}"
-            f" QProgressBar::chunk {{ background: {_C.PROGRESS_CHUNK};"
-            " border-radius: 4px; }"
-        )
         bar.hide()
         return bar
 
     def _buildMessageLabel(self, parent: QWidget) -> QLabel:
         label = QLabel("", parent)
-        label.setStyleSheet(
-            f"background: transparent; color: {_C.CARD_TEXT};"
-            " font-size: 12px;"
-        )
+        label.setObjectName("progressOverlayMessageLabel")
         label.setAlignment(Qt.AlignCenter)
         label.setWordWrap(True)
         label.hide()

--- a/src/le_beta_vis/frontend/widgets/VerticalRangeControl.py
+++ b/src/le_beta_vis/frontend/widgets/VerticalRangeControl.py
@@ -19,57 +19,30 @@ from le_beta_vis.frontend.theme import TooltipStyle
 logger = logging.getLogger(__name__)
 
 
-# Private namespace for widget styles
-class _Style:
-    SLIDER = """
-        QRangeSlider {
-            background: transparent;
-        }
-        QRangeSlider::groove:vertical {
-            background: transparent;
-            width: 80px;
-        }
-        QRangeSlider::handle:vertical {
-            background: rgba(255, 255, 255, 150);
-            border: 1px solid #ffffff;
-            border-radius: 0px;
-            height: 4px;
-            width: 80px;
-        }
-        QRangeSlider::sub-page:vertical {
-            background: transparent;
-        }
-    """
-    SPINBOX = """
-        QDoubleSpinBox {
-            background-color: #3d3d3d;
-            color: #eeeeee;
-            border: 1px solid #555555;
-            border-radius: 3px;
-            padding: 2px;
-        }
-        QDoubleSpinBox:focus {
-            border: 1px solid #0078d7;
-        }
-    """
-    LABEL = "color: #eeeeee; font-size: 10px; font-weight: bold;"
-    AUTO_RANGE_BUTTON = f"""
-        QPushButton {{
-            background-color: #3d3d3d;
-            color: #eeeeee;
-            border: 1px solid #555555;
-            border-radius: 3px;
-            padding: 3px 6px;
-            font-size: 10px;
-        }}
-        QPushButton:hover {{
-            background-color: #4a4a4a;
-        }}
-        QPushButton:pressed {{
-            background-color: #2d2d2d;
-        }}
-        {TooltipStyle.QSS}
-    """
+# superqt.QRangeSlider pseudo-state styling — sanctioned exception to the
+# QSS-only rule: this groove/handle/sub-page geometry is tightly coupled to
+# this widget's 80px vertical slider-over-gradient layout and isn't reused
+# anywhere else, so it stays a direct setStyleSheet call rather than a QSS
+# rule.
+_SLIDER_STYLESHEET = """
+    QRangeSlider {
+        background: transparent;
+    }
+    QRangeSlider::groove:vertical {
+        background: transparent;
+        width: 80px;
+    }
+    QRangeSlider::handle:vertical {
+        background: rgba(255, 255, 255, 150);
+        border: 1px solid #ffffff;
+        border-radius: 0px;
+        height: 4px;
+        width: 80px;
+    }
+    QRangeSlider::sub-page:vertical {
+        background: transparent;
+    }
+"""
 
 
 class GradientBar(QLabel):
@@ -169,12 +142,12 @@ class VerticalRangeControl(QWidget):
         """Initializes the absolute range labels."""
         self.lblAbsMax = QLabel(f"{self.tr('Max:')} {self._formatLabel(self._abs_max)}")
         self.lblAbsMax.setAlignment(Qt.AlignCenter)
-        self.lblAbsMax.setStyleSheet(_Style.LABEL)
+        self.lblAbsMax.setProperty("class", "rangeAbsLabel")
         self.lblAbsMax.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
 
         self.lblAbsMin = QLabel(f"{self.tr('Min:')} {self._formatLabel(self._abs_min)}")
         self.lblAbsMin.setAlignment(Qt.AlignCenter)
-        self.lblAbsMin.setStyleSheet(_Style.LABEL)
+        self.lblAbsMin.setProperty("class", "rangeAbsLabel")
         self.lblAbsMin.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
 
     def _setupSpinBoxes(self):
@@ -185,7 +158,6 @@ class VerticalRangeControl(QWidget):
         self.spinMax.setRange(self._abs_min, self._abs_max)
         self.spinMax.setDecimals(2)
         self.spinMax.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
-        self.spinMax.setStyleSheet(_Style.SPINBOX)
         self.spinMax.editingFinished.connect(self._onSpinBoxChanged)
 
         self.spinMin = QDoubleSpinBox()
@@ -194,7 +166,6 @@ class VerticalRangeControl(QWidget):
         self.spinMin.setRange(self._abs_min, self._abs_max)
         self.spinMin.setDecimals(2)
         self.spinMin.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
-        self.spinMin.setStyleSheet(_Style.SPINBOX)
         self.spinMin.editingFinished.connect(self._onSpinBoxChanged)
 
     def _setupSliderStack(self):
@@ -211,7 +182,7 @@ class VerticalRangeControl(QWidget):
 
         self.slider = QRangeSlider(Qt.Vertical)
         self.slider.setRange(0, self._steps)
-        self.slider.setStyleSheet(_Style.SLIDER)
+        self.slider.setStyleSheet(_SLIDER_STYLESHEET)
         self.slider.setMouseTracking(True)
         self.slider.installEventFilter(self)
         self.slider.valueChanged.connect(self._onSliderChanged)
@@ -225,7 +196,7 @@ class VerticalRangeControl(QWidget):
         self.btnAutoRange.setToolTip(
             self.tr("Reset range to cover the full data extent")
         )
-        self.btnAutoRange.setStyleSheet(_Style.AUTO_RANGE_BUTTON)
+        self.btnAutoRange.setProperty("styleRole", "secondary")
         self.btnAutoRange.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
         self.btnAutoRange.clicked.connect(self.resetToFullRange)
 

--- a/src/le_beta_vis/resources/qss/dark/hdu_visualization.qss
+++ b/src/le_beta_vis/resources/qss/dark/hdu_visualization.qss
@@ -1,0 +1,31 @@
+/* HDUVisualizationView — fixed-dark canvas regardless of OS theme (see
+   raw_data_view.qss note on the toolbar framing it); horizontal scrollbar
+   rule is shared with MosaicView in raw_data_view.qss, this file only
+   carries the vertical-only variant. */
+HDUVisualizationView CaptureGraphicsView {
+    background-color: #000;
+    border: none;
+}
+HDUVisualizationView CaptureGraphicsView QScrollBar:vertical {
+    width: 12px;
+    background: transparent;
+    margin: 0px;
+}
+HDUVisualizationView CaptureGraphicsView QScrollBar::handle:vertical {
+    background: rgba(100, 100, 100, 165);
+    min-height: 30px;
+    border-radius: 6px;
+    margin: 2px;
+}
+HDUVisualizationView CaptureGraphicsView QScrollBar::handle:vertical:hover {
+    background: rgba(150, 150, 150, 200);
+}
+HDUVisualizationView CaptureGraphicsView QScrollBar::add-line:vertical,
+HDUVisualizationView CaptureGraphicsView QScrollBar::sub-line:vertical { height: 0px; }
+HDUVisualizationView CaptureGraphicsView QScrollBar::add-page:vertical,
+HDUVisualizationView CaptureGraphicsView QScrollBar::sub-page:vertical { background: transparent; }
+
+/* HDUVisualizationHUDWidget — must stay fully transparent (click-through
+   overlay); WA_TranslucentBackground + setBackgroundBrush(Qt.NoBrush) stay
+   in Python since they're widget attributes, not stylesheet-driven. */
+HDUVisualizationHUDWidget { background: transparent; border: 0px; }

--- a/src/le_beta_vis/resources/qss/dark/progress_overlays.qss
+++ b/src/le_beta_vis/resources/qss/dark/progress_overlays.qss
@@ -1,0 +1,36 @@
+/* ProgressOverlay — dims to black via paintEvent (theme.ProgressOverlayColors.DIM_RGBA,
+   not QSS-styleable); card/label/button chrome below is theme-invariant by design,
+   duplicated identically in light/progress_overlays.qss per the skill's file-split
+   convention rather than moved to base.qss. */
+ProgressOverlay QWidget#progressOverlayCard {
+    background-color: rgba(255, 255, 255, 64);
+    border-radius: 12px;
+}
+ProgressOverlay QLabel#progressOverlayHeaderLabel {
+    background: transparent;
+    color: #000000;
+    font-size: 16px;
+}
+ProgressOverlay QProgressBar {
+    background: rgba(0, 0, 0, 40);
+    border-radius: 4px;
+    text-align: center;
+    color: #000000;
+}
+ProgressOverlay QProgressBar::chunk {
+    background: #3daee9;
+    border-radius: 4px;
+}
+ProgressOverlay QLabel#progressOverlayMessageLabel {
+    background: transparent;
+    color: #000000;
+    font-size: 12px;
+}
+
+/* ClusteringProgressOverlay */
+ClusteringProgressOverlay QPushButton {
+    background-color: rgba(0, 0, 0, 180);
+    color: #ffffff;
+    border-radius: 4px;
+    padding: 4px 8px;
+}

--- a/src/le_beta_vis/resources/qss/dark/raw_cluster_dialogs.qss
+++ b/src/le_beta_vis/resources/qss/dark/raw_cluster_dialogs.qss
@@ -1,0 +1,19 @@
+/* _RawClusterClassificationDialog */
+_RawClusterClassificationDialog QLabel[class="callout"] {
+    background-color: #1a2a3a;
+    border: 1px solid #1565c0;
+    color: #bbdefb;
+    border-radius: 4px;
+    padding: 8px 10px;
+    font-size: 12px;
+}
+
+/* _RawClusterLabelingDialog */
+_RawClusterLabelingDialog QLabel[class="callout"] {
+    background-color: #1a3a1a;
+    border: 1px solid #2e7d32;
+    color: #c8e6c9;
+    border-radius: 4px;
+    padding: 8px 10px;
+    font-size: 12px;
+}

--- a/src/le_beta_vis/resources/qss/dark/raw_data_view.qss
+++ b/src/le_beta_vis/resources/qss/dark/raw_data_view.qss
@@ -1,0 +1,107 @@
+/* MosaicView — thumbnail strip stays a fixed dark image-viewing surface
+   regardless of OS theme (mirrors HDUVisualizationView's canvas), so this
+   file's content is identical in light/raw_data_view.qss. */
+MosaicView QScrollArea {
+    background-color: #1e1e1e;
+    border: none;
+}
+MosaicView QWidget#mosaicContainer { background-color: #1e1e1e; }
+
+/* Horizontal scrollbar — shared with HDUVisualizationView's CaptureGraphicsView
+   (see hdu_visualization.qss for its vertical-only counterpart) so the two
+   near-identical rules don't drift apart as separate copies. */
+MosaicView QScrollBar:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar:horizontal {
+    height: 12px;
+    background: transparent;
+    margin: 0px;
+}
+MosaicView QScrollBar::handle:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar::handle:horizontal {
+    background: rgba(100, 100, 100, 165);
+    min-width: 30px;
+    border-radius: 6px;
+    margin: 2px;
+}
+MosaicView QScrollBar::handle:horizontal:hover,
+HDUVisualizationView CaptureGraphicsView QScrollBar::handle:horizontal:hover {
+    background: rgba(150, 150, 150, 200);
+}
+MosaicView QScrollBar::add-line:horizontal,
+MosaicView QScrollBar::sub-line:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar::add-line:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar::sub-line:horizontal { width: 0px; }
+MosaicView QScrollBar::add-page:horizontal,
+MosaicView QScrollBar::sub-page:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar::add-page:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar::sub-page:horizontal { background: transparent; }
+
+/* ThumbnailButton */
+ThumbnailButton {
+    background-color: #333;
+    color: #ccc;
+    border: 1px solid #555;
+    border-radius: 4px;
+    font-size: 10px;
+}
+ThumbnailButton:checked {
+    background-color: #444;
+    border: 2px solid #0078d7;
+}
+ThumbnailButton:hover { border: 1px solid #888; }
+
+/* _LeftToolbarView, _CenterImageAreaView, _RawDataManipulationToolbar —
+   fixed-dark chrome framing the image canvas. The toolbar's icons/"+"/"-"/
+   "1x" text are painted in hardcoded white ink (see _createMagnifierIcon /
+   _createBoxSelectIcon), so this area stays dark regardless of OS theme
+   rather than adapting like the right sidebar/dialogs — a light background
+   here would make the white icon ink invisible. */
+_LeftToolbarView { background-color: #2d2d2d; border-right: 1px solid #3d3d3d; }
+
+_CenterImageAreaView QWidget#rawDataStatusBar {
+    background-color: #1e1e1e;
+    color: #cccccc;
+    font-size: 12px;
+    padding-left: 8px;
+}
+_CenterImageAreaView QLabel#rawDataToolHintLabel { padding-right: 8px; }
+
+_RawDataManipulationToolbar {
+    background-color: #2d2d2d;
+    border-bottom: 1px solid #3d3d3d;
+}
+_RawDataManipulationToolbar QToolButton { font-weight: bold; color: #ffffff; }
+_RawDataManipulationToolbar QToolButton[class="zoomButton"] { font-size: 20px; }
+_RawDataManipulationToolbar QFrame#toolbarDivider { background-color: #555555; }
+_RawDataManipulationToolbar QLabel#rawDataToolbarHduLabel {
+    color: #aaaaaa;
+    font-size: 11px;
+    padding-left: 8px;
+    font-weight: bold;
+}
+
+/* VerticalRangeControl — QRangeSlider pseudo-states stay a direct Python
+   setStyleSheet (see _SLIDER_STYLESHEET); QDoubleSpinBox styling dropped
+   entirely (redundant with controls.qss's shared form-input rule). */
+VerticalRangeControl QLabel[class="rangeAbsLabel"] {
+    color: #eeeeee;
+    font-size: 10px;
+    font-weight: bold;
+}
+
+/* InteractiveHistogramWidget — placeholder text and the custom floating
+   tooltip (a QLabel, not a native QToolTip) stay fixed-dark like the rest
+   of this control surface; pyqtgraph plot theming is set at runtime via
+   setTheme() and is not QSS-styleable. */
+InteractiveHistogramWidget QLabel[class="placeholder"] {
+    color: #999999;
+    font-style: italic;
+    padding: 20px;
+}
+InteractiveHistogramWidget QLabel[class="histogramTooltip"] {
+    background-color: rgba(44, 62, 80, 220);
+    color: #ffffff;
+    padding: 4px 8px;
+    border-radius: 3px;
+    font-size: 11px;
+}

--- a/src/le_beta_vis/resources/qss/light/hdu_visualization.qss
+++ b/src/le_beta_vis/resources/qss/light/hdu_visualization.qss
@@ -1,0 +1,29 @@
+/* HDUVisualizationView — see dark/hdu_visualization.qss: fixed-dark canvas
+   regardless of OS theme, so values here are identical to the dark variant. */
+HDUVisualizationView CaptureGraphicsView {
+    background-color: #000;
+    border: none;
+}
+HDUVisualizationView CaptureGraphicsView QScrollBar:vertical {
+    width: 12px;
+    background: transparent;
+    margin: 0px;
+}
+HDUVisualizationView CaptureGraphicsView QScrollBar::handle:vertical {
+    background: rgba(100, 100, 100, 165);
+    min-height: 30px;
+    border-radius: 6px;
+    margin: 2px;
+}
+HDUVisualizationView CaptureGraphicsView QScrollBar::handle:vertical:hover {
+    background: rgba(150, 150, 150, 200);
+}
+HDUVisualizationView CaptureGraphicsView QScrollBar::add-line:vertical,
+HDUVisualizationView CaptureGraphicsView QScrollBar::sub-line:vertical { height: 0px; }
+HDUVisualizationView CaptureGraphicsView QScrollBar::add-page:vertical,
+HDUVisualizationView CaptureGraphicsView QScrollBar::sub-page:vertical { background: transparent; }
+
+/* HDUVisualizationHUDWidget — must stay fully transparent (click-through
+   overlay); WA_TranslucentBackground + setBackgroundBrush(Qt.NoBrush) stay
+   in Python since they're widget attributes, not stylesheet-driven. */
+HDUVisualizationHUDWidget { background: transparent; border: 0px; }

--- a/src/le_beta_vis/resources/qss/light/progress_overlays.qss
+++ b/src/le_beta_vis/resources/qss/light/progress_overlays.qss
@@ -1,0 +1,35 @@
+/* ProgressOverlay — see dark/progress_overlays.qss: theme-invariant by design
+   (always dims to black via paintEvent, translucent white card on top), so
+   values here are identical to the dark variant. */
+ProgressOverlay QWidget#progressOverlayCard {
+    background-color: rgba(255, 255, 255, 64);
+    border-radius: 12px;
+}
+ProgressOverlay QLabel#progressOverlayHeaderLabel {
+    background: transparent;
+    color: #000000;
+    font-size: 16px;
+}
+ProgressOverlay QProgressBar {
+    background: rgba(0, 0, 0, 40);
+    border-radius: 4px;
+    text-align: center;
+    color: #000000;
+}
+ProgressOverlay QProgressBar::chunk {
+    background: #3daee9;
+    border-radius: 4px;
+}
+ProgressOverlay QLabel#progressOverlayMessageLabel {
+    background: transparent;
+    color: #000000;
+    font-size: 12px;
+}
+
+/* ClusteringProgressOverlay */
+ClusteringProgressOverlay QPushButton {
+    background-color: rgba(0, 0, 0, 180);
+    color: #ffffff;
+    border-radius: 4px;
+    padding: 4px 8px;
+}

--- a/src/le_beta_vis/resources/qss/light/raw_cluster_dialogs.qss
+++ b/src/le_beta_vis/resources/qss/light/raw_cluster_dialogs.qss
@@ -1,0 +1,19 @@
+/* _RawClusterClassificationDialog */
+_RawClusterClassificationDialog QLabel[class="callout"] {
+    background-color: #e3f2fd;
+    border: 1px solid #1565c0;
+    color: #0d47a1;
+    border-radius: 4px;
+    padding: 8px 10px;
+    font-size: 12px;
+}
+
+/* _RawClusterLabelingDialog */
+_RawClusterLabelingDialog QLabel[class="callout"] {
+    background-color: #e8f5e9;
+    border: 1px solid #2e7d32;
+    color: #1b5e20;
+    border-radius: 4px;
+    padding: 8px 10px;
+    font-size: 12px;
+}

--- a/src/le_beta_vis/resources/qss/light/raw_data_view.qss
+++ b/src/le_beta_vis/resources/qss/light/raw_data_view.qss
@@ -1,0 +1,100 @@
+/* MosaicView — see dark/raw_data_view.qss: thumbnail strip stays a fixed
+   dark image-viewing surface regardless of OS theme, so values here are
+   identical to the dark variant. */
+MosaicView QScrollArea {
+    background-color: #1e1e1e;
+    border: none;
+}
+MosaicView QWidget#mosaicContainer { background-color: #1e1e1e; }
+
+/* Horizontal scrollbar — see dark/raw_data_view.qss: shared with
+   HDUVisualizationView's CaptureGraphicsView. */
+MosaicView QScrollBar:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar:horizontal {
+    height: 12px;
+    background: transparent;
+    margin: 0px;
+}
+MosaicView QScrollBar::handle:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar::handle:horizontal {
+    background: rgba(100, 100, 100, 165);
+    min-width: 30px;
+    border-radius: 6px;
+    margin: 2px;
+}
+MosaicView QScrollBar::handle:horizontal:hover,
+HDUVisualizationView CaptureGraphicsView QScrollBar::handle:horizontal:hover {
+    background: rgba(150, 150, 150, 200);
+}
+MosaicView QScrollBar::add-line:horizontal,
+MosaicView QScrollBar::sub-line:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar::add-line:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar::sub-line:horizontal { width: 0px; }
+MosaicView QScrollBar::add-page:horizontal,
+MosaicView QScrollBar::sub-page:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar::add-page:horizontal,
+HDUVisualizationView CaptureGraphicsView QScrollBar::sub-page:horizontal { background: transparent; }
+
+/* ThumbnailButton */
+ThumbnailButton {
+    background-color: #333;
+    color: #ccc;
+    border: 1px solid #555;
+    border-radius: 4px;
+    font-size: 10px;
+}
+ThumbnailButton:checked {
+    background-color: #444;
+    border: 2px solid #0078d7;
+}
+ThumbnailButton:hover { border: 1px solid #888; }
+
+/* _LeftToolbarView, _CenterImageAreaView, _RawDataManipulationToolbar — see
+   dark/raw_data_view.qss: fixed-dark chrome regardless of OS theme (toolbar
+   icons/text are hardcoded white ink), so values here are identical to the
+   dark variant. */
+_LeftToolbarView { background-color: #2d2d2d; border-right: 1px solid #3d3d3d; }
+
+_CenterImageAreaView QWidget#rawDataStatusBar {
+    background-color: #1e1e1e;
+    color: #cccccc;
+    font-size: 12px;
+    padding-left: 8px;
+}
+_CenterImageAreaView QLabel#rawDataToolHintLabel { padding-right: 8px; }
+
+_RawDataManipulationToolbar {
+    background-color: #2d2d2d;
+    border-bottom: 1px solid #3d3d3d;
+}
+_RawDataManipulationToolbar QToolButton { font-weight: bold; color: #ffffff; }
+_RawDataManipulationToolbar QToolButton[class="zoomButton"] { font-size: 20px; }
+_RawDataManipulationToolbar QFrame#toolbarDivider { background-color: #555555; }
+_RawDataManipulationToolbar QLabel#rawDataToolbarHduLabel {
+    color: #aaaaaa;
+    font-size: 11px;
+    padding-left: 8px;
+    font-weight: bold;
+}
+
+/* VerticalRangeControl, InteractiveHistogramWidget — see
+   dark/raw_data_view.qss: fixed-dark regardless of OS theme, so values
+   here are identical to the dark variant. */
+VerticalRangeControl QLabel[class="rangeAbsLabel"] {
+    color: #eeeeee;
+    font-size: 10px;
+    font-weight: bold;
+}
+
+InteractiveHistogramWidget QLabel[class="placeholder"] {
+    color: #999999;
+    font-style: italic;
+    padding: 20px;
+}
+InteractiveHistogramWidget QLabel[class="histogramTooltip"] {
+    background-color: rgba(44, 62, 80, 220);
+    color: #ffffff;
+    padding: 4px 8px;
+    border-radius: 3px;
+    font-size: 11px;
+}

--- a/tests/test_RawDataViewPackageImports.py
+++ b/tests/test_RawDataViewPackageImports.py
@@ -17,7 +17,6 @@ _PACKAGE_MODULES = [
     "le_beta_vis.frontend.views.raw_data_view._RightSidebarView",
     "le_beta_vis.frontend.views.raw_data_view._ROIInfoWidget",
     "le_beta_vis.frontend.views.raw_data_view._RawDataManipulationToolbar",
-    "le_beta_vis.frontend.views.raw_data_view._RawDataViewStyle",
 ]
 
 


### PR DESCRIPTION
refactor: migrate raw data view and widget styles to QSS files

- Extracted inline styles from MosaicView, _CenterImageAreaView,
  _LeftToolbarView, _RawDataManipulationToolbar, and corresponding
  sub-widgets into light/dark QSS stylesheets.
- Replaced hardcoded properties with setObjectName and QWidget class
  properties (e.g., class="callout", styleRole="primary",
  scoreLevel="good") to support clean selectors.
- Removed unused style helper classes and constants from
  frontend/theme.py.
- Deleted _RawDataViewStyle.py entirely and updated package import
  tests.
- Added dark and light QSS stylesheets for hdu_visualization,
  progress_overlays, raw_cluster_dialogs, and raw_data_view.

Resolves #220