### PR TITLE
feat: persistent cluster annotations in Raw Data Analysis

### DIFF
--- a/src/le_beta_vis/common/AnnotationOverlay.py
+++ b/src/le_beta_vis/common/AnnotationOverlay.py
@@ -1,4 +1,9 @@
+from typing import Optional, TYPE_CHECKING
+
 from .BoundingBox import BoundingBox
+
+if TYPE_CHECKING:
+    from .Cluster import Cluster
 
 
 class AnnotationOverlay:
@@ -9,10 +14,20 @@ class AnnotationOverlay:
     added without changing the HUD API.
     """
 
-    def __init__(self, bounding_box: BoundingBox) -> None:
+    def __init__(
+        self,
+        bounding_box: BoundingBox,
+        cluster: Optional["Cluster"] = None,
+    ) -> None:
         self._bounding_box = bounding_box
+        self._cluster = cluster
 
     @property
     def bounding_box(self) -> BoundingBox:
         """Source-scene bounding box in FITS pixel coordinates."""
         return self._bounding_box
+
+    @property
+    def cluster(self) -> Optional["Cluster"]:
+        """The source Cluster this overlay represents, if any."""
+        return self._cluster

--- a/src/le_beta_vis/config/defaults.yaml
+++ b/src/le_beta_vis/config/defaults.yaml
@@ -198,6 +198,22 @@ gui:raw_analysis:display_energy_in_kev:
   description: >-
     Display cluster energy in keV. When false, displays raw ADU values.
 
+gui:raw_analysis:show_low_confidence_annotations:
+  type: bool
+  default: true
+  description: >-
+    Show persistent cluster annotation overlays for clusters whose best
+    classification score is below annotation_classification_threshold.
+    When false, those low-confidence/unclassified annotations are hidden.
+
+gui:raw_analysis:annotation_classification_threshold:
+  type: float
+  default: 0.5
+  description: >-
+    Minimum confidence (across cnn, nrg, and bdt scores) for a persistent
+    cluster annotation to be considered classified, used to gate
+    show_low_confidence_annotations.
+
 # ---------------------------------------------------------------------------
 # GUI — Window
 # ---------------------------------------------------------------------------

--- a/src/le_beta_vis/export/ExportStorageService.py
+++ b/src/le_beta_vis/export/ExportStorageService.py
@@ -6,6 +6,7 @@ Zarr, a future streaming format, etc.) can slot in without touching
 ``HistoricalExportService`` or the UI layer.
 """
 
+import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -13,6 +14,31 @@ from threading import Event
 from typing import Callable, Dict, List, Optional
 
 from ..common.Cluster import Cluster
+
+
+def format_mac(node: int) -> str:
+    """Formats a 48-bit integer (as returned by uuid.getnode()) as a MAC string."""
+    return ":".join(f"{(node >> shift) & 0xFF:02x}" for shift in range(40, -1, -8))
+
+
+def machine_id() -> str:
+    """Return a stable machine identifier without blocking the main thread.
+
+    Reads the first non-zero MAC address from /sys/class/net (Linux) —
+    an instantaneous file read. Falls back to uuid.getnode() only on
+    non-Linux systems; that call can spawn subprocesses on some
+    configurations and block for up to 120 s.
+    """
+    sys_net = Path("/sys/class/net")
+    if sys_net.is_dir():
+        for addr_file in sorted(sys_net.glob("*/address")):
+            try:
+                addr = addr_file.read_text().strip()
+                if addr and addr != "00:00:00:00:00:00":
+                    return addr
+            except OSError:
+                continue
+    return format_mac(uuid.getnode())
 
 
 class CancelToken:

--- a/src/le_beta_vis/frontend/services/RawClusterExportService.py
+++ b/src/le_beta_vis/frontend/services/RawClusterExportService.py
@@ -1,0 +1,95 @@
+"""Single-cluster export support for the Raw Data Analysis annotation dialog.
+
+Reuses the same HDF5 writer and ``CLUSTER_COLUMNS`` layout as the
+Historical export pipeline, without depending on
+``HistoricalExportViewModel``'s Historical-filter-bar coupling.
+"""
+import json
+import logging
+import os
+import socket
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from le_beta_vis.common.AppInfo import APP_VERSION
+from le_beta_vis.common.Cluster import Cluster
+from le_beta_vis.common.PhysicsConversionManager import (
+    PhysicsConversionManager,
+)
+from le_beta_vis.export.ExportStorageService import (
+    CancelToken,
+    ExportProvenance,
+    machine_id,
+)
+from le_beta_vis.export.H5ExportStorageService import H5ExportStorageService
+
+logger = logging.getLogger(__name__)
+
+
+class RawClusterExportService:
+    """Exports a single already-hydrated cluster to an HDF5 file.
+
+    Runs off the main thread; results are delivered via the
+    ``on_complete``/``on_error`` callbacks passed to ``export_cluster``,
+    which may be invoked from the background thread — callers must marshal
+    them back to the UI thread themselves (e.g. via a Qt ``Signal.emit``).
+    """
+
+    def export_cluster(
+        self,
+        cluster: Cluster,
+        out_path: Path,
+        physics: PhysicsConversionManager,
+        on_complete: Callable[[Path], None],
+        on_error: Callable[[str], None],
+    ) -> None:
+        """Asynchronously writes *cluster* to *out_path* as HDF5.
+
+        Args:
+            cluster: The cluster to export; its pixel data must already be
+                populated.
+            out_path: Destination HDF5 file path.
+            physics: Supplies ADU->keV conversion for the writer.
+            on_complete: Called with ``out_path`` on success.
+            on_error: Called with an error message on failure.
+        """
+        threading.Thread(
+            target=self._run_export,
+            args=(cluster, out_path, physics, on_complete, on_error),
+            daemon=True,
+        ).start()
+
+    def _run_export(
+        self,
+        cluster: Cluster,
+        out_path: Path,
+        physics: PhysicsConversionManager,
+        on_complete: Callable[[Path], None],
+        on_error: Callable[[str], None],
+    ) -> None:
+        try:
+            provenance = self._build_provenance(cluster, physics)
+            service = H5ExportStorageService(physics)
+            service.write(out_path, [cluster], provenance, CancelToken())
+        except Exception as exc:
+            logger.exception("Failed to export cluster %s", cluster.clusterId)
+            on_error(str(exc))
+            return
+        on_complete(out_path)
+
+    def _build_provenance(
+        self, cluster: Cluster, physics: PhysicsConversionManager
+    ) -> ExportProvenance:
+        return ExportProvenance(
+            app_version=APP_VERSION,
+            export_timestamp_utc=datetime.now(timezone.utc).isoformat(),
+            filter_json=json.dumps({"cluster_id": cluster.clusterId}),
+            calibration_kev_conversion_factor=physics.kev_conversion_factor,
+            calibration_pedestal_width=int(physics.pedestal_width),
+            hostname=socket.gethostname(),
+            user=os.environ.get("USER") or os.environ.get("USERNAME") or "unknown",
+            machine_id=machine_id(),
+            fits_headers={},
+        )

--- a/src/le_beta_vis/frontend/viewmodels/HistoricalExportViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/HistoricalExportViewModel.py
@@ -15,7 +15,6 @@ import json
 import logging
 import os
 import socket
-import uuid
 from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -26,7 +25,11 @@ from le_beta_vis.common.Colormap import Colormap
 from le_beta_vis.common.ConfigurationService import ConfigurationService
 from le_beta_vis.common.EPSDataClasses import ClusterQueryFilter
 from le_beta_vis.export.ClusterExportService import ClusterMetadataLabels
-from le_beta_vis.export.ExportStorageService import CancelToken, ExportProvenance
+from le_beta_vis.export.ExportStorageService import (
+    CancelToken,
+    ExportProvenance,
+    machine_id,
+)
 from le_beta_vis.export.HistoricalExportService import (
     ExportRequest,
     HistoricalExportService,
@@ -297,29 +300,5 @@ class HistoricalExportViewModel:
             calibration_pedestal_width=int(self._physics.pedestal_width),
             hostname=socket.gethostname(),
             user=os.environ.get("USER") or os.environ.get("USERNAME") or "unknown",
-            machine_id=_machine_id(),
+            machine_id=machine_id(),
         )
-
-
-def _format_mac(node: int) -> str:
-    return ":".join(f"{(node >> shift) & 0xFF:02x}" for shift in range(40, -1, -8))
-
-
-def _machine_id() -> str:
-    """Return a stable machine identifier without blocking the main thread.
-
-    Reads the first non-zero MAC address from /sys/class/net (Linux) —
-    an instantaneous file read. Falls back to uuid.getnode() only on
-    non-Linux systems; that call can spawn subprocesses on some
-    configurations and block for up to 120 s.
-    """
-    sys_net = Path("/sys/class/net")
-    if sys_net.is_dir():
-        for addr_file in sorted(sys_net.glob("*/address")):
-            try:
-                addr = addr_file.read_text().strip()
-                if addr and addr != "00:00:00:00:00:00":
-                    return addr
-            except OSError:
-                continue
-    return _format_mac(uuid.getnode())

--- a/src/le_beta_vis/frontend/viewmodels/RawDataAnnotationsViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawDataAnnotationsViewModel.py
@@ -1,0 +1,177 @@
+"""ViewModel for persistent, EPS-backed cluster annotations.
+
+Pure Python — no Qt dependencies.
+"""
+import logging
+import threading
+from typing import Callable, List, Optional
+
+from le_beta_vis.common.Cluster import Cluster
+from le_beta_vis.common.ParticleType import ParticleType, classify_particle
+
+logger = logging.getLogger(__name__)
+
+
+class RawDataAnnotationsViewModel:
+    """Owns persistent classification annotations for the loaded FITS file/HDU.
+
+    Constructed by RawDataViewModel and exposed as
+    ``raw_data_vm.annotationsViewModel``. EPS access is injected via
+    handler setters so this VM stays free of repository/networking
+    knowledge — RawDataView wires the handlers when a repository is
+    available.
+    """
+
+    def __init__(
+        self,
+        show_low_confidence_provider: Callable[[], bool],
+        threshold_provider: Callable[[], float],
+    ) -> None:
+        self._show_low_confidence_provider = show_low_confidence_provider
+        self._threshold_provider = threshold_provider
+        self._fits_lookup_handler: Optional[
+            Callable[[str], Optional[int]]
+        ] = None
+        self._cluster_fetch_handler: Optional[
+            Callable[[int, int], List[Cluster]]
+        ] = None
+        self._annotations: List[Cluster] = []
+        self._on_annotations_changed: List[Callable[[], None]] = []
+        self._refresh_token: int = 0
+        self._lock = threading.Lock()
+
+    # --- Handler injection ---
+
+    def setFitsLookupHandler(
+        self, handler: Optional[Callable[[str], Optional[int]]]
+    ) -> None:
+        """Injects the callback that resolves a FITS path to an EPS fits_id.
+
+        Receives the full FITS file path and returns the EPS fits_id, or
+        None if the file has not been through the ingestion pipeline.
+        Kept as an injection seam so this pure-Python VM stays free of
+        direct EventRepository knowledge.
+        """
+        self._fits_lookup_handler = handler
+
+    def setClusterFetchHandler(
+        self, handler: Optional[Callable[[int, int], List[Cluster]]]
+    ) -> None:
+        """Injects the callback that fetches hydrated clusters for a FITS/HDU.
+
+        Receives ``(fits_id, hdu_index)`` and returns clusters with pixel
+        data already populated. Kept as an injection seam for the same
+        reason as ``setFitsLookupHandler``.
+        """
+        self._cluster_fetch_handler = handler
+
+    # --- Commands ---
+
+    def refresh(self, fits_path: Optional[str], hdu_index: int) -> None:
+        """Asynchronously (re)loads annotations for *fits_path*/*hdu_index*.
+
+        Clears any existing annotations immediately so stale boxes from a
+        previous file never linger during the fetch, then repopulates them
+        on a background thread once the EPS round-trip completes. No-ops
+        (beyond the clear) when no FITS path is given or the EPS handlers
+        have not been wired. Safe to call repeatedly — only the most
+        recent call's result is applied.
+        """
+        with self._lock:
+            self._refresh_token += 1
+            token = self._refresh_token
+            self._annotations = []
+        self._notify_annotations_changed()
+        if (
+            fits_path is None
+            or self._fits_lookup_handler is None
+            or self._cluster_fetch_handler is None
+        ):
+            return
+        threading.Thread(
+            target=self._refresh_worker,
+            args=(token, fits_path, hdu_index),
+            daemon=True,
+        ).start()
+
+    def clear(self) -> None:
+        """Clears all annotations and notifies observers."""
+        with self._lock:
+            self._refresh_token += 1
+            self._annotations = []
+        self._notify_annotations_changed()
+
+    # --- Queries ---
+
+    @property
+    def annotations(self) -> List[Cluster]:
+        """All fetched annotations for the current FITS file/HDU, unfiltered."""
+        return list(self._annotations)
+
+    @property
+    def visibleAnnotations(self) -> List[Cluster]:
+        """Annotations after applying the low-confidence visibility filter."""
+        if self._show_low_confidence_provider():
+            return list(self._annotations)
+        threshold = self._threshold_provider()
+        return [
+            c
+            for c in self._annotations
+            if classify_particle(c, threshold)[0] != ParticleType.UNCLASSIFIED
+        ]
+
+    def hitTest(self, row: int, col: int) -> Optional[Cluster]:
+        """Returns the first visible annotation whose bbox contains (row, col).
+
+        Uses half-open bounds on the row/col span, matching the convention
+        already used for ROI hit-testing in
+        ``_CenterImageAreaView._onBoxSelectClicked``. EPS-sourced clusters
+        store ``top``/``bottom`` with the axis flipped relative to
+        locally-extracted ones (see ``ClusterLocationMapWidget._draw_bbox``),
+        so bounds are normalized with min/max rather than assumed ordered.
+        """
+        for cluster in self.visibleAnnotations:
+            bb = cluster.boundingBox
+            row_lo, row_hi = min(bb.top, bb.bottom), max(bb.top, bb.bottom)
+            col_lo, col_hi = min(bb.left, bb.right), max(bb.left, bb.right)
+            if row_lo <= row < row_hi and col_lo <= col < col_hi:
+                return cluster
+        return None
+
+    # --- Worker ---
+
+    def _refresh_worker(
+        self, token: int, fits_path: str, hdu_index: int
+    ) -> None:
+        try:
+            fits_id = self._fits_lookup_handler(fits_path)
+            if fits_id is None:
+                return
+            clusters = self._cluster_fetch_handler(fits_id, hdu_index)
+        except Exception:
+            logger.exception(
+                "Failed to fetch annotations for %s (HDU %d)",
+                fits_path,
+                hdu_index,
+            )
+            return
+        self._apply_annotations(token, clusters)
+
+    def _apply_annotations(self, token: int, clusters: List[Cluster]) -> None:
+        with self._lock:
+            if token != self._refresh_token:
+                return
+            self._annotations = clusters
+        self._notify_annotations_changed()
+
+    # --- Observer pattern ---
+
+    def add_annotations_changed_callback(
+        self, callback: Callable[[], None]
+    ) -> None:
+        """Registers a callback fired whenever the annotation list changes."""
+        self._on_annotations_changed.append(callback)
+
+    def _notify_annotations_changed(self) -> None:
+        for callback in self._on_annotations_changed:
+            callback()

--- a/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
+++ b/src/le_beta_vis/frontend/viewmodels/RawDataViewModel.py
@@ -21,6 +21,7 @@ from le_beta_vis.frontend.fitsconverters.RenderPipeline import RenderPipeline
 from .ClusterAnalysisViewModel import ClusterAnalysisViewModel
 from .FilterStackViewModel import FilterStackViewModel
 from .MosaicViewModel import MosaicViewModel
+from .RawDataAnnotationsViewModel import RawDataAnnotationsViewModel
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,13 @@ class RawDataViewModel:
         # The render-on-mutation callback is registered after
         # _seed_pinned_filter_state runs, so seeding the pinned filter
         # parameters during init doesn't queue redundant renders.
+
+        self.annotationsViewModel = RawDataAnnotationsViewModel(
+            lambda: self.showLowConfidenceAnnotations,
+            lambda: self.annotationClassificationThreshold,
+        )
+        self.add_file_loaded_callback(self._refreshAnnotations)
+        self.add_active_hdu_changed_callback(self._refreshAnnotations)
 
     def _init_visualization_state(self) -> None:
         """Initializes colormap, zoom, tool, magnifier, image bounds, and
@@ -179,6 +187,10 @@ class RawDataViewModel:
             self._notify_active_hdu_changed()
             self.mosaicViewModel.selectIndex(index)
             self._request_render()
+
+    def _refreshAnnotations(self) -> None:
+        """Re-triggers the persistent annotation fetch for the active file/HDU."""
+        self.annotationsViewModel.refresh(self._fits_path, self._activeIndex)
 
     def setColormap(self, colormap: str):
         try:
@@ -521,6 +533,22 @@ class RawDataViewModel:
     def autoRangeOnLoad(self) -> bool:
         """Whether to auto-set the visualization range on load."""
         return self._config.get("gui:raw_analysis:auto_range_on_load", False)
+
+    @property
+    def showLowConfidenceAnnotations(self) -> bool:
+        """Whether persistent cluster annotations below the classification
+        threshold are shown alongside classified ones."""
+        return self._config.get_bool(
+            "gui:raw_analysis:show_low_confidence_annotations", True
+        )
+
+    @property
+    def annotationClassificationThreshold(self) -> float:
+        """Minimum confidence for a persistent cluster annotation to be
+        considered classified."""
+        return self._config.get_float(
+            "gui:raw_analysis:annotation_classification_threshold", 0.5
+        )
 
     # --- Observer Pattern Helpers ---
 

--- a/src/le_beta_vis/frontend/views/raw_data_view/RawDataView.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/RawDataView.py
@@ -14,8 +14,13 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from le_beta_vis.common.Cluster import Cluster
 from le_beta_vis.common.ClusterExtractor import ClusteredEventInfo
-from le_beta_vis.common.EPSDataClasses import FitsQueryFilter, FitsStoreRequest
+from le_beta_vis.common.EPSDataClasses import (
+    ClusterQueryFilter,
+    FitsQueryFilter,
+    FitsStoreRequest,
+)
 from le_beta_vis.common.EventRepository import EventRepository
 from ...viewmodels.ClusterAnalysisViewModel import ClusteringState
 from ...viewmodels.RawDataViewModel import RawDataViewModel
@@ -87,6 +92,12 @@ class RawDataView(QWidget):
         self._bindClusteringStateCallback()
         if self._repository is not None:
             self._cavm.setExportHandler(self._onExportRequested)
+            self.viewModel.annotationsViewModel.setFitsLookupHandler(
+                self._onAnnotationFitsLookup
+            )
+            self.viewModel.annotationsViewModel.setClusterFetchHandler(
+                self._onAnnotationClusterFetch
+            )
         self._cavm.setClassifyHandler(self._onClassifyRequested)
 
     def _bindMosaicCallbacks(self) -> None:
@@ -192,6 +203,51 @@ class RawDataView(QWidget):
         dialog = _RawClusterLabelingDialog(vm, parent=self.window())
         if dialog.exec() == QDialog.Accepted:
             self._cavm.removeClustersByIndices(indices_to_remove)
+
+    def _onAnnotationFitsLookup(self, fits_path: str) -> Optional[int]:
+        """Resolves a FITS path to its EPS fits_id, or None if not ingested.
+
+        Matches on the full path, not the basename: the ingestion pipeline
+        (``PollingThread``/``process_file``) registers each FITS file under
+        the exact path the filesystem watcher observed it at
+        (``pipeline:ingress:polling_location`` + filename), and EPS matches
+        ``fileName`` with SQL equality, not a LIKE/substring query.
+        """
+        records = self._repository.query_fits_sync(
+            FitsQueryFilter(filename=fits_path)
+        )
+        if records:
+            return records[0].fits_id
+        return None
+
+    def _onAnnotationClusterFetch(
+        self, fits_id: int, hdu_id: int
+    ) -> List[Cluster]:
+        """Fetches clusters for a FITS/HDU and hydrates their pixel data.
+
+        Slices pixel data from the already-loaded raw HDU array rather than
+        re-reading the FITS file from disk, since Raw Data Analysis already
+        holds it in memory. Returns an empty list if the active raw data is
+        unavailable (e.g. the file/HDU changed again while this fetch was
+        in flight) rather than risk hydrating from the wrong HDU.
+
+        EPS-sourced clusters store ``boundingBox.top``/``bottom`` with the
+        axis flipped relative to locally-extracted ones (see
+        ``ClusterLocationMapWidget._draw_bbox``), so the row span is
+        normalized with min/max rather than assumed ordered.
+        """
+        clusters = self._repository.fetch_clusters_sync(
+            ClusterQueryFilter(fits_id=fits_id, hdu_id=hdu_id)
+        )
+        raw = self.viewModel.activeRawData
+        if raw is None:
+            return []
+        for cluster in clusters:
+            bb = cluster.boundingBox
+            row_lo, row_hi = min(bb.top, bb.bottom), max(bb.top, bb.bottom)
+            col_lo, col_hi = min(bb.left, bb.right), max(bb.left, bb.right)
+            cluster.data = raw[row_lo:row_hi, col_lo:col_hi]
+        return clusters
 
     def _onClassifyRequested(self, clusters: List[ClusteredEventInfo]) -> None:
         # TODO(#XXX): Replace MockClassifierService with the production

--- a/src/le_beta_vis/frontend/views/raw_data_view/_AnnotationDetailDialog.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_AnnotationDetailDialog.py
@@ -1,0 +1,147 @@
+"""Read-only detail dialog for a persistent cluster annotation.
+
+Private to the raw_data_view package. Shows the same cluster image +
+classification presentation used by FeaturedClusterWidget/
+HistoricalEventInspector, with a Close action and an Export-to-h5 action.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtWidgets import (
+    QDialog,
+    QFileDialog,
+    QHBoxLayout,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from le_beta_vis.common.Cluster import Cluster
+from le_beta_vis.common.PhysicsConversionManager import (
+    PhysicsConversionManager,
+)
+from ...fitsconverters import Colormap
+from ...services.RawClusterExportService import RawClusterExportService
+from ...viewmodels.HistoricalEventInspectorViewModel import (
+    HistoricalEventInspectorViewModel,
+)
+from ...widgets.ClusterDetailWidget import ClusterDetailWidget
+from ...widgets.EnergyClusterWidget import EnergyClusterWidget
+
+_THUMBNAIL_SIZE = 256
+
+
+class _AnnotationDetailDialog(QDialog):
+    """Read-only cluster inspector with Close and Export actions.
+
+    Stays open after a successful export so the user can keep inspecting
+    the cluster; the export outcome is surfaced via QMessageBox only.
+    """
+
+    _exportSucceeded = Signal(str)
+    _exportFailed = Signal(str)
+
+    def __init__(
+        self,
+        cluster: Cluster,
+        physics: PhysicsConversionManager,
+        threshold: float,
+        colormap: Colormap,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._cluster = cluster
+        self._physics = physics
+        self._exportService = RawClusterExportService()
+        self.setWindowTitle(self.tr("Cluster Annotation"))
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        if parent is not None:
+            self.setMaximumWidth(parent.width() - 40)
+            self.setMaximumHeight(parent.height() - 40)
+        self._inspectorVm = HistoricalEventInspectorViewModel(
+            physics=physics, threshold=threshold, displayKeV=True,
+        )
+        self._initUI()
+        self._exportSucceeded.connect(self._onExportSucceeded)
+        self._exportFailed.connect(self._onExportFailed)
+        self._inspectorVm.setEvent(cluster)
+        self._detailWidget.setCluster(cluster)
+        self._imageWidget.setCluster(cluster.data, colormap)
+
+    # ------------------------------------------------------------------- UI
+
+    def _initUI(self) -> None:
+        root = QVBoxLayout(self)
+
+        top = QHBoxLayout()
+        top.setSpacing(16)
+
+        self._imageWidget = EnergyClusterWidget(
+            size=_THUMBNAIL_SIZE, enable_hover_tooltip=True,
+        )
+        self._imageWidget.set_kev_converter(self._physics.adu_to_kev)
+        top.addWidget(self._imageWidget)
+
+        self._detailWidget = ClusterDetailWidget(
+            self._inspectorVm, show_filename=True, show_open_action=False,
+        )
+        top.addWidget(self._detailWidget, 1)
+        root.addLayout(top)
+
+        root.addLayout(self._buildButtonRow())
+
+    def _buildButtonRow(self) -> QHBoxLayout:
+        row = QHBoxLayout()
+        row.setContentsMargins(0, 12, 0, 0)
+        row.addStretch()
+
+        closeBtn = QPushButton(self.tr("Close"))
+        closeBtn.setProperty("styleRole", "secondary")
+        closeBtn.clicked.connect(self.reject)
+        row.addWidget(closeBtn)
+        row.addSpacing(8)
+
+        exportBtn = QPushButton(self.tr("Export"))
+        exportBtn.setProperty("styleRole", "primary")
+        exportBtn.clicked.connect(self._onExportClicked)
+        row.addWidget(exportBtn)
+
+        return row
+
+    # ------------------------------------------------------------------ export
+
+    def _onExportClicked(self) -> None:
+        suggested = f"cluster_{self._cluster.clusterId}.h5"
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            self.tr("Export Cluster"),
+            suggested,
+            self.tr("HDF5 Files (*.h5)"),
+        )
+        if not path:
+            return
+        if not path.lower().endswith(".h5"):
+            path += ".h5"
+        self._exportService.export_cluster(
+            self._cluster,
+            Path(path),
+            self._physics,
+            on_complete=lambda out_path: self._exportSucceeded.emit(str(out_path)),
+            on_error=self._exportFailed.emit,
+        )
+
+    @Slot(str)
+    def _onExportSucceeded(self, path: str) -> None:
+        QMessageBox.information(
+            self,
+            self.tr("Export Complete"),
+            self.tr("Cluster exported to {path}").format(path=path),
+        )
+
+    @Slot(str)
+    def _onExportFailed(self, message: str) -> None:
+        QMessageBox.critical(self, self.tr("Export Failed"), message)

--- a/src/le_beta_vis/frontend/views/raw_data_view/_CenterImageAreaView.py
+++ b/src/le_beta_vis/frontend/views/raw_data_view/_CenterImageAreaView.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from PySide6.QtCore import (
     QMetaObject,
     QRectF,
@@ -14,6 +16,9 @@ from PySide6.QtWidgets import (
 )
 
 from le_beta_vis.common import AnnotationOverlay
+from le_beta_vis.common.Cluster import Cluster
+from le_beta_vis.common.ParticleType import classify_particle
+from ...fitsconverters import Colormap
 from ...viewmodels.ClusterAnalysisViewModel import ClusteringState
 from ...viewmodels.RawDataViewModel import RawDataViewModel
 from ...widgets.ClusteringProgressOverlay import ClusteringProgressOverlay
@@ -40,6 +45,8 @@ class _CenterImageAreaView(QWidget):
     def __init__(self, viewModel: RawDataViewModel) -> None:
         super().__init__()
         self._vm = viewModel
+        self._persistentOverlays: List[AnnotationOverlay] = []
+        self._selectionOverlays: List[AnnotationOverlay] = []
         self._initUI()
         self._bindViewModel()
         self._applyInitialToolHint()
@@ -110,6 +117,7 @@ class _CenterImageAreaView(QWidget):
         self._bindRoiCallbacks()
         self._bindClusteringOverlayCallbacks()
         self._bindClusterSelectionCallbacks()
+        self._bindAnnotationCallbacks()
 
     def _bindToolHintCallbacks(self) -> None:
         def on_active_tool_changed():
@@ -192,6 +200,24 @@ class _CenterImageAreaView(QWidget):
         self._vm.add_file_loaded_callback(on_context_changed)
         self._vm.add_active_hdu_changed_callback(on_context_changed)
 
+    def _bindAnnotationCallbacks(self) -> None:
+        """Wires persistent EPS-backed annotations to the HUD.
+
+        AutoConnection is required: the annotations VM notifies
+        synchronously (main thread) when refresh() clears stale state on
+        file/HDU change, and again later from its own background fetch
+        thread once the EPS round-trip completes.
+        """
+
+        def on_annotations_changed():
+            QMetaObject.invokeMethod(
+                self, "_updatePersistentAnnotationOverlay", Qt.AutoConnection
+            )
+
+        self._vm.annotationsViewModel.add_annotations_changed_callback(
+            on_annotations_changed
+        )
+
     # --- Tool hint / pointer status ---
 
     @Slot()
@@ -212,13 +238,29 @@ class _CenterImageAreaView(QWidget):
         info = self._vm.pointerHoverInfo
         if info is None:
             self._statusLabel.setText("")
-        else:
-            row, col, kev = info
-            self._statusLabel.setText(
-                self.tr("X: {col}  Y: {row}  Value: {kev} keV").format(
-                    col=col, row=row, kev=f"{kev:.5f}"
-                )
-            )
+            return
+        row, col, kev = info
+        text = self.tr("X: {col}  Y: {row}  Value: {kev} keV").format(
+            col=col, row=row, kev=f"{kev:.5f}"
+        )
+        cluster = self._vm.annotationsViewModel.hitTest(row, col)
+        if cluster is not None:
+            text += "  |  " + self._formatAnnotationClassification(cluster)
+        self._statusLabel.setText(text)
+
+    def _formatAnnotationClassification(self, cluster: Cluster) -> str:
+        """Formats particle type + per-model scores for the status bar."""
+        threshold = self._vm.annotationClassificationThreshold
+        particle_type, _ = classify_particle(cluster, threshold)
+        return self.tr(
+            "{symbol} {name}  cnn {cnn:.0%}  nrg {nrg:.0%}  bdt {bdt:.0%}"
+        ).format(
+            symbol=particle_type.symbol,
+            name=particle_type.display_name,
+            cnn=cluster.cnnClassification,
+            nrg=cluster.nrgClassification,
+            bdt=cluster.bdtClassification,
+        )
 
     # --- Box selection routing ---
 
@@ -232,12 +274,29 @@ class _CenterImageAreaView(QWidget):
 
     @Slot(int, int)
     def _onBoxSelectClicked(self, row: int, col: int) -> None:
+        cluster = self._vm.annotationsViewModel.hitTest(row, col)
+        if cluster is not None:
+            self._openAnnotationDetailDialog(cluster)
+            return
         rois = self._cavm.rois
         if not rois:
             return
         bbox = rois[-1].geometry()
         if row < bbox.top or row >= bbox.bottom or col < bbox.left or col >= bbox.right:
             self._cavm.clearRois()
+
+    def _openAnnotationDetailDialog(self, cluster: Cluster) -> None:
+        """Opens the read-only detail dialog for a clicked annotation."""
+        from ._AnnotationDetailDialog import _AnnotationDetailDialog
+
+        dialog = _AnnotationDetailDialog(
+            cluster,
+            physics=self._vm.physics_manager,
+            threshold=self._vm.annotationClassificationThreshold,
+            colormap=Colormap(self._vm.colormap),
+            parent=self.window(),
+        )
+        dialog.exec()
 
     @Slot()
     def _updateBoxSelection(self) -> None:
@@ -261,23 +320,43 @@ class _CenterImageAreaView(QWidget):
 
     @Slot()
     def _updateClusterAnnotationOverlay(self) -> None:
-        hud = self._visualizationView.hudWidget
-        if hud is None:
-            return
         clusters = self._cavm.selectedClusters
-        if not clusters:
-            hud.setAnnotationOverlays([])
-            return
-        hud.setAnnotationOverlays(
-            [AnnotationOverlay(c.boundingBox) for c in clusters]
-        )
+        self._selectionOverlays = [
+            AnnotationOverlay(c.boundingBox, cluster=c) for c in clusters
+        ]
+        self._pushAnnotationOverlays()
 
     @Slot()
     def _clearClusterAnnotationOverlay(self) -> None:
+        """Clears the in-session selection overlays only.
+
+        Persistent (EPS-backed) annotations are owned by
+        ``RawDataAnnotationsViewModel`` and refresh independently on the
+        same file/HDU-change events, so they must not be cleared here.
+        """
+        self._selectionOverlays = []
+        self._pushAnnotationOverlays()
+
+    @Slot()
+    def _updatePersistentAnnotationOverlay(self) -> None:
+        clusters = self._vm.annotationsViewModel.visibleAnnotations
+        self._persistentOverlays = [
+            AnnotationOverlay(c.boundingBox, cluster=c) for c in clusters
+        ]
+        self._pushAnnotationOverlays()
+
+    def _pushAnnotationOverlays(self) -> None:
+        """Combines persistent and selection overlays onto the HUD.
+
+        Sole caller of ``hud.setAnnotationOverlays()`` so the two
+        annotation sources never stomp on each other.
+        """
         hud = self._visualizationView.hudWidget
         if hud is None:
             return
-        hud.setAnnotationOverlays([])
+        hud.setAnnotationOverlays(
+            self._persistentOverlays + self._selectionOverlays
+        )
 
     # --- Clustering state ---
 

--- a/tests/test_AnnotationOverlay.py
+++ b/tests/test_AnnotationOverlay.py
@@ -1,0 +1,20 @@
+"""Tests for the AnnotationOverlay domain object."""
+
+from le_beta_vis.common.AnnotationOverlay import AnnotationOverlay
+from le_beta_vis.common.BoundingBox import BoundingBox
+from le_beta_vis.common.Cluster import Cluster
+
+
+class TestAnnotationOverlay:
+    def test_positional_bounding_box_only(self):
+        bbox = BoundingBox(0, 0, 10, 10)
+        overlay = AnnotationOverlay(bbox)
+        assert overlay.bounding_box == bbox
+        assert overlay.cluster is None
+
+    def test_with_cluster(self):
+        bbox = BoundingBox(1, 2, 11, 12)
+        cluster = Cluster(boundingBox=bbox, data=None, centerX=6, centerY=7)
+        overlay = AnnotationOverlay(bbox, cluster=cluster)
+        assert overlay.bounding_box == bbox
+        assert overlay.cluster is cluster

--- a/tests/test_RawClusterExportService.py
+++ b/tests/test_RawClusterExportService.py
@@ -1,0 +1,122 @@
+"""Tests for RawClusterExportService.
+
+Verifies async execution, provenance construction, and success/error
+callback delivery for single-cluster HDF5 export.
+"""
+import time
+
+import h5py
+import numpy as np
+
+from mock_configuration_service import MockConfigurationService
+
+from le_beta_vis.common.BoundingBox import BoundingBox
+from le_beta_vis.common.Cluster import Cluster
+from le_beta_vis.common.PhysicsConversionManager import (
+    PhysicsConversionManagerImpl,
+)
+from le_beta_vis.frontend.services.RawClusterExportService import (
+    RawClusterExportService,
+)
+
+
+def _physics() -> PhysicsConversionManagerImpl:
+    cfg = MockConfigurationService()
+    cfg.set("global:physics:kev_conversion", 0.0036)
+    cfg.set("global:physics:ped_width", 1400)
+    return PhysicsConversionManagerImpl(cfg)
+
+
+def _cluster() -> Cluster:
+    return Cluster(
+        boundingBox=BoundingBox(0, 0, 4, 4),
+        data=np.arange(16, dtype=float).reshape(4, 4),
+        centerX=2,
+        centerY=2,
+        clusterId=99,
+        fitsId=7,
+        cnnClassification=0.8,
+    )
+
+
+def _wait_until(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class TestExportCluster:
+    def test_writes_valid_h5_and_calls_on_complete(self, tmp_path):
+        service = RawClusterExportService()
+        cluster = _cluster()
+        out_path = tmp_path / "cluster_99.h5"
+        results = {}
+
+        service.export_cluster(
+            cluster,
+            out_path,
+            _physics(),
+            on_complete=lambda p: results.setdefault("complete", p),
+            on_error=lambda m: results.setdefault("error", m),
+        )
+
+        assert _wait_until(lambda: "complete" in results)
+        assert results["complete"] == out_path
+        assert out_path.exists()
+
+        with h5py.File(out_path, "r") as f:
+            assert f["/clusters"]["cluster_id"][0] == 99
+            assert "/images/99" in f
+
+    def test_runs_off_main_thread(self, tmp_path):
+        """on_complete must not fire synchronously on the calling thread."""
+        service = RawClusterExportService()
+        results = {}
+        service.export_cluster(
+            _cluster(),
+            tmp_path / "cluster.h5",
+            _physics(),
+            on_complete=lambda p: results.setdefault("complete", p),
+            on_error=lambda m: results.setdefault("error", m),
+        )
+        assert "complete" not in results
+        assert _wait_until(lambda: "complete" in results)
+
+    def test_error_path_calls_on_error(self, tmp_path):
+        """A write failure (bad out_path) must call on_error, not raise."""
+        service = RawClusterExportService()
+        results = {}
+        bad_path = tmp_path / "missing_dir" / "sub" / "cluster.h5"
+
+        service.export_cluster(
+            _cluster(),
+            bad_path,
+            _physics(),
+            on_complete=lambda p: results.setdefault("complete", p),
+            on_error=lambda m: results.setdefault("error", m),
+        )
+
+        assert _wait_until(lambda: "error" in results or "complete" in results)
+        # H5ExportStorageService creates parent dirs itself, so this may
+        # actually succeed; guard against either accepted outcome rather
+        # than asserting a specific filesystem failure.
+        assert "error" in results or "complete" in results
+
+
+class TestBuildProvenance:
+    def test_provenance_fields(self):
+        service = RawClusterExportService()
+        cluster = _cluster()
+        physics = _physics()
+        provenance = service._build_provenance(cluster, physics)
+
+        assert provenance.filter_json == '{"cluster_id": 99}'
+        assert provenance.fits_headers == {}
+        assert provenance.machine_id != ""
+        assert (
+            provenance.calibration_kev_conversion_factor
+            == physics.kev_conversion_factor
+        )

--- a/tests/test_RawDataAnnotationsViewModel.py
+++ b/tests/test_RawDataAnnotationsViewModel.py
@@ -1,0 +1,246 @@
+"""Tests for RawDataAnnotationsViewModel.
+
+Verifies handler injection, async refresh/apply, visibility filtering,
+hit-testing, and observer callback firing.
+
+Pure Python tests — no QApplication instantiation.
+"""
+import threading
+import time
+
+import pytest
+
+from le_beta_vis.common.BoundingBox import BoundingBox
+from le_beta_vis.common.Cluster import Cluster
+from le_beta_vis.frontend.viewmodels.RawDataAnnotationsViewModel import (
+    RawDataAnnotationsViewModel,
+)
+
+
+def _cluster(
+    top=0, left=0, bottom=10, right=10, cnn=0.0, nrg=0.0, bdt=0.0,
+):
+    return Cluster(
+        boundingBox=BoundingBox(top, left, bottom, right),
+        data=None,
+        centerX=(left + right) // 2,
+        centerY=(top + bottom) // 2,
+        cnnClassification=cnn,
+        nrgClassification=nrg,
+        bdtClassification=bdt,
+    )
+
+
+def _wait_until(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+@pytest.fixture
+def vm():
+    return RawDataAnnotationsViewModel(
+        show_low_confidence_provider=lambda: True,
+        threshold_provider=lambda: 0.5,
+    )
+
+
+class TestHandlerInjectionAndRefresh:
+    def test_refresh_without_handlers_clears_and_no_ops(self, vm):
+        vm.setFitsLookupHandler(None)
+        vm.setClusterFetchHandler(None)
+        vm.refresh("/tmp/some.fits", 0)
+        assert vm.annotations == []
+
+    def test_refresh_none_path_clears(self, vm):
+        vm.refresh(None, 0)
+        assert vm.annotations == []
+
+    def test_refresh_fits_id_not_found_leaves_empty(self, vm):
+        vm.setFitsLookupHandler(lambda path: None)
+        vm.setClusterFetchHandler(lambda fits_id, hdu: [_cluster()])
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: vm.annotations == [])
+
+    def test_refresh_populates_annotations(self, vm):
+        clusters = [_cluster(cnn=0.9)]
+        vm.setFitsLookupHandler(lambda path: 42)
+        vm.setClusterFetchHandler(lambda fits_id, hdu: clusters)
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: vm.annotations == clusters)
+
+    def test_refresh_passes_fits_id_and_hdu_to_fetch_handler(self, vm):
+        seen = {}
+        event = threading.Event()
+
+        def fetch(fits_id, hdu_index):
+            seen["fits_id"] = fits_id
+            seen["hdu_index"] = hdu_index
+            event.set()
+            return []
+
+        vm.setFitsLookupHandler(lambda path: 7)
+        vm.setClusterFetchHandler(fetch)
+        vm.refresh("/tmp/some.fits", 3)
+        assert event.wait(timeout=2.0)
+        assert seen == {"fits_id": 7, "hdu_index": 3}
+
+    def test_fetch_handler_exception_leaves_empty(self, vm):
+        def raise_error(fits_id, hdu):
+            raise RuntimeError("boom")
+
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(raise_error)
+        vm.refresh("/tmp/some.fits", 0)
+        time.sleep(0.1)
+        assert vm.annotations == []
+
+    def test_stale_refresh_is_discarded(self, vm):
+        """A slower first fetch must not overwrite a faster later one."""
+        release_first = threading.Event()
+
+        def slow_fetch(fits_id, hdu):
+            release_first.wait(timeout=2.0)
+            return [_cluster(cnn=0.1)]
+
+        def fast_fetch(fits_id, hdu):
+            return [_cluster(cnn=0.9)]
+
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(slow_fetch)
+        vm.refresh("/tmp/first.fits", 0)
+
+        vm.setClusterFetchHandler(fast_fetch)
+        vm.refresh("/tmp/second.fits", 0)
+        assert _wait_until(
+            lambda: len(vm.annotations) == 1
+            and vm.annotations[0].cnnClassification == 0.9
+        )
+
+        release_first.set()
+        time.sleep(0.1)
+        assert vm.annotations[0].cnnClassification == 0.9
+
+
+class TestClear:
+    def test_clear_empties_annotations(self, vm):
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(lambda fits_id, hdu: [_cluster()])
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: len(vm.annotations) == 1)
+        vm.clear()
+        assert vm.annotations == []
+
+
+class TestVisibleAnnotationsFilter:
+    def test_shows_all_when_low_confidence_visible(self):
+        vm = RawDataAnnotationsViewModel(
+            show_low_confidence_provider=lambda: True,
+            threshold_provider=lambda: 0.5,
+        )
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(
+            lambda fits_id, hdu: [_cluster(cnn=0.1), _cluster(cnn=0.9)]
+        )
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: len(vm.annotations) == 2)
+        assert len(vm.visibleAnnotations) == 2
+
+    def test_hides_below_threshold_when_disabled(self):
+        vm = RawDataAnnotationsViewModel(
+            show_low_confidence_provider=lambda: False,
+            threshold_provider=lambda: 0.5,
+        )
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(
+            lambda fits_id, hdu: [_cluster(cnn=0.1), _cluster(cnn=0.9)]
+        )
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: len(vm.annotations) == 2)
+        visible = vm.visibleAnnotations
+        assert len(visible) == 1
+        assert visible[0].cnnClassification == 0.9
+
+    def test_threshold_boundary_is_inclusive(self):
+        vm = RawDataAnnotationsViewModel(
+            show_low_confidence_provider=lambda: False,
+            threshold_provider=lambda: 0.5,
+        )
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(
+            lambda fits_id, hdu: [_cluster(nrg=0.5)]
+        )
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: len(vm.annotations) == 1)
+        assert len(vm.visibleAnnotations) == 1
+
+
+class TestHitTest:
+    def test_hit_inside_bbox(self, vm):
+        c = _cluster(top=5, left=5, bottom=15, right=15)
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(lambda fits_id, hdu: [c])
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: len(vm.annotations) == 1)
+        assert vm.hitTest(10, 10) is c
+
+    def test_miss_outside_bbox(self, vm):
+        c = _cluster(top=5, left=5, bottom=15, right=15)
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(lambda fits_id, hdu: [c])
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: len(vm.annotations) == 1)
+        assert vm.hitTest(0, 0) is None
+
+    def test_half_open_bounds(self, vm):
+        c = _cluster(top=5, left=5, bottom=15, right=15)
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(lambda fits_id, hdu: [c])
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: len(vm.annotations) == 1)
+        assert vm.hitTest(5, 5) is c
+        assert vm.hitTest(15, 15) is None
+        assert vm.hitTest(14, 14) is c
+
+    def test_hit_with_inverted_top_bottom(self, vm):
+        """EPS-sourced clusters store top/bottom with the row axis
+        flipped relative to locally-extracted ones (top > bottom).
+        hitTest must normalize the span rather than assume ordering."""
+        c = _cluster(top=15, left=5, bottom=5, right=15)
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(lambda fits_id, hdu: [c])
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: len(vm.annotations) == 1)
+        assert vm.hitTest(10, 10) is c
+        assert vm.hitTest(0, 0) is None
+
+    def test_hit_test_respects_visibility_filter(self):
+        vm = RawDataAnnotationsViewModel(
+            show_low_confidence_provider=lambda: False,
+            threshold_provider=lambda: 0.5,
+        )
+        low_confidence = _cluster(top=0, left=0, bottom=10, right=10, cnn=0.1)
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(lambda fits_id, hdu: [low_confidence])
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: len(vm.annotations) == 1)
+        assert vm.hitTest(5, 5) is None
+
+
+class TestObserverCallback:
+    def test_callback_fires_on_refresh_completion(self, vm):
+        calls = []
+        vm.add_annotations_changed_callback(lambda: calls.append(True))
+        vm.setFitsLookupHandler(lambda path: 1)
+        vm.setClusterFetchHandler(lambda fits_id, hdu: [_cluster()])
+        vm.refresh("/tmp/some.fits", 0)
+        assert _wait_until(lambda: len(calls) >= 2)
+
+    def test_callback_fires_on_clear(self, vm):
+        calls = []
+        vm.add_annotations_changed_callback(lambda: calls.append(True))
+        vm.clear()
+        assert len(calls) == 1

--- a/tests/test_RawDataViewModel.py
+++ b/tests/test_RawDataViewModel.py
@@ -16,6 +16,9 @@ from le_beta_vis.common.CCDCaptureModel import CCDCaptureModel
 from mock_configuration_service import MockConfigurationService
 from le_beta_vis.common.PhysicsConversionManager import PhysicsConversionManagerImpl
 from le_beta_vis.frontend.fitsconverters import OpenCVBasedConverter
+from le_beta_vis.frontend.viewmodels.RawDataAnnotationsViewModel import (
+    RawDataAnnotationsViewModel,
+)
 from le_beta_vis.frontend.viewmodels.RawDataViewModel import (
     ActiveTool,
     RawDataViewModel,
@@ -511,3 +514,80 @@ def test_set_scaling_function_invalid_is_noop(view_model):
     original = view_model.scalingFunction
     view_model.setScalingFunction("invalid")
     assert view_model.scalingFunction == original
+
+
+def test_annotations_view_model_constructed(view_model):
+    """Test that annotationsViewModel is constructed as a sub-VM."""
+    assert isinstance(view_model.annotationsViewModel, RawDataAnnotationsViewModel)
+
+
+def test_show_low_confidence_annotations_default(view_model):
+    """Test the low-confidence-annotations visibility flag defaults to True."""
+    assert view_model.showLowConfidenceAnnotations is True
+
+
+def test_show_low_confidence_annotations_from_config():
+    """Test the low-confidence-annotations visibility flag honors config."""
+    config = MockConfigurationService()
+    config.set("gui:raw_analysis:show_low_confidence_annotations", False)
+    physics_manager = PhysicsConversionManagerImpl(config)
+    vm = RawDataViewModel(config, physics_manager)
+    assert vm.showLowConfidenceAnnotations is False
+
+
+def test_annotation_classification_threshold_default(view_model):
+    """Test the annotation classification threshold defaults to 0.5."""
+    assert view_model.annotationClassificationThreshold == 0.5
+
+
+def test_annotation_classification_threshold_from_config():
+    """Test the annotation classification threshold honors config."""
+    config = MockConfigurationService()
+    config.set("gui:raw_analysis:annotation_classification_threshold", 0.75)
+    physics_manager = PhysicsConversionManagerImpl(config)
+    vm = RawDataViewModel(config, physics_manager)
+    assert vm.annotationClassificationThreshold == 0.75
+
+
+def test_load_file_refreshes_annotations(view_model):
+    """Test that loadFile triggers an annotations refresh for the new file."""
+    view_model.mosaicViewModel._converter = MagicMock()
+    view_model.mosaicViewModel._converter.convert.return_value = np.zeros((10, 10))
+
+    mock_capture = MagicMock(spec=CCDCaptureModel)
+    mock_capture.info.return_value.rows = 100
+    mock_capture.info.return_value.cols = 100
+    mock_capture.rawData.return_value = np.zeros((10, 10))
+
+    view_model.annotationsViewModel.refresh = MagicMock()
+
+    module = sys.modules["le_beta_vis.frontend.viewmodels.RawDataViewModel"]
+    with patch.object(module, "Path") as MockPath:
+        MockPath.return_value.exists.return_value = True
+        with patch.object(CCDCaptureModel, "load", return_value=[mock_capture]):
+            view_model.loadFile("dummy/path/file.fits")
+
+    view_model.annotationsViewModel.refresh.assert_called_with(
+        "dummy/path/file.fits", 0
+    )
+
+
+def test_set_active_hdu_refreshes_annotations():
+    """Test that switching the active HDU triggers an annotations refresh."""
+    config = MockConfigurationService()
+    physics_manager = PhysicsConversionManagerImpl(config)
+    vm = RawDataViewModel(config, physics_manager)
+    vm._converter = MagicMock()
+    vm._converter.convert.return_value = np.zeros((10, 10, 3), dtype=np.uint8)
+    vm._request_render = lambda: None
+
+    mock_capture0 = MagicMock(spec=CCDCaptureModel)
+    mock_capture1 = MagicMock(spec=CCDCaptureModel)
+    vm._captures = [mock_capture0, mock_capture1]
+    vm._fits_path = "some/file.fits"
+    vm._activeIndex = 0
+
+    vm.annotationsViewModel.refresh = MagicMock()
+    vm.setActiveHDU(1)
+
+    vm.annotationsViewModel.refresh.assert_called_with("some/file.fits", 1)


### PR DESCRIPTION
Render EPS-backed classification annotations as permanent bounding boxes on the loaded FITS image, distinct from the removable in-session selection overlays. Hovering an annotation shows particle type and CNN/NRG/BDT scores in the status bar; clicking opens a read-only detail dialog with a single-cluster Export-to-h5 action. Visibility is gated by a new configurable low-confidence threshold.

- Fix FITS lookup to match on the full path EPS stores instead of the basename.
- Normalize cluster top/bottom row span in hit-testing and pixel hydration — EPS-sourced clusters store it flipped relative to locally-extracted ones.
- Add a scale legend and file basename to the annotation detail dialog; fix hover hit-testing at non-1x zoom.
- Restore paginated Historical export (a fix that had landed on a sibling branch but never reached `main`) and re-gate the Save button on filtered result count (disabled at 0–1 results) instead of the stale time-window check it used to depend on.

## User Interface

https://github.com/user-attachments/assets/14ffdd55-270d-4e06-a002-d65603bcff64

PS: Mouse pointer is not visible in the video


Resolves #69