### PR TITLE
feat: Migrate livemode styling to QSS

### DIFF
--- a/src/le_beta_vis/frontend/livemode/LiveModeView.py
+++ b/src/le_beta_vis/frontend/livemode/LiveModeView.py
@@ -27,7 +27,6 @@ from PySide6.QtWidgets import (
 )
 
 from le_beta_vis.common.Cluster import Cluster
-from le_beta_vis.frontend.theme import LiveModeColors
 from le_beta_vis.frontend.viewmodels.HistoricalEventInspectorViewModel import (
     HistoricalEventInspectorViewModel,
 )
@@ -81,7 +80,6 @@ class LiveModeView(QDialog):
         self.setWindowFlags(
             Qt.Window | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
         )
-        self.setStyleSheet(f"background-color: {LiveModeColors.BACKGROUND};")
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/src/le_beta_vis/frontend/livemode/widgets/FeaturedClusterWidget.py
+++ b/src/le_beta_vis/frontend/livemode/widgets/FeaturedClusterWidget.py
@@ -70,17 +70,12 @@ class FeaturedClusterWidget(QWidget):
     def _buildLayout(self) -> None:
         """Construct the vertical label / featured row / stats / histogram layout."""
         self.setObjectName("FeaturedClusterWidget")
-        self.setStyleSheet(
-            f"#FeaturedClusterWidget {{ background-color: {LiveModeColors.PANEL_LEFT}; }}"
-        )
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(8)
 
         self._titleLabel = QLabel(self.tr("Live mode"))
-        self._titleLabel.setStyleSheet(
-            f"color: {LiveModeColors.TITLE_TEXT}; font-size: 18px; font-weight: bold;"
-        )
+        self._titleLabel.setObjectName("featuredTitleLabel")
         self._titleLabel.setAlignment(Qt.AlignCenter | Qt.AlignVCenter)
 
         top_row = QHBoxLayout()
@@ -99,11 +94,7 @@ class FeaturedClusterWidget(QWidget):
             show_filename=False,
             show_open_action=False,
         )
-        self._statsWidget.setStyleSheet(
-            f"background-color: {LiveModeColors.STATS_BACKGROUND};"
-            f"color: {LiveModeColors.STATS_TEXT};"
-            "padding: 8px; border-radius: 4px;"
-        )
+        self._statsWidget.setObjectName("featuredStatsWidget")
         layout.addWidget(self._statsWidget, stretch=0)
 
         self._histogram = InteractiveHistogramWidget()
@@ -111,10 +102,7 @@ class FeaturedClusterWidget(QWidget):
             self.tr("Awaiting cluster data..."),
         )
         self._histogram.setMinimumHeight(150)
-        self._histogram.setStyleSheet(
-            f"background-color: {LiveModeColors.HISTOGRAM_BG_DARK};"
-            "border-radius: 4px;"
-        )
+        self._histogram.setObjectName("featuredHistogram")
         self._histogram.setTheme(
             LiveModeColors.HISTOGRAM_BG_DARK,
             LiveModeColors.HISTOGRAM_FG_DARK,
@@ -122,9 +110,7 @@ class FeaturedClusterWidget(QWidget):
         layout.addWidget(self._histogram, stretch=1)
 
         sensorLabel = QLabel(self.tr("Sensor Location"))
-        sensorLabel.setStyleSheet(
-            f"color: {LiveModeColors.TITLE_TEXT};" "font-size: 12px; font-weight: bold;"
-        )
+        sensorLabel.setObjectName("featuredSensorLabel")
         sensorLabel.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         layout.addWidget(sensorLabel)
 
@@ -144,9 +130,7 @@ class FeaturedClusterWidget(QWidget):
             enable_hover_tooltip=True,
         )
         self._featuredWidget.set_kev_converter(self._vm.physics.adu_to_kev)
-        self._featuredWidget.setStyleSheet(
-            f"background-color: {LiveModeColors.BACKGROUND};"
-        )
+        self._featuredWidget.setObjectName("featuredThumbnail")
         row_layout.addWidget(self._featuredWidget)
 
         self._gradientWidget = _ScaleGradientWidget(

--- a/src/le_beta_vis/frontend/livemode/widgets/_ScaleGradientWidget.py
+++ b/src/le_beta_vis/frontend/livemode/widgets/_ScaleGradientWidget.py
@@ -17,7 +17,6 @@ from le_beta_vis.frontend.fitsconverters.cluster_thumbnail import (
     generate_cluster_thumbnail,
 )
 from le_beta_vis.frontend.fitsconverters.interface import Colormap
-from le_beta_vis.frontend.theme import LiveModeColors
 
 _STRIP_WIDTH = 20
 _TOTAL_WIDTH = 60
@@ -120,13 +119,9 @@ class _ScaleGradientWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(2)
 
-        label_style = (
-            f"color: {LiveModeColors.GRADIENT_LABEL}; font-size: 7pt;"
-        )
-
         self._maxLabel = QLabel()
         self._maxLabel.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
-        self._maxLabel.setStyleSheet(label_style)
+        self._maxLabel.setProperty("class", "scaleGradientRangeLabel")
         layout.addWidget(self._maxLabel)
 
         self._strip = _GradientStripWidget()
@@ -135,7 +130,7 @@ class _ScaleGradientWidget(QWidget):
 
         self._minLabel = QLabel()
         self._minLabel.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
-        self._minLabel.setStyleSheet(label_style)
+        self._minLabel.setProperty("class", "scaleGradientRangeLabel")
         layout.addWidget(self._minLabel)
 
     def setColormap(self, colormap: Colormap) -> None:

--- a/src/le_beta_vis/frontend/theme.py
+++ b/src/le_beta_vis/frontend/theme.py
@@ -36,17 +36,16 @@ class EventGridSectionHeaderColors:
 
 
 class LiveModeColors:
-    """Colors for the Live Mode screensaver."""
+    """Colors for the Live Mode screensaver.
 
-    BACKGROUND = "#000000"
-    PANEL_LEFT = "#0d0d0d"
-    GRADIENT_LABEL = "#ffffff"
-    STATS_BACKGROUND = "#0a1628"
-    STATS_TEXT = "#e0f0ff"
-    HISTOGRAM_BACKGROUND = "#1a0a0a"
+    Only the pyqtgraph-theming values consumed by
+    InteractiveHistogramWidget.setTheme() in FeaturedClusterWidget remain
+    here; all other Live Mode colors moved to
+    resources/qss/{dark,light}/live_mode.qss.
+    """
+
     HISTOGRAM_BG_DARK = "#111111"
     HISTOGRAM_FG_DARK = "#dddddd"
-    TITLE_TEXT = "#ffffff"
 
 
 class LiveModeBadgeColors:

--- a/src/le_beta_vis/resources/qss/dark/live_mode.qss
+++ b/src/le_beta_vis/resources/qss/dark/live_mode.qss
@@ -1,0 +1,40 @@
+/* Live Mode is intentionally rendered dark regardless of OS theme
+   (mirrors LiveModeColors, which has no light/dark split) — this file
+   is identical to the other theme's live_mode.qss on purpose. */
+
+LiveModeView { background-color: #000000; }
+
+#FeaturedClusterWidget { background-color: #0d0d0d; }
+
+FeaturedClusterWidget QLabel#featuredTitleLabel {
+    color: #ffffff;
+    font-size: 18px;
+    font-weight: bold;
+}
+
+FeaturedClusterWidget ClusterDetailWidget#featuredStatsWidget {
+    background-color: #0a1628;
+    color: #e0f0ff;
+    padding: 8px;
+    border-radius: 4px;
+}
+
+FeaturedClusterWidget InteractiveHistogramWidget#featuredHistogram {
+    background-color: #111111;
+    border-radius: 4px;
+}
+
+FeaturedClusterWidget QLabel#featuredSensorLabel {
+    color: #ffffff;
+    font-size: 12px;
+    font-weight: bold;
+}
+
+FeaturedClusterWidget EnergyClusterWidget#featuredThumbnail {
+    background-color: #000000;
+}
+
+_ScaleGradientWidget QLabel[class="scaleGradientRangeLabel"] {
+    color: #ffffff;
+    font-size: 7pt;
+}

--- a/src/le_beta_vis/resources/qss/light/live_mode.qss
+++ b/src/le_beta_vis/resources/qss/light/live_mode.qss
@@ -1,0 +1,40 @@
+/* Live Mode is intentionally rendered dark regardless of OS theme
+   (mirrors LiveModeColors, which has no light/dark split) — this file
+   is identical to the other theme's live_mode.qss on purpose. */
+
+LiveModeView { background-color: #000000; }
+
+#FeaturedClusterWidget { background-color: #0d0d0d; }
+
+FeaturedClusterWidget QLabel#featuredTitleLabel {
+    color: #ffffff;
+    font-size: 18px;
+    font-weight: bold;
+}
+
+FeaturedClusterWidget ClusterDetailWidget#featuredStatsWidget {
+    background-color: #0a1628;
+    color: #e0f0ff;
+    padding: 8px;
+    border-radius: 4px;
+}
+
+FeaturedClusterWidget InteractiveHistogramWidget#featuredHistogram {
+    background-color: #111111;
+    border-radius: 4px;
+}
+
+FeaturedClusterWidget QLabel#featuredSensorLabel {
+    color: #ffffff;
+    font-size: 12px;
+    font-weight: bold;
+}
+
+FeaturedClusterWidget EnergyClusterWidget#featuredThumbnail {
+    background-color: #000000;
+}
+
+_ScaleGradientWidget QLabel[class="scaleGradientRangeLabel"] {
+    color: #ffffff;
+    font-size: 7pt;
+}


### PR DESCRIPTION
Migrate remaining inline `setStyleSheet()` calls in the Live Mode view and
its widgets to external `.qss` stylesheet files. This ensures theme
management consistency across the application.

- Remove inline `setStyleSheet()` from `LiveModeView`, `FeaturedClusterWidget`, and `_ScaleGradientWidget`.
- Create identical `live_mode.qss` stylesheet files for both dark and light resource directories to ensure Live Mode remains dark regardless of the OS theme.
- Assign appropriate object names (e.g., `featuredTitleLabel`, `featuredStatsWidget`, `featuredHistogram`, `featuredSensorLabel`, `featuredThumbnail`) and classes to map existing selectors accurately.
- Remove deprecated style constants from `LiveModeColors` in `theme.py` while keeping pyqtgraph-specific colors.

Resolves #222