### PR TITLE
feat: Migrate Historical View and Event Grid components to QSS

### DIFF
--- a/src/le_beta_vis/frontend/theme.py
+++ b/src/le_beta_vis/frontend/theme.py
@@ -24,17 +24,6 @@ class ProgressOverlayColors:
     ACTION_BUTTON_BACKGROUND = "rgba(0, 0, 0, 180)"
 
 
-class EventGridSectionHeaderColors:
-    """Colors for EventGridSectionHeaderWidget."""
-
-    BACKGROUND = "#000000"
-    TEXT = "#bbbbbb"
-    TEXT_FILENAME = "#999999"
-    NAV_TEXT = "#888888"
-    NAV_TEXT_DISABLED = "#555555"
-    NAV_HOVER_BACKGROUND = "#4a4a4a"
-
-
 class LiveModeColors:
     """Colors for the Live Mode screensaver."""
 
@@ -167,10 +156,6 @@ class RawClusterClassificationDialogColors:
     SCORE_LABEL_GOOD = "#81c784"
     SCORE_LABEL_MEDIUM = "#ffb74d"
     SCORE_LABEL_LOW = "#e57373"
-
-
-class ClusteredEventWidgetColors:
-    BUTTON_DISABLED_TEXT = "#a0a0a0"
 
 
 class TooltipStyle:

--- a/src/le_beta_vis/frontend/views/HistoricalEventInspector.py
+++ b/src/le_beta_vis/frontend/views/HistoricalEventInspector.py
@@ -39,14 +39,6 @@ _HIGH_RES_SIZE = 256
 _HISTOGRAM_BINS = 50
 
 
-class _Style:
-    PANEL = "background-color: #f0f0f0;" "color: #000000;"
-    SECTION_HEADER = (
-        "font-weight: bold;" "font-size: 13px;" "color: #333333;" "padding-top: 8px;"
-    )
-    PLACEHOLDER = "color: #999999;" "font-style: italic;" "padding: 20px;"
-
-
 class HistoricalEventInspector(QWidget):
     """View for displaying detailed information about a selected event.
 
@@ -68,14 +60,14 @@ class HistoricalEventInspector(QWidget):
         self._initUI()
 
     def _initUI(self) -> None:
-        self.setStyleSheet(_Style.PANEL)
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
         self._layout = QVBoxLayout(self)
         self._layout.setContentsMargins(0, 0, 0, 0)
         self._layout.setAlignment(Qt.AlignTop)
 
         # Placeholder shown when nothing is selected
         self._placeholder = QLabel(self.tr("Select an event to inspect"))
-        self._placeholder.setStyleSheet(_Style.PLACEHOLDER)
+        self._placeholder.setProperty("class", "placeholder")
         self._placeholder.setAlignment(Qt.AlignCenter)
         self._layout.addWidget(self._placeholder)
 
@@ -126,7 +118,7 @@ class HistoricalEventInspector(QWidget):
     def _createHistogramSection(self, parent: QVBoxLayout) -> None:
         """Creates the energy histogram section."""
         header = QLabel(self.tr("Energy Distribution"))
-        header.setStyleSheet(_Style.SECTION_HEADER)
+        header.setProperty("class", "sectionHeader")
         parent.addWidget(header)
 
         self._histogram = InteractiveHistogramWidget()

--- a/src/le_beta_vis/frontend/views/HistoricalView.py
+++ b/src/le_beta_vis/frontend/views/HistoricalView.py
@@ -40,11 +40,6 @@ from le_beta_vis.common.Cluster import Cluster
 logger = logging.getLogger(__name__)
 
 
-class _Style:
-    BROWSER_PANEL = "background-color: #2d2d2d;"
-    INSPECTOR_PANEL = "background-color: #f0f0f0; color: #000000;"
-
-
 class HistoricalView(QWidget):
     """View for the Historical Event Analysis tab.
 
@@ -148,7 +143,6 @@ class HistoricalView(QWidget):
         self._splitter = QSplitter(Qt.Horizontal)
 
         self._gridWidget = EventGridWidget()
-        self._gridWidget.setStyleSheet(_Style.BROWSER_PANEL)
         self._splitter.addWidget(self._gridWidget)
 
         self._inspectorVM = HistoricalEventInspectorViewModel(

--- a/src/le_beta_vis/frontend/widgets/ClusteredEventWidget.py
+++ b/src/le_beta_vis/frontend/widgets/ClusteredEventWidget.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional
 
-from PySide6.QtCore import Signal, Slot
+from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QGroupBox,
@@ -17,19 +17,11 @@ from le_beta_vis.common.ClassifierService import ClusterScores
 from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
 from le_beta_vis.common.ParticleType import CLASSIFICATION_THRESHOLD, ParticleType
 from le_beta_vis.frontend.fitsconverters.interface import Colormap
-from le_beta_vis.frontend.theme import (
-    ClusteredEventWidgetColors as _CEC,
-    RawClusterClassificationDialogColors as _SC,
-)
 from le_beta_vis.frontend.widgets.EnergyClusterWidget import (
     EnergyClusterWidget,
 )
 
 THUMBNAIL_SIZE = 64
-
-
-class _Style:
-    ENTRY_WIDGET = "background: transparent; border: 0;"
 
 
 class ClusteredEventWidget(QWidget):
@@ -78,19 +70,14 @@ class ClusteredEventWidget(QWidget):
         layout.addWidget(self._listWidget)
 
         btnLayout = QHBoxLayout()
-        _disabled_style = (
-            "QPushButton:disabled {" f" color: {_CEC.BUTTON_DISABLED_TEXT};" "}"
-        )
 
         self._btnClassify = QPushButton(self.tr("Classify"))
         self._btnClassify.setEnabled(False)
-        self._btnClassify.setStyleSheet(_disabled_style)
         self._btnClassify.clicked.connect(self.classifyRequested)
         btnLayout.addWidget(self._btnClassify)
 
         self._btnExport = QPushButton(self.tr("Export for Training"))
         self._btnExport.setEnabled(False)
-        self._btnExport.setStyleSheet(_disabled_style)
         self._btnExport.clicked.connect(self.exportRequested)
         btnLayout.addWidget(self._btnExport)
 
@@ -205,7 +192,8 @@ class ClusteredEventWidget(QWidget):
     def _createEntryWidget(self, index: int, event: ClusteredEventInfo) -> QWidget:
         """Creates a single list entry with thumbnail and metadata."""
         entry = QWidget()
-        entry.setStyleSheet(_Style.ENTRY_WIDGET)
+        entry.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        entry.setProperty("class", "entry")
         layout = QHBoxLayout(entry)
         layout.setContentsMargins(4, 4, 4, 4)
         layout.setSpacing(8)
@@ -261,14 +249,14 @@ class ClusteredEventWidget(QWidget):
         def _fmt(v: Optional[float]) -> str:
             return f"{v * 100:.0f}%" if v is not None else "?"
 
-        def _color(v: Optional[float]) -> str:
+        def _level(v: Optional[float]) -> str:
             if v is None:
-                return _SC.SCORE_LABEL_LOW
+                return "low"
             if v >= CLASSIFICATION_THRESHOLD:
-                return _SC.SCORE_LABEL_GOOD
+                return "good"
             if v >= 0.5:
-                return _SC.SCORE_LABEL_MEDIUM
-            return _SC.SCORE_LABEL_LOW
+                return "medium"
+            return "low"
 
         for model, val in (
             ("CNN", scores.cnn),
@@ -280,7 +268,7 @@ class ClusteredEventWidget(QWidget):
                     model=model, score=_fmt(val)
                 )
             )
-            lbl.setStyleSheet(f"color: {_color(val)};")
+            lbl.setProperty("scoreLevel", _level(val))
             layout.addWidget(lbl)
 
         valid = [v for v in (scores.cnn, scores.nrg, scores.bdt) if v is not None]

--- a/src/le_beta_vis/frontend/widgets/EventGridWidget.py
+++ b/src/le_beta_vis/frontend/widgets/EventGridWidget.py
@@ -31,7 +31,6 @@ from PySide6.QtWidgets import (
 
 from le_beta_vis.common.Cluster import Cluster
 from le_beta_vis.common.PhysicsConversionManager import PhysicsConversionManager
-from le_beta_vis.frontend.theme import COLOR_BACKGROUND_SURFACE
 from le_beta_vis.frontend.widgets._EventItemDelegate import (
     CLUSTER_ROLE,
     THUMBNAIL_ROLE,
@@ -98,6 +97,7 @@ class EventGridWidget(QWidget):
     # ------------------------------------------------------------------ #
 
     def _initUI(self) -> None:
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
         root = QVBoxLayout(self)
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(0)
@@ -129,16 +129,12 @@ class EventGridWidget(QWidget):
         area.setFrameShape(QScrollArea.Shape.NoFrame)
         area.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
         area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        area.setStyleSheet(f"background-color: {COLOR_BACKGROUND_SURFACE};")
 
         self._contentWidget = QWidget()
         self._contentLayout = QVBoxLayout(self._contentWidget)
         self._contentLayout.setContentsMargins(0, 0, 0, 0)
         self._contentLayout.setSpacing(0)
         area.setWidget(self._contentWidget)
-        area.verticalScrollBar().setStyleSheet(
-            "QScrollBar:vertical { width: 0px; max-width: 0px; }"
-        )
         return area
 
     def _buildStickyOverlay(self) -> EventGridSectionHeaderWidget:
@@ -181,7 +177,6 @@ class EventGridWidget(QWidget):
         view.setSpacing(4)
         view.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         view.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        view.setStyleSheet(f"background-color: {COLOR_BACKGROUND_SURFACE};")
         view.clicked.connect(
             lambda idx, s=section_index: self._onSectionItemClicked(s, idx)
         )
@@ -336,7 +331,7 @@ class EventGridWidget(QWidget):
         view.setModel(model)
 
         start = info.start_index
-        for cluster in events[start : start + info.count]:
+        for cluster in events[start: start + info.count]:
             item = QStandardItem()
             item.setData(cluster, CLUSTER_ROLE)
             item.setEditable(False)

--- a/src/le_beta_vis/frontend/widgets/HistoricalAdvancedFilterDialog.py
+++ b/src/le_beta_vis/frontend/widgets/HistoricalAdvancedFilterDialog.py
@@ -24,80 +24,6 @@ from ..viewmodels.HistoricalFilterBarViewModel import (
 )
 
 
-class _Style:
-    DIALOG = "background-color: #2d2d2d; color: #eeeeee;"
-    LABEL = "color: #cccccc; font-size: 12px;"
-    SPINBOX = (
-        "QDoubleSpinBox, QSpinBox {"
-        "  background-color: #3d3d3d;"
-        "  color: #eeeeee;"
-        "  border: 1px solid #555555;"
-        "  border-radius: 3px;"
-        "  padding: 3px;"
-        "}"
-        "QDoubleSpinBox:focus, QSpinBox:focus {"
-        "  border: 1px solid #0078d7;"
-        "}"
-    )
-    COMBO = (
-        "QComboBox {"
-        "  background-color: #3d3d3d;"
-        "  color: #eeeeee;"
-        "  border: 1px solid #555555;"
-        "  border-radius: 3px;"
-        "  padding: 3px;"
-        "}"
-        "QComboBox:focus {"
-        "  border: 1px solid #0078d7;"
-        "}"
-        "QComboBox::drop-down {"
-        "  border: none;"
-        "}"
-        "QComboBox QAbstractItemView {"
-        "  background-color: #3d3d3d;"
-        "  color: #eeeeee;"
-        "  selection-background-color: #0078d7;"
-        "}"
-    )
-    APPLY_BTN = (
-        "QPushButton {"
-        "  background-color: #0078d7;"
-        "  color: white;"
-        "  border: none;"
-        "  border-radius: 4px;"
-        "  padding: 6px 16px;"
-        "  font-weight: bold;"
-        "}"
-        "QPushButton:hover {"
-        "  background-color: #005fa3;"
-        "}"
-    )
-    RESET_BTN = (
-        "QPushButton {"
-        "  background-color: #3d3d3d;"
-        "  color: #cccccc;"
-        "  border: 1px solid #555555;"
-        "  border-radius: 4px;"
-        "  padding: 6px 16px;"
-        "}"
-        "QPushButton:hover {"
-        "  background-color: #505050;"
-        "}"
-    )
-    DATETIME_EDIT = (
-        "QDateTimeEdit {"
-        "  background-color: #3d3d3d;"
-        "  color: #eeeeee;"
-        "  border: 1px solid #555555;"
-        "  border-radius: 3px;"
-        "  padding: 3px;"
-        "}"
-        "QDateTimeEdit:focus {"
-        "  border: 1px solid #0078d7;"
-        "}"
-    )
-
-
 _TIME_PRESETS = [
     ("24h", "Last 24 hours"),
     ("3d", "Last 3 days"),
@@ -122,7 +48,6 @@ class HistoricalAdvancedFilterDialog(QDialog):
         self._vm = viewModel
         self.setWindowTitle(self.tr("Advanced Filters"))
         self.setMinimumWidth(360)
-        self.setStyleSheet(_Style.DIALOG)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self._initUI()
         self._syncFromViewModel()
@@ -139,20 +64,19 @@ class HistoricalAdvancedFilterDialog(QDialog):
 
         # Time
         self._timeCombo = QComboBox()
-        self._timeCombo.setStyleSheet(_Style.COMBO)
         for key, label in _TIME_PRESETS:
             self._timeCombo.addItem(self.tr(label), key)
-        form.addRow(self._styledLabel(self.tr("Time Range:")), self._timeCombo)
+        form.addRow(QLabel(self.tr("Time Range:")), self._timeCombo)
 
         # Start / End date-time
         self._startEdit = self._makeDateTimeEdit()
         form.addRow(
-            self._styledLabel(self.tr("Start:")),
+            QLabel(self.tr("Start:")),
             self._startEdit,
         )
         self._endEdit = self._makeDateTimeEdit()
         form.addRow(
-            self._styledLabel(self.tr("End:")),
+            QLabel(self.tr("End:")),
             self._endEdit,
         )
 
@@ -160,49 +84,48 @@ class HistoricalAdvancedFilterDialog(QDialog):
 
         # Cluster ID
         self._clusterIdSpin = self._makeIntSpin()
-        form.addRow(self._styledLabel(self.tr("Cluster ID:")), self._clusterIdSpin)
+        form.addRow(QLabel(self.tr("Cluster ID:")), self._clusterIdSpin)
 
         # FITS ID
         self._fitsIdSpin = self._makeIntSpin()
-        form.addRow(self._styledLabel(self.tr("FITS ID:")), self._fitsIdSpin)
+        form.addRow(QLabel(self.tr("FITS ID:")), self._fitsIdSpin)
 
         # HDU ID
         self._hduIdSpin = self._makeIntSpin()
-        form.addRow(self._styledLabel(self.tr("HDU ID:")), self._hduIdSpin)
+        form.addRow(QLabel(self.tr("HDU ID:")), self._hduIdSpin)
 
         # Min sigma-x
         self._sigmaXSpin = self._makeDoubleSpin()
         form.addRow(
-            self._styledLabel(self.tr("Min \u03c3\u2093:")),
+            QLabel(self.tr("Min \u03c3\u2093:")),
             self._sigmaXSpin,
         )
 
         # Min sigma-y
         self._sigmaYSpin = self._makeDoubleSpin()
         form.addRow(
-            self._styledLabel(self.tr("Min \u03c3\u1d67:")),
+            QLabel(self.tr("Min \u03c3\u1d67:")),
             self._sigmaYSpin,
         )
 
         # Min Energy
         unit = self._vm.energy_unit_label
         self._energySpin = self._makeDoubleSpin()
-        self._energyLabel = self._styledLabel(
+        self._energyLabel = QLabel(
             self.tr("Min Energy ({unit}):").format(unit=unit)
         )
         form.addRow(self._energyLabel, self._energySpin)
 
         # Min Pixels
         self._pixelsSpin = self._makeIntSpin()
-        form.addRow(self._styledLabel(self.tr("Min Pixels:")), self._pixelsSpin)
+        form.addRow(QLabel(self.tr("Min Pixels:")), self._pixelsSpin)
 
         # Classification
         self._classCombo = QComboBox()
-        self._classCombo.setStyleSheet(_Style.COMBO)
         for label, value in self._vm.classification_options:
             self._classCombo.addItem(self.tr(label), value)
         form.addRow(
-            self._styledLabel(self.tr("Classification:")),
+            QLabel(self.tr("Classification:")),
             self._classCombo,
         )
 
@@ -214,12 +137,12 @@ class HistoricalAdvancedFilterDialog(QDialog):
         btnRow.addStretch()
 
         resetBtn = QPushButton(self.tr("Reset"))
-        resetBtn.setStyleSheet(_Style.RESET_BTN)
+        resetBtn.setProperty("styleRole", "secondary")
         resetBtn.clicked.connect(self._onResetClicked)
         btnRow.addWidget(resetBtn)
 
         applyBtn = QPushButton(self.tr("Apply"))
-        applyBtn.setStyleSheet(_Style.APPLY_BTN)
+        applyBtn.setProperty("styleRole", "primary")
         applyBtn.clicked.connect(self._onApplyClicked)
         btnRow.addWidget(applyBtn)
 
@@ -227,14 +150,8 @@ class HistoricalAdvancedFilterDialog(QDialog):
 
     # --- Helpers ---
 
-    def _styledLabel(self, text: str) -> QLabel:
-        lbl = QLabel(text)
-        lbl.setStyleSheet(_Style.LABEL)
-        return lbl
-
     def _makeIntSpin(self) -> QSpinBox:
         spin = QSpinBox()
-        spin.setStyleSheet(_Style.SPINBOX)
         spin.setRange(0, 999999)
         spin.setSingleStep(1)
         spin.setSpecialValueText(self.tr("Any"))
@@ -244,7 +161,6 @@ class HistoricalAdvancedFilterDialog(QDialog):
 
     def _makeDoubleSpin(self) -> QDoubleSpinBox:
         spin = QDoubleSpinBox()
-        spin.setStyleSheet(_Style.SPINBOX)
         spin.setRange(0.0, 999999.0)
         spin.setDecimals(4)
         spin.setSingleStep(0.01)
@@ -255,7 +171,6 @@ class HistoricalAdvancedFilterDialog(QDialog):
 
     def _makeDateTimeEdit(self) -> QDateTimeEdit:
         edit = QDateTimeEdit()
-        edit.setStyleSheet(_Style.DATETIME_EDIT)
         edit.setDisplayFormat("yyyy-MM-dd HH:mm")
         edit.setCalendarPopup(True)
         return edit

--- a/src/le_beta_vis/frontend/widgets/_EventGridSectionHeaderWidget.py
+++ b/src/le_beta_vis/frontend/widgets/_EventGridSectionHeaderWidget.py
@@ -18,36 +18,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from le_beta_vis.frontend.theme import EventGridSectionHeaderColors as _C
-
 _NAV_BTN_SIZE = 28
-
-_DATE_STYLE = (
-    f"color: {_C.TEXT};"
-    " font-weight: bold; font-size: 12px;"
-    " padding: 4px 8px 0px 8px;"
-)
-
-_FILE_STYLE = (
-    f"color: {_C.TEXT_FILENAME};"
-    " font-size: 10px;"
-    " padding: 0px 8px 4px 8px;"
-)
-
-_NAV_BTN_STYLE = (
-    "QToolButton {{"
-    f"  color: {_C.NAV_TEXT};"
-    "  font-size: 12px;"
-    "  border: none;"
-    f"  background: {_C.BACKGROUND};"
-    "}}"
-    "QToolButton:hover {{"
-    f"  background: {_C.NAV_HOVER_BACKGROUND};"
-    "}}"
-    "QToolButton:disabled {{"
-    f"  color: {_C.NAV_TEXT_DISABLED};"
-    "}}"
-)
 
 
 class EventGridSectionHeaderWidget(QWidget):
@@ -75,9 +46,6 @@ class EventGridSectionHeaderWidget(QWidget):
 
     def _initUI(self) -> None:
         self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
-        self.setStyleSheet(
-            f"background-color: {_C.BACKGROUND};"
-        )
         self.setMinimumWidth(0)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
@@ -103,7 +71,6 @@ class EventGridSectionHeaderWidget(QWidget):
         btn.setText(symbol)
         btn.setAutoRaise(True)
         btn.setFixedSize(_NAV_BTN_SIZE, _NAV_BTN_SIZE)
-        btn.setStyleSheet(_NAV_BTN_STYLE)
         btn.setCursor(Qt.CursorShape.PointingHandCursor)
         return btn
 
@@ -117,11 +84,11 @@ class EventGridSectionHeaderWidget(QWidget):
         layout.setSpacing(0)
 
         self._dateLabel = QLabel()
-        self._dateLabel.setStyleSheet(_DATE_STYLE)
+        self._dateLabel.setProperty("class", "dateLabel")
         self._dateLabel.setMinimumWidth(0)
 
         self._fileLabel = QLabel()
-        self._fileLabel.setStyleSheet(_FILE_STYLE)
+        self._fileLabel.setProperty("class", "fileLabel")
         self._fileLabel.setMinimumWidth(0)
         self._fileLabel.setSizePolicy(
             QSizePolicy.Ignored, QSizePolicy.Preferred,

--- a/src/le_beta_vis/resources/qss/dark/dialogs.qss
+++ b/src/le_beta_vis/resources/qss/dark/dialogs.qss
@@ -65,3 +65,8 @@ AboutDialog QTextBrowser {
     color: #eeeeee;
     border: 1px solid #555555;
 }
+
+/* HistoricalAdvancedFilterDialog — pre-migration hardcoded look, not yet
+   adapted for light/dark parity; dark/light copies stay identical here. */
+HistoricalAdvancedFilterDialog { background-color: #2d2d2d; color: #eeeeee; }
+HistoricalAdvancedFilterDialog QLabel { color: #cccccc; font-size: 12px; }

--- a/src/le_beta_vis/resources/qss/dark/event_grid.qss
+++ b/src/le_beta_vis/resources/qss/dark/event_grid.qss
@@ -1,0 +1,41 @@
+/* EventGridWidget — sectioned grid of thumbnails in Historical Event
+   Analysis. Colors below were previously theme.py's dark-only constants
+   with no light-theme counterpart; dark/light copies stay identical here
+   to preserve current behavior. */
+EventGridWidget { background-color: #2d2d2d; }
+EventGridWidget QScrollArea { background-color: #2d2d2d; }
+EventGridWidget QListView { background-color: #2d2d2d; }
+
+/* Hides the scroll area's vertical scrollbar (kinetic scrolling only).
+   Scoped to EventGridWidget — a bare QScrollBar:vertical rule here would
+   zero the width of every vertical scrollbar in the app. */
+EventGridWidget QScrollBar:vertical { width: 0px; max-width: 0px; }
+
+/* EventGridSectionHeaderWidget — per-section + sticky-overlay header,
+   instantiated many times, styled by class name (no per-instance objectName
+   needed). */
+EventGridSectionHeaderWidget { background-color: #000000; }
+EventGridSectionHeaderWidget QLabel[class="dateLabel"] {
+    color: #bbbbbb;
+    font-weight: bold;
+    font-size: 12px;
+    padding: 4px 8px 0px 8px;
+}
+EventGridSectionHeaderWidget QLabel[class="fileLabel"] {
+    color: #999999;
+    font-size: 10px;
+    padding: 0px 8px 4px 8px;
+}
+EventGridSectionHeaderWidget QToolButton {
+    color: #888888;
+    font-size: 12px;
+    border: none;
+    background: #000000;
+}
+EventGridSectionHeaderWidget QToolButton:hover { background: #4a4a4a; }
+EventGridSectionHeaderWidget QToolButton:disabled { color: #555555; }
+
+/* ClusteredEventWidget — standalone list widget reused by both Historical
+   and Raw Data Analysis; grouped here with the grid/browse experience. */
+ClusteredEventWidget QPushButton:disabled { color: #a0a0a0; }
+ClusteredEventWidget QWidget[class="entry"] { background: transparent; border: 0; }

--- a/src/le_beta_vis/resources/qss/dark/historical.qss
+++ b/src/le_beta_vis/resources/qss/dark/historical.qss
@@ -1,0 +1,26 @@
+/* HistoricalEventInspector — detail panel for a selected historical event.
+   Adaptive per OS theme, matching the rest of the app (EventGridWidget's
+   browser panel sits right next to this one and is dark in both themes).
+   The histogram's own plot canvas stays white regardless — it's set via
+   pyqtgraph's setBackground(), not QSS, so it's unaffected by this. */
+HistoricalEventInspector { background-color: #2d2d2d; color: #eeeeee; }
+
+HistoricalEventInspector QLabel[class="placeholder"] {
+    color: #999999;
+    font-style: italic;
+    padding: 20px;
+}
+
+HistoricalEventInspector QLabel[class="sectionHeader"] {
+    font-weight: bold;
+    font-size: 13px;
+    color: #eeeeee;
+    padding-top: 8px;
+}
+
+/* ClusterDetailWidget's rich-text QLabel doesn't reliably inherit an
+   ancestor's QSS `color:` for its HTML content, so it needs an explicit
+   rule here rather than relying on cascade. Scoped under
+   HistoricalEventInspector so Live Mode's own dark-panel usage of the
+   same shared widget (FeaturedClusterWidget) is untouched. */
+HistoricalEventInspector ClusterDetailWidget QLabel { color: #eeeeee; }

--- a/src/le_beta_vis/resources/qss/light/dialogs.qss
+++ b/src/le_beta_vis/resources/qss/light/dialogs.qss
@@ -65,3 +65,8 @@ AboutDialog QTextBrowser {
     color: #000000;
     border: 1px solid #cccccc;
 }
+
+/* HistoricalAdvancedFilterDialog — pre-migration hardcoded look, not yet
+   adapted for light/dark parity; dark/light copies stay identical here. */
+HistoricalAdvancedFilterDialog { background-color: #2d2d2d; color: #eeeeee; }
+HistoricalAdvancedFilterDialog QLabel { color: #cccccc; font-size: 12px; }

--- a/src/le_beta_vis/resources/qss/light/event_grid.qss
+++ b/src/le_beta_vis/resources/qss/light/event_grid.qss
@@ -1,0 +1,41 @@
+/* EventGridWidget — sectioned grid of thumbnails in Historical Event
+   Analysis. Colors below were previously theme.py's dark-only constants
+   with no light-theme counterpart; dark/light copies stay identical here
+   to preserve current behavior. */
+EventGridWidget { background-color: #2d2d2d; }
+EventGridWidget QScrollArea { background-color: #2d2d2d; }
+EventGridWidget QListView { background-color: #2d2d2d; }
+
+/* Hides the scroll area's vertical scrollbar (kinetic scrolling only).
+   Scoped to EventGridWidget — a bare QScrollBar:vertical rule here would
+   zero the width of every vertical scrollbar in the app. */
+EventGridWidget QScrollBar:vertical { width: 0px; max-width: 0px; }
+
+/* EventGridSectionHeaderWidget — per-section + sticky-overlay header,
+   instantiated many times, styled by class name (no per-instance objectName
+   needed). */
+EventGridSectionHeaderWidget { background-color: #000000; }
+EventGridSectionHeaderWidget QLabel[class="dateLabel"] {
+    color: #bbbbbb;
+    font-weight: bold;
+    font-size: 12px;
+    padding: 4px 8px 0px 8px;
+}
+EventGridSectionHeaderWidget QLabel[class="fileLabel"] {
+    color: #999999;
+    font-size: 10px;
+    padding: 0px 8px 4px 8px;
+}
+EventGridSectionHeaderWidget QToolButton {
+    color: #888888;
+    font-size: 12px;
+    border: none;
+    background: #000000;
+}
+EventGridSectionHeaderWidget QToolButton:hover { background: #4a4a4a; }
+EventGridSectionHeaderWidget QToolButton:disabled { color: #555555; }
+
+/* ClusteredEventWidget — standalone list widget reused by both Historical
+   and Raw Data Analysis; grouped here with the grid/browse experience. */
+ClusteredEventWidget QPushButton:disabled { color: #a0a0a0; }
+ClusteredEventWidget QWidget[class="entry"] { background: transparent; border: 0; }

--- a/src/le_beta_vis/resources/qss/light/historical.qss
+++ b/src/le_beta_vis/resources/qss/light/historical.qss
@@ -1,0 +1,25 @@
+/* HistoricalEventInspector — detail panel for a selected historical event.
+   Light-theme variant keeps its existing light panel look; the histogram's
+   own plot canvas stays white regardless — it's set via pyqtgraph's
+   setBackground(), not QSS, so it's unaffected by this. */
+HistoricalEventInspector { background-color: #f0f0f0; color: #000000; }
+
+HistoricalEventInspector QLabel[class="placeholder"] {
+    color: #777777;
+    font-style: italic;
+    padding: 20px;
+}
+
+HistoricalEventInspector QLabel[class="sectionHeader"] {
+    font-weight: bold;
+    font-size: 13px;
+    color: #333333;
+    padding-top: 8px;
+}
+
+/* ClusterDetailWidget's rich-text QLabel doesn't reliably inherit an
+   ancestor's QSS `color:` for its HTML content, so it needs an explicit
+   rule here rather than relying on cascade. Scoped under
+   HistoricalEventInspector so Live Mode's own dark-panel usage of the
+   same shared widget (FeaturedClusterWidget) is untouched. */
+HistoricalEventInspector ClusterDetailWidget QLabel { color: #000000; }


### PR DESCRIPTION
Removes hardcoded inline style constants and helper classes from
widgets and views within the Historical Event Analysis tab. Custom
property bindings (e.g., class, styleRole, scoreLevel) are introduced
for dynamic styles, and background rendering is enabled via
WA_StyledBackground.

- Move HistoricalEventInspector and HistoricalView styling to
  dark/light QSS files.
- Move EventGridWidget and EventGridSectionHeaderWidget styles to QSS
  files, delegating scrollbar hiding and button interaction states.
- Clean up theme.py by removing EventGridSectionHeaderColors and
  ClusteredEventWidgetColors classes.
- Standardize HistoricalAdvancedFilterDialog elements under dialogs.qss.
- Apply scoreLevel property in ClusteredEventWidget classification
  results for badge coloring.

Resolves #221
